### PR TITLE
Cleaned import and used argparse for options

### DIFF
--- a/reco/LST1_Hillas.py
+++ b/reco/LST1_Hillas.py
@@ -9,20 +9,11 @@ USAGE: python LST1_Hillas.py 'Particle' 'Simtelarray file' 'Store Img(True or Fa
 
 """
 
-# import matplotlib.pylab as plt
-# import astropy.units as u
 import numpy as np
-# import ctapipe
 import os
-# import copy
-import sys
-# from ctapipe.core import Container, Field, Map
-# from ctapipe.instrument import CameraGeometry
-# from ctapipe.visualization import CameraDisplay
 from ctapipe.image import hillas_parameters, hillas_parameters_2, tailcuts_clean
 from ctapipe.io.eventsourcefactory import EventSourceFactory
 from ctapipe.image.charge_extractors import LocalPeakIntegrator
-# from astropy.visualization import quantity_support
 from astropy.table import vstack,Table
 from astropy.io import fits
 import argparse

--- a/reco/LST1_Hillas.py
+++ b/reco/LST1_Hillas.py
@@ -51,8 +51,6 @@ parser.add_argument('--storeimg', '-s', dest='storeimg', action='store',
 
 
 args = parser.parse_args()
-print(args)
-# print(args.accumulate(args.integers))
 
 
 def guess_type(filename):
@@ -72,7 +70,6 @@ def guess_type(filename):
         if p in filename:
             return p
     return 'unknown'
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- removed all unused import (matplotlib, some astropy.__ , some ctapipe.__ , sys, copy)
- introduced argparse to deal with options
   - filename
   - particle_type
   - outdir
   - storeimg
- Removed all absolute paths
- Introduced default settings for options
   - filename = gamma_test from ctapipe
   - particle_type is guessed from filename or set to 'unknown'
   - outdir = './results'
   - storeimg = False

The code is cleaner and can be tested by anyone that has ctapipe installed with a simple 
``` python LST1_Hillas.py```
(before needed to manually change absolute paths)