### PR TITLE
Add gamma-hadron separation script

### DIFF
--- a/reco/LST1_Hillas.py
+++ b/reco/LST1_Hillas.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     storeimg = eval(sys.argv[3]) #True for storing pixel information
     assert isinstance(storeimg,bool)
     
-    outfile = "/home/queenmab/DATA/LST1/Events/test_img.fits" #File where DL2 data will be stored 
+    outfile = "/home/queenmab/DATA/LST1/Events/"+TYPE+"_events.fits" #File where DL2 data will be stored 
     #######################################################
     
     #Cleaning levels:
@@ -210,7 +210,8 @@ if __name__ == '__main__':
         
         #Concatenate data
         data = vstack([data,ntuple])
-        pixdata = np.vstack([pixdata,fitsdata])
+        if storeimg==True:
+            pixdata = np.vstack([pixdata,fitsdata])
 
         #Convert into HDU objects
         pardata = data.as_array()

--- a/reco/RFDisp.py
+++ b/reco/RFDisp.py
@@ -17,7 +17,7 @@ import scipy
 import Disp
 
 
-hdu_list = fits.open("/home/queenmab/DATA/LST1/Events/events.fits") #File with events
+hdu_list = fits.open("/home/queenmab/DATA/LST1/Events/Gamma_events.fits") #File with events
 hdu_list[1].data
 
 tel = OpticsDescription.from_name('LST') #Telescope description
@@ -49,7 +49,7 @@ disp = Disp.calc_DISP(sourcepos[0],sourcepos[1],cen_x,cen_y)
 max_depth = 50
 regr_rf = RandomForestRegressor(max_depth=max_depth, random_state=2)
 
-X_disp = np.array([width/length,size,width,length,dist,phi,psi]).T
+X_disp = np.array([width/length,size,width,length,r,phi,psi]).T
 X_dtrain, X_dtest, Disp_train, Disp_test = train_test_split(X_disp, disp,
                                                     train_size=int(2*nevents/3),
                                                     random_state=4)
@@ -59,8 +59,6 @@ Disprec = regr_rf.predict(X_dtest)
 
 difD = ((Disp_test-Disprec))
 print(difD.mean(),difD.std())
-print(Disp_test.mean(),Disp_test.std())
-print(Disprec.mean(),Disprec.std())
 plt.hist(difD,bins=100)
 plt.xlabel('$Disp_{test} - Disp_{rec}$',fontsize=24)
 plt.figtext(0.6,0.7,'Mean: '+str(round(scipy.stats.describe(difD).mean,6)),fontsize=15)

--- a/reco/RFEnergy.py
+++ b/reco/RFEnergy.py
@@ -16,7 +16,7 @@ import ctapipe.coordinates as c
 import matplotlib as mpl
 import Disp
 
-hdu_list = fits.open("/home/queenmab/DATA/LST1/Events/events.fits") #File with events
+hdu_list = fits.open("/home/queenmab/DATA/LST1/Events/Gamma_events.fits") #File with events
 hdu_list[1].data
 
 tel = OpticsDescription.from_name('LST') #Telescope description

--- a/reco/RFGHseparation.py
+++ b/reco/RFGHseparation.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+'''
+Script for Energy reconstruction using Random Forest regressor
+'''
+
+from astropy.io import fits
+import scipy
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.ensemble import RandomForestClassifier,RandomForestRegressor
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+from sklearn.metrics import roc_curve
+import math as m
+from ctapipe.instrument import OpticsDescription
+import astropy.units as u
+import ctapipe.coordinates as c
+import matplotlib as mpl
+import Disp
+
+
+hdu_gamma = fits.open("/home/queenmab/DATA/LST1/Events/Gamma_events.fits") #File with events
+hdu_proton = fits.open("/home/queenmab/DATA/LST1/Events/Proton_events.fits") #File with events
+
+data_gamma = hdu_gamma[1].data
+data_proton = hdu_proton[1].data
+
+tel = OpticsDescription.from_name('LST') #Telescope description
+focal_length = tel.equivalent_focal_length.value #Telescope focal length
+
+data_gamma = hdu_gamma[1].data
+data_proton = hdu_proton[1].data
+disp = np.array([]) #Disp quantity
+
+width = np.append(data_gamma.field('width'),
+                  data_proton.field('width'))
+length = np.append(data_gamma.field('length'),
+                   data_proton.field('length'))
+size = np.append(data_gamma.field('size'),
+                 data_proton.field('size'))
+phi = np.append(data_gamma.field('phi'),
+                data_proton.field('phi'))
+energy = np.append(np.log10(data_gamma.field('mcEnergy')*1e3),
+                   np.log10(data_proton.field('mcEnergy')*1e3))
+#Log of energy in GeV
+cen_x = np.append(data_gamma.field('cen_x'),
+                  data_proton.field('cen_x'))
+cen_y = np.append(data_gamma.field('cen_y'),
+                  data_proton.field('cen_y'))
+psi = np.append(data_gamma.field('psi'),
+                data_proton.field('psi'))
+r = np.append(data_gamma.field('r'),
+              data_proton.field('r'))
+
+mcAlt = np.append(data_gamma.field('mcAlt'),
+                  data_proton.field('mcAlt'))
+mcAz = np.append(data_gamma.field('mcAz'),
+                 data_proton.field('mcAz'))
+mcAlttel = np.append(data_gamma.field('mcAlttel'),
+                     data_proton.field('mcAlttel'))
+mcAztel = np.append(data_gamma.field('mcAztel'),
+                    data_proton.field('mcAztel'))
+
+sourcepos = Disp.calc_CamSourcePos(mcAlt,mcAz,mcAlttel,mcAztel,focal_length)
+disp = Disp.calc_DISP(sourcepos[0],sourcepos[1],cen_x,cen_y)
+
+hadroness = np.append(np.zeros(data_gamma.size),np.ones(data_proton.size))
+
+nevents = hadroness.size
+
+X = np.array([size,r,width,length,width/length,psi,phi]).T
+X_train, X_test, E_train, E_test, D_train, D_test, H_train, H_test = train_test_split(X, energy, disp, hadroness, train_size=int(nevents/2),random_state=4)
+
+#First reconstruct energy
+
+max_depth = 50
+regr_rf_e = RandomForestRegressor(max_depth=max_depth, random_state=2)                                                           
+regr_rf_e.fit(X_train, E_train)
+erec = regr_rf_e.predict(X_test)
+
+#Second, reconstruct DISP:
+
+max_depth = 50
+regr_rf_d = RandomForestRegressor(max_depth=max_depth, random_state=2)                                                           
+regr_rf_d.fit(X_train, D_train)
+disprec = regr_rf_d.predict(X_test)
+
+#Build the new set of training data:
+nevents = X_test.shape[0]
+nfeatures = X_test.shape[1]
+
+newX = np.zeros((nevents,nfeatures+2))
+newX[:,:-2] = X_test
+
+newX = newX.T
+newX[nfeatures] = erec
+newX[nfeatures+1] = disprec
+
+newX = newX.T
+
+#newX = np.array([size,r,width,length,width/length,psi,phi,energy,disp]).T
+#newX_train, newX_test, newH_train, newH_test = train_test_split(newX,hadroness,train_size=int(2*nevents/3),random_state=4)
+
+newX_train, newX_test, newH_train, newH_test = train_test_split(newX, H_test,train_size=int(2*nevents/3),random_state=4)
+
+clf = RandomForestClassifier(n_jobs=2,random_state=0)
+
+clf.fit(newX_train,newH_train)
+
+result = clf.predict(newX_test)
+
+check = clf.predict_proba(newX_test)[0:,1]
+
+accuracy = accuracy_score(newH_test, result)
+print(accuracy)
+
+fpr_rf, tpr_rf, _ = roc_curve(newH_test, check)
+
+plt.plot(fpr_rf, tpr_rf, label='Reco Energy and Disp')
+plt.xlabel('False positive rate')
+plt.ylabel('True positive rate')
+plt.legend(loc='best')
+plt.show()
+


### PR DESCRIPTION
I corrected some bugs in RFEnergy.py and RFDisp.py, and added RFGHseparation.py.
This last script performs Energy/Disp reconstruction and uses the results for gamma/hadron separation using a Random Forest classifier. 