### PR TITLE
Modules and pipelines for an easy use of LST1 reconstruction chain

### DIFF
--- a/reco/calib_dl0_to_dl1.py
+++ b/reco/calib_dl0_to_dl1.py
@@ -1,0 +1,288 @@
+"""This is a module for extracting data from simtelarray files and 
+calculate image parameters of the events: Hillas parameters, timing 
+parameters. They can be stored in HDF5 file. The option of saving the 
+full camera image is also available.
+
+Usage:
+
+"import calib_dl0_to_dl1"
+
+"""
+import numpy as np
+from ctapipe.image import hillas_parameters, hillas_parameters_2, tailcuts_clean
+from ctapipe.io.eventsourcefactory import EventSourceFactory
+from ctapipe.image.charge_extractors import LocalPeakIntegrator
+from ctapipe.utils import get_dataset
+from ctapipe.image import timing_parameters as time
+from ctapipe.instrument import OpticsDescription
+import pandas as pd
+import astropy.units as units
+import h5py
+import utils
+
+def guess_type(filename):
+    """Guess the particle type from the filename
+    
+    Parameters
+    ----------
+    filename: str
+
+    Returns
+    -------
+    str: 'gamma', 'proton', 'electron' or 'unknown'
+    """
+    particles = ['gamma', 'proton', 'electron']
+    for p in particles:
+        if p in filename:
+            return p
+    return 'unknown'
+    
+def get_events(filename,storedata=False,
+               concatenate=False,storeimg=False,outdir='./results/'):
+    """
+    Read a Simtelarray file, extract pixels charge, calculate image 
+    parameters and timing parameters and store the result in an hdf5
+    file. 
+    
+    Parameters:
+    -----------
+    filename: str
+    Name of the simtelarray file.
+
+    storedata: boolean
+    True: store extracted data in a hdf5 file
+
+    concatenate: boolean
+    True: store the extracted data at the end of an existing file
+
+    storeimg: boolean
+    True: store also pixel data
+    
+    outdir: srt
+    Output directory
+    
+    Returns:
+    --------
+    pandas DataFrame: output
+    """
+    #Particle type:
+    
+    particle_type = guess_type(filename)
+    
+    #Create data frame where DL2 data will be stored:
+
+    features = ['ObsID','EvID','mcEnergy','mcAlt','mcAz','mcCore_x','mcCore_y',
+                'mcHfirst','mcType','GPStime','width','length','w/l','phi',
+                'psi','r','x','y','intensity','skewness','kurtosis','mcAlttel',
+                'mcAztel','impact','mcXmax','time_gradient','intercept','SrcX',
+                'SrcY','disp','hadroness']
+    output = pd.DataFrame(columns=features)
+
+    #Read LST1 events:
+    source = EventSourceFactory.produce(
+        input_url=filename, 
+        allowed_tels={1}) #Open Simtelarray file
+
+    #Cleaning levels:
+        
+    level1 = {'LSTCam' : 6.}
+    level2 = level1.copy()
+    # We use as second cleaning level just half of the first cleaning level
+    
+    for key in level2:
+        level2[key] *= 0.5
+    
+    
+    log10pixelHGsignal = {}
+    survived = {}
+
+    imagedata = np.array([])
+    
+    for key in level1:
+
+        log10pixelHGsignal[key] = []
+        survived[key] = []
+    i=0
+    for event in source:
+        if i%100==0:
+            print("EVENT_ID: ", event.r0.event_id, "TELS: ",
+                  event.r0.tels_with_data,
+                  "MC Energy:", event.mc.energy )
+
+        i=i+1
+
+        ntels = len(event.r0.tels_with_data)
+
+        '''
+        if i > 100:   # for quick tests
+            break
+        '''
+        for ii, tel_id in enumerate(event.r0.tels_with_data):
+            
+            geom = event.inst.subarray.tel[tel_id].camera     #Camera geometry
+            tel_coords = event.inst.subarray.tel_coords[
+                event.inst.subarray.tel_indices[tel_id]
+            ]
+            
+            data = event.r0.tel[tel_id].waveform
+            
+            ped = event.mc.tel[tel_id].pedestal    # the pedestal is the 
+            #average (for pedestal events) of the *sum* of all samples,
+            #from sim_telarray
+
+            nsamples = data.shape[2]  # total number of samples
+            
+            # Subtract pedestal baseline. atleast_3d converts 2D to 3D matrix
+            
+            pedcorrectedsamples = data - np.atleast_3d(ped)/nsamples    
+            
+            integrator = LocalPeakIntegrator(None, None)
+            integration, peakpos, window = integrator.extract_charge(
+                pedcorrectedsamples) # these are 2D matrices num_gains * num_pixels
+            
+            chan = 0  # high gain used for now...
+            signals = integration[chan].astype(float)
+
+            dc2pe = event.mc.tel[tel_id].dc_to_pe   # numgains * numpixels
+            signals *= dc2pe[chan]
+
+            # Add all individual pixel signals to the numpy array of the
+            # corresponding camera inside the log10pixelsignal dictionary
+            
+            log10pixelHGsignal[str(geom)].extend(np.log10(signals))  
+            
+            # Apply image cleaning
+        
+            cleanmask = tailcuts_clean(geom, signals, 
+                                       picture_thresh=level1[str(geom)],
+                                       boundary_thresh=level2[str(geom)], 
+                                       keep_isolated_pixels=False, 
+                                       min_number_picture_neighbors=1)
+           
+            survived[str(geom)].extend(cleanmask)  
+           
+            clean = signals.copy()
+            clean[~cleanmask] = 0.0   # set to 0 pixels which did not 
+            # survive cleaning
+            
+            if np.max(clean) < 1.e-6:  # skip images with no pixels
+                continue
+                
+            # Calculate image parameters
+        
+            hillas = hillas_parameters(geom, clean)  
+            foclen = event.inst.subarray.tel[tel_id].optics.equivalent_focal_length
+
+            w = np.rad2deg(np.arctan2(hillas.width, foclen))
+            l = np.rad2deg(np.arctan2(hillas.length, foclen))
+
+            #Calculate Timing parameters
+        
+            peak_time = units.Quantity(peakpos[chan])*units.Unit("ns")
+            timepars = time.timing_parameters(geom.pix_x,geom.pix_y,clean,peak_time,hillas.psi)
+            
+            if w >= 0:
+                if storeimg==True:
+                    if imagedata.size == 0:
+                        imagedata = clean
+                    else:
+                        imagedata = np.vstack([imagedata,clean]) #Pixel content
+                
+                #Hillas parameters
+                width = w.value
+                length = l.value
+                phi = hillas.phi.value
+                psi = hillas.psi.value
+                r = hillas.r.value
+                x = hillas.x.value
+                y = hillas.y.value
+                intensity = np.log10(hillas.intensity)
+                skewness =  hillas.skewness
+                kurtosis = hillas.kurtosis
+                
+                #MC data:
+                ObsID = event.r0.obs_id
+                EvID = event.r0.event_id
+
+                mcEnergy = np.log10(event.mc.energy.value*1e3) #Log10(Energy) in GeV
+                mcAlt = event.mc.alt.value
+                mcAz = event.mc.az.value
+                mcCore_x = event.mc.core_x.value
+                mcCore_y = event.mc.core_y.value
+                mcHfirst = event.mc.h_first_int.value
+                mcType = event.mc.shower_primary_id
+                mcAztel = event.mcheader.run_array_direction[0].value
+                mcAlttel = event.mcheader.run_array_direction[1].value
+                mcXmax = event.mc.x_max.value
+                GPStime = event.trig.gps_time.value
+
+                #Calculate impact parameters
+
+                impact = np.sqrt((
+                    tel_coords.x.value-event.mc.core_x.value)**2
+                    +(tel_coords.y.value-event.mc.core_y.value)**2)
+                
+                #Timing parameters
+
+                time_gradient = timepars[0].value
+                intercept = timepars[1].value
+
+                #Calculate Disp and Source position in camera coordinates
+                
+                tel = OpticsDescription.from_name('LST') #Telescope description
+                focal_length = tel.equivalent_focal_length.value
+                sourcepos = utils.calc_CamSourcePos(mcAlt,mcAz,
+                                                              mcAlttel,mcAztel,
+                                                              focal_length) 
+                SrcX = sourcepos[0]
+                SrcY = sourcepos[1]
+                disp = utils.calc_DISP(sourcepos[0],sourcepos[1],
+                                                 x,y)
+                
+                hadroness = 0
+                if particle_type=='proton':
+                    hadroness = 1
+
+                eventdf = pd.DataFrame([[ObsID,EvID,mcEnergy,mcAlt,mcAz,
+                                         mcCore_x,mcCore_y,mcHfirst,mcType,
+                                         GPStime,width,length,width/length,phi,
+                                         psi,r,x,y,intensity,skewness,kurtosis,
+                                         mcAlttel,mcAztel,impact,mcXmax,
+                                         time_gradient,intercept,SrcX,SrcY,
+                                         disp,hadroness]],
+                                       columns=features)
+                
+                output = output.append(eventdf,
+                                       ignore_index=True)
+
+    outfile = outdir + particle_type + '_events.hdf5'
+    
+    if storedata==True:
+        if (concatenate==False or 
+            (concatenate==True and 
+             np.DataSource().exists(outfile)==False)):
+            output.to_hdf(outfile,
+                          key=particle_type+"_events",mode="w")
+            if storeimg==True:
+                f = h5py.File(outfile,'r+')
+                f.create_dataset('images',data=imagedata)
+                f.close()
+        else:
+            if storeimg==True:
+                f = h5py.File(outfile,'r')
+                images = f['images']
+                del f['images']
+                images = np.vstack([images,imagedata])
+                f.close()
+                saved = pd.read_hdf(outfile,key=particle_type+'_events')
+                output = saved.append(output,ignore_index=True)
+                output.to_hdf(outfile,key=particle_type+"_events",mode="w")
+                f = h5py.File(outfile,'r+')
+                f.create_dataset('images',data=images)
+                f.close()
+            else:
+                saved = pd.read_hdf(outfile,key=particle_type+'_events')
+                output = saved.append(output,ignore_index=True)
+                output.to_hdf(outfile,key=particle_type+"_events",mode="w")
+    del source
+    return output

--- a/reco/lst-recopipe.py
+++ b/reco/lst-recopipe.py
@@ -1,26 +1,84 @@
-import parameters
-import reconstruction
+"""Pipeline for reconstruction of Energy, Disp and gamma/hadron
+separation of events stored in a simtelarray file.
+Result is a dataframe with dl2 data.
+Already trained Random Forests are required.
+
+Usage:
+
+$> python lst-recopipe arg1 arg2 ...
+
+"""
+import calib_dl0_to_dl1
+import reco_dl1_to_dl2
+import plot_dl2
 from sklearn.externals import joblib
+from ctapipe.utils import get_dataset_path
+import matplotlib.pyplot as plt 
+import argparse
 
-#Simtelarray file with data
+parser = argparse.ArgumentParser(description = "Train Random Forests.")
 
-datafile = '/scratch/bernardos/LST1/Gamma/Point_Prod-3_LaPalma_flashcam-prod3j/gamma_20deg_0deg_run11716___cta-prod3-lapalma-2147m-LaPalma-FlashCam.simtel.gz'
+# Required arguments
+parser.add_argument('--datafile', '-f', type=str,
+                    dest='datafile',
+                    help='path to the file with simtelarray events',
+                    default=get_dataset_path('gamma_test_large.simtel.gz'))
 
-#Get out the data from the Simtelarray file:
+parser.add_argument('--pathmodels', '-p', action='store', type=str,
+                     dest='path_models',
+                     help='Path where to find the trained RF',
+                     default='./results/')
+parser.add_argument('--storeresults', '-s', action='store', type=bool,
+                    dest='storeresults',
+                    help='Boolean. True for storing the reco dl2 events'
+                    'Default=False, any user input will be considered True',
+                    default=False)
+# Optional argument
+parser.add_argument('--outdir', '-o', action='store', type=str,
+                     dest='outdir',
+                     help='Path where to store the reco dl2 events',
+                     default='./results/')
 
-data = parameters.get_events(datafile,False)
+args = parser.parse_args()
 
-#Load the trained RF for reconstruction:
-path_models = "/scratch/bernardos/LST1/Models/"
-fileE = path_models+"RFreg_Energy.sav"
-fileD = path_models+"RFreg_Disp.sav"
-fileH = path_models+"RFcls_GH.sav"
+if __name__ == '__main__':
 
-RFreg_Energy = joblib.load(fileE)
-RFreg_Disp = joblib.load(fileD)
-RFcls_GH = joblib.load(fileH)
+    #Get out the data from the Simtelarray file:
 
-#Apply the models to the data
-features = ['intensity','time_gradient','width','length','w/l','phi','psi']
-reconstruction.ApplyModels(data,features,RFcls_GH,RFreg_Energy,RFreg_Disp)
+    data = calib_dl0_to_dl1.get_events(args.datafile,False)
 
+    #Load the trained RF for reconstruction:
+    fileE = args.path_models+"RFreg_Energy.sav"
+    fileD = args.path_models+"RFreg_Disp.sav"
+    fileH = args.path_models+"RFcls_GH.sav"
+    
+    RFreg_Energy = joblib.load(fileE)
+    RFreg_Disp = joblib.load(fileD)
+    RFcls_GH = joblib.load(fileH)
+    
+    #Apply the models to the data
+    features = ['intensity',
+                'time_gradient',
+                'width',
+                'length',
+                'w/l',
+                'phi',
+                'psi']
+    dl2 = data
+    reco_dl1_to_dl2.ApplyModels(data,dl2,features,RFcls_GH,RFreg_Energy,RFreg_Disp)
+
+    if args.storeresults==True:
+        #Store results
+        outfile = args.outdir+"dl2_events.hdf5"
+        dl2.to_hdf(outfile,key="dl2_events",mode="w")
+
+    #Plot some results
+        
+    plot_dl2.plot_features(dl2)
+    plt.show()
+    plot_dl2.plot_E(dl2)
+    plt.show()
+    plot_dl2.plot_Disp(dl2)
+    plt.show()
+    plot_dl2.plot_pos(dl2)
+    plt.show()

--- a/reco/lst-recopipe.py
+++ b/reco/lst-recopipe.py
@@ -1,0 +1,26 @@
+import parameters
+import reconstruction
+from sklearn.externals import joblib
+
+#Simtelarray file with data
+
+datafile = '/scratch/bernardos/LST1/Gamma/Point_Prod-3_LaPalma_flashcam-prod3j/gamma_20deg_0deg_run11716___cta-prod3-lapalma-2147m-LaPalma-FlashCam.simtel.gz'
+
+#Get out the data from the Simtelarray file:
+
+data = parameters.get_events(datafile,False)
+
+#Load the trained RF for reconstruction:
+path_models = "/scratch/bernardos/LST1/Models/"
+fileE = path_models+"RFreg_Energy.sav"
+fileD = path_models+"RFreg_Disp.sav"
+fileH = path_models+"RFcls_GH.sav"
+
+RFreg_Energy = joblib.load(fileE)
+RFreg_Disp = joblib.load(fileD)
+RFcls_GH = joblib.load(fileH)
+
+#Apply the models to the data
+features = ['intensity','time_gradient','width','length','w/l','phi','psi']
+reconstruction.ApplyModels(data,features,RFcls_GH,RFreg_Energy,RFreg_Disp)
+

--- a/reco/lst-trainpipe.py
+++ b/reco/lst-trainpipe.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pandas as pd
+import reconstruction
+
+#Files with events for training
+gammafile = "/scratch/bernardos/LST1/Events/gamma_events_point.hdf5" #File with events
+protonfile = "/scratch/bernardos/LST1/Events/proton_events.hdf5" #File with events
+
+#Train the models
+path_models = "/scratch/bernardos/LST1/Models/"
+features = ['intensity','time_gradient','width','length','w/l','phi','psi']
+RFreg_Energy,RFreg_Disp,RFcls_GH = reconstruction.buildModels(gammafile,protonfile,features,True,path_models)
+

--- a/reco/lst-trainpipe.py
+++ b/reco/lst-trainpipe.py
@@ -1,13 +1,57 @@
+"""Pipeline for training three Random Forests destinated to Energy, Disp
+reconstruction and Gamma/Hadron separation.
+The resulting RF models can be stored in files for later use on data.
+
+Usage:
+
+$> python lst-trainpipe arg1 arg2 ...
+
+"""
 import numpy as np
 import pandas as pd
-import reconstruction
+import argparse
+import reco_dl1_to_dl2
 
-#Files with events for training
-gammafile = "/scratch/bernardos/LST1/Events/gamma_events_point.hdf5" #File with events
-protonfile = "/scratch/bernardos/LST1/Events/proton_events.hdf5" #File with events
+parser = argparse.ArgumentParser(description = "Train Random Forests.")
 
-#Train the models
-path_models = "/scratch/bernardos/LST1/Models/"
-features = ['intensity','time_gradient','width','length','w/l','phi','psi']
-RFreg_Energy,RFreg_Disp,RFcls_GH = reconstruction.buildModels(gammafile,protonfile,features,True,path_models)
+# Required argument
+parser.add_argument('--gammafile', '-fg', type=str,
+                    dest='gammafile',
+                    help='path to the dl1 file of gamma events for training')
 
+parser.add_argument('--protonfile', '-fp', type=str,
+                    dest='protonfile',
+                    help='path to the dl1 file of proton events for training')
+
+parser.add_argument('--storerf', '-s', action='store', type=bool,
+                    dest='storerf',
+                    help='Boolean. True for storing trained RF in 3 files'
+                    'Deafult=False, any user input will be considered True',
+                    default=False)
+
+# Optional arguments
+parser.add_argument('--opath', '-o', action='store', type=str,
+                     dest='path_models',
+                     help='Path to store the resulting RF',
+                     default='./results/')
+
+args = parser.parse_args()
+
+if __name__ == '__main__':
+
+    #Train the models
+
+    features = ['intensity',
+                'time_gradient',
+                'width',
+                'length',
+                'w/l',
+                'phi',
+                'psi']
+    print(args.storerf)
+
+    RFreg_Energy,RFreg_Disp,RFcls_GH = reco_dl1_to_dl2.buildModels(
+        args.gammafile,args.protonfile,
+        features,
+        args.storerf,args.path_models)
+    

--- a/reco/lstpipe.py
+++ b/reco/lstpipe.py
@@ -21,4 +21,10 @@ data = parameters.get_events(datafile,False)
 
 features = ['intensity','time_gradient','width','length','w/l','phi','psi']
 
-RFreg_Energy,RFreg_Disp,RFcls_GH = reconstruction.buildModels(gammafile,protonfile,features)
+RFreg_Energy,RFreg_Disp,RFcls_GH = reconstruction.buildModels(gammafile,protonfile,features,True)
+
+#Apply the models to the data
+
+reconstruction.ApplyModels(data,features,RFcls_GH,RFreg_Energy,RFreg_Disp)
+
+

--- a/reco/plot_dl2.py
+++ b/reco/plot_dl2.py
@@ -1,0 +1,332 @@
+"""Module for plotting results from reconstruction.
+
+Usage:
+"import plot_dl2"
+"""
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import scipy.stats
+from scipy.stats import norm
+from matplotlib import gridspec
+
+def plot_features(data,truehadroness=False):
+    """Plot the distribution of different features that characterize
+    events, such as hillas parameters or MC data.
+
+    Parameters:
+    -----------
+    data: pandas DataFrame
+    
+    truehadroness:
+    True: True gammas and proton events are plotted (they are separated using true hadroness). 
+    False: Gammas and protons are separated using reconstructed hadroness (Hadrorec)
+    """
+    hadro = "Hadrorec"
+    if truehadroness:
+        hadro = "hadroness"
+
+    #Energy distribution
+    plt.subplot(331)
+    plt.hist(data[data[hadro]<1]['mcEnergy'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(data[data[hadro]>0]['mcEnergy'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"$log_{10}E$(GeV)")
+    plt.legend()
+
+    #Disp distribution
+    plt.subplot(332)
+    plt.hist(data[data[hadro]<1]['disp'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(data[data[hadro]>0]['disp'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"Disp (m)")
+
+    #Intensity distribution
+    plt.subplot(333)
+    plt.hist(data[data[hadro]<1]['intensity'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(data[data[hadro]>0]['intensity'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"$log_{10}Intensity$")
+
+    dataforwl = data[data['intensity']>np.log10(200)]
+    #Width distribution
+    plt.subplot(334)
+    plt.hist(dataforwl[dataforwl[hadro]<1]['width'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(dataforwl[dataforwl[hadro]>0]['width'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"Width (º)")
+
+    #Length distribution
+    plt.subplot(335)
+    plt.hist(dataforwl[dataforwl[hadro]<1]['length'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(dataforwl[dataforwl[hadro]>0]['length'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"Length (º)")
+
+    #r distribution
+    plt.subplot(336)
+    plt.hist(data[data[hadro]<1]['r'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(data[data[hadro]>0]['r'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"r (m)")
+
+    #psi distribution
+
+    plt.subplot(337)
+    plt.hist(data[data[hadro]<1]['psi'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(data[data[hadro]>0]['psi'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"psi angle(rad)")
+    
+    #psi distribution
+
+    plt.subplot(338)
+    plt.hist(data[data[hadro]<1]['phi'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(data[data[hadro]>0]['phi'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"phi angle(m)")
+    
+    #Time gradient
+
+    plt.subplot(339)
+    plt.hist(data[data[hadro]<1]['time_gradient'],
+             histtype=u'step',bins=100,
+             label="Gammas")
+    plt.hist(data[data[hadro]>0]['time_gradient'],
+             histtype=u'step',bins=100,
+             label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"Time gradient")
+
+
+def plot_E(data,truehadroness=False):
+    
+    """Plot the performance of reconstructed Energy. 
+
+    Parameters:
+    -----------
+    data: pandas DataFrame
+    
+    truehadroness:
+    True: True gammas and proton events are plotted (they are separated using true hadroness). 
+    False: Gammas and protons are separated using reconstructed hadroness (Hadrorec)
+    
+    """
+    hadro = "Hadrorec"
+    if truehadroness:
+        hadro = "hadroness"
+    
+    gammas = data[data[hadro]==0] 
+    
+    plt.subplot(221)
+    difE = ((gammas['mcEnergy']-gammas['Erec'])*np.log(10))
+    section = difE[abs(difE) < 1.5]
+    mu,sigma = norm.fit(section)
+    print(mu,sigma)
+    n, bins, patches = plt.hist(difE,100,
+                                density=1,alpha=0.75)
+    y = norm.pdf( bins, mu, sigma)
+    l = plt.plot(bins, y, 'r--', linewidth=2)
+    plt.xlabel('$(log_{10}(E_{gammas})-log_{10}(E_{rec}))*log_{N}(10)$',
+               fontsize=10)
+    plt.figtext(0.15,0.7,'Mean: '+str(round(mu,4)),
+                fontsize=10)
+    plt.figtext(0.15,0.65,'Std: '+str(round(sigma,4)),
+                fontsize=10)
+    
+    plt.subplot(222)
+    hE = plt.hist2d(gammas['mcEnergy'],gammas['Erec'],
+                    bins=100)
+    plt.colorbar(hE[3])
+    plt.xlabel('$log_{10}E_{gammas}$',
+               fontsize=15)
+    plt.ylabel('$log_{10}E_{rec}$',
+               fontsize=15)
+    plt.plot(gammas['mcEnergy'],gammas['mcEnergy'],
+             "-",color='red')
+
+    #Plot a profile
+    subplot = plt.subplot(223)
+    means_result = scipy.stats.binned_statistic(
+        gammas['mcEnergy'],[difE,difE**2],
+        bins=50,range=(1,6),statistic='mean')
+    means, means2 = means_result.statistic
+    standard_deviations = np.sqrt(means2 - means**2)
+    bin_edges = means_result.bin_edges
+    bin_centers = (bin_edges[:-1] + bin_edges[1:])/2.
+    
+    #fig = plt.figure()
+    gs = gridspec.GridSpecFromSubplotSpec(2, 1,
+                                          height_ratios=[2, 1],
+                                          subplot_spec=subplot)
+    ax0 = plt.subplot(gs[0])
+    plot0 = ax0.errorbar(x=bin_centers, y=means, yerr=standard_deviations, 
+                         linestyle='none', marker='.')
+    plt.ylabel('$(log_{10}(E_{true})-log_{10}(E_{rec}))*log_{N}(10)$',
+               fontsize=10)
+    
+    ax1 = plt.subplot(gs[1], sharex = ax0)
+    plot1 = ax1.plot(bin_centers,standard_deviations,
+                     marker='+',linestyle='None')
+    plt.setp(ax0.get_xticklabels(), 
+             visible=False)
+    yticks = ax1.yaxis.get_major_ticks()
+    yticks[-1].label1.set_visible(False)
+    plt.ylabel("Std",fontsize=10)
+    plt.xlabel('$log_{10}E_{true}$',
+               fontsize=10)
+    plt.subplots_adjust(hspace=.0)
+
+    
+def plot_Disp(data,truehadroness=False):
+    
+    """Plot the performance of reconstructed position
+
+    Parameters:
+    -----------
+    data: pandas DataFrame
+    
+    truehadroness: boolean
+    True: True gammas and proton events are plotted (they are separated
+    using true hadroness). 
+    False: Gammas and protons are separated using reconstructed
+    hadroness (Hadrorec)
+    """
+    hadro = "Hadrorec"
+    if truehadroness:
+        hadro = "hadroness"
+
+    gammas = data[data[hadro]==0] 
+
+    plt.subplot(221)
+    difD = ((gammas['disp']-gammas['Disprec'])/gammas['disp'])
+    section = difD[abs(difD) < 0.5]
+    mu,sigma = norm.fit(section)
+    print(mu,sigma)
+    n,bins,patches = plt.hist(difD,100,density=1,
+                              alpha=0.75,range=[-2,1.5])
+    y = norm.pdf( bins, mu, sigma)
+    l = plt.plot(bins, y, 'r--', linewidth=2)
+    plt.xlabel('$\\frac{Disp_{gammas}-Disp_{rec}}{Disp_{gammas}}$',
+               fontsize=15)
+    plt.figtext(0.15,0.7,'Mean: '+str(round(mu,4)),
+                fontsize=12)
+    plt.figtext(0.15,0.65,'Std: '+str(round(sigma,4)),
+                fontsize=12)
+                
+    plt.subplot(222)
+    hD = plt.hist2d(gammas['disp'],gammas['Disprec'],
+                    bins=100,range=([0,1.1],[0,1.1]))
+    plt.colorbar(hD[3])
+    plt.xlabel('$Disp_{gammas}$',
+               fontsize=15)
+    plt.ylabel('$Disp_{rec}$',
+               fontsize=15)
+    plt.plot(gammas['disp'],gammas['disp'],
+             "-",color='red')   
+ 
+    plt.subplot(223)
+    theta2 = (gammas['SrcX']-gammas['SrcXrec'])**2
+    +(gammas['SrcY']-gammas['SrcY'])**2
+    plt.hist(theta2,bins=100,
+             range=[0,0.1],histtype=u'step')
+    plt.xlabel(r'$\theta^{2}(º)$',
+               fontsize=15)
+    plt.ylabel(r'# of events',
+               fontsize=15)
+    
+
+def plot_pos(data,truehadroness=False):
+    
+    """Plot the performance of reconstructed position
+
+    Parameters:
+    data: pandas DataFrame
+    
+    truehadroness: boolean
+    True: True gammas and proton events are plotted (they are separated
+    using true hadroness). 
+    False: Gammas and protons are separated using reconstructed
+    hadroness (Hadrorec)
+    """
+    hadro = "Hadrorec"
+    if truehadroness:
+        hadro = "hadroness"
+
+    #True position
+
+    trueX = data[data[hadro]==0]['SrcX']
+    trueY = data[data[hadro]==0]['SrcY']
+    trueXprot = data[data[hadro]==1]['SrcX']
+    trueYprot = data[data[hadro]==1]['SrcY']
+
+    #Reconstructed position
+
+    recX = data[data[hadro]==0]['SrcXrec']
+    recY = data[data[hadro]==0]['SrcYrec']
+    recXprot = data[data[hadro]==1]['SrcXrec']
+    recYprot = data[data[hadro]==1]['SrcYrec']
+
+    plt.subplot(221)
+    plt.hist2d(trueXprot,trueYprot,
+               bins=100,label="Protons")
+    plt.colorbar()
+    plt.title("True position Protons")
+    plt.xlabel("x(m)")
+    plt.ylabel("y (m)")
+    plt.subplot(222)
+    plt.hist2d(trueX,trueY,
+               bins=100,label="Gammas",
+               range=np.array([(-1, 1), (-1, 1)]))
+    plt.colorbar()
+    plt.title("True position Gammas")
+    plt.xlabel("x (m)")
+    plt.ylabel("y (m)")
+    plt.subplot(223)
+    plt.hist2d(recXprot,recYprot,
+               bins=100,label="Protons",
+               range=np.array([(-1, 1), (-1, 1)]))
+    plt.colorbar()
+    plt.title("Reconstructed position Protons")
+    plt.xlabel("x (m)")
+    plt.ylabel("y (m)")
+    plt.subplot(224)
+    plt.hist2d(recX,recY,
+               bins=100,label="Gammas",
+               range=np.array([(-1, 1), (-1, 1)]))
+    plt.colorbar()
+    plt.title("Reconstructed position Gammas ")
+    plt.xlabel("x (m)")
+    plt.ylabel("y (m)")

--- a/reco/reco_dl1_to_dl2.py
+++ b/reco/reco_dl1_to_dl2.py
@@ -1,0 +1,259 @@
+"""Module with functions for Energy and Disp reconstruction and G/H
+separation. There are functions for raining random forest and for
+applying them to data. The RF can be saved into a file for later use.
+
+Usage:
+
+"import reco_dl1_to_dl2"
+"""
+import numpy as np
+import pandas as pd
+import utils
+from sklearn.ensemble import RandomForestClassifier,RandomForestRegressor
+from sklearn.metrics import accuracy_score
+from sklearn.metrics import roc_curve
+from sklearn.externals import joblib
+
+def split_traintest(data,proportion):
+    """
+    Split a dataset in "train" and "test" sets.
+
+    Parameters:
+    -----------
+    data: pandas DataFrame
+
+    proportion: float
+    Percentage of the total dataset that will be part of the train set.
+
+    Returns:
+    --------
+    pandas dataFrame: train
+    
+    pandas dataFrame: test
+    
+    """
+    data['is_train'] = np.random.uniform(0,1,len(data))<= proportion
+    train = data[(data['is_train']==True)]
+    test = data[(data['is_train']==False)]
+    return train,test
+
+def trainRFreco(train,features):
+    """
+    Trains two Random Forest regressors for Energy and Disp
+    reconstruction respectively. Returns the trained RF.
+
+    Parameters:
+    -----------
+    train: pandas DataFrame
+    data set for training the RF
+
+    features: list of strings
+    List of features to train the RF
+    
+    Returns:
+    --------
+    RandomForestRegressor: regr_rf_e
+
+    RandomForestRegressor: regr_rf_disp
+    """
+
+    print("Given features: ",features)
+    print("Number of events for training: ",train.shape[0])
+    print("Training Random Forest Regressor for Energy Reconstruction...")
+    
+    
+    max_depth = 50
+    regr_rf_e = RandomForestRegressor(max_depth=max_depth, 
+                                      random_state=2,
+                                      n_estimators=30)                                                           
+    regr_rf_e.fit(train[features],
+                  train['mcEnergy'])
+    
+    print("Random Forest trained!")    
+    print("Training Random Forest Regressor for Disp Reconstruction...")
+    
+    regr_rf_disp = RandomForestRegressor(max_depth=max_depth,
+                                         random_state=2,
+                                         n_estimators=30)                                                           
+    regr_rf_disp.fit(train[features],
+                     train['disp'])
+    
+    print("Random Forest trained!")
+    print("Done!")
+    return regr_rf_e, regr_rf_disp
+
+def trainRFsep(train,features):
+    
+    """Trains a Random Forest classifier for Gamma/Hadron separation.
+    Returns the trained RF.
+
+    Parameters:
+    -----------
+    train: pandas DataFrame
+    data set for training the RF
+
+    features: list of strings
+    List of features to train the RF
+
+    Return:
+    -------
+    RandomForestClassifier: clf
+    """
+    print("Given features: ",features)
+    print("Number of events for training: ",train.shape[0])
+    print("Training Random Forest Classifier for",
+    "Gamma/Hadron separation...")
+    
+    clf = RandomForestClassifier(max_depth = 50,
+                             n_jobs=10,
+                             random_state=4,
+                             n_estimators=30)
+    
+    clf.fit(train[features],
+            train['hadroness'])
+    print("Random Forest trained!")
+    print("Done!")
+    return clf 
+
+
+def buildModels(filegammas,fileprotons,features,
+                SaveModels=True,path_models="",
+                EnergyCut=-1,IntensityCut=60,rCut=0.94):
+    """Uses MC data to train Random Forests for Energy and Disp
+    reconstruction and G/H separation. Returns 3 trained RF.
+
+    Parameters:
+    -----------
+    filegammas: string
+    Name of the file with MC gamma events
+    
+    fileprotons: string
+    Name of the file with MC proton events
+
+    features: list of strings
+    Features for traininf the RF
+
+    EnergyCut: float 
+    Cut in energy for gamma/hadron separation
+    
+    IntensityCut: float
+    Cut in intensity of the showers for training RF. Default is 60 phe
+
+    rCut: float
+    Cut in distance from c.o.g of hillas ellipse to camera center, to avoid images truncated
+    in the border. Default is 80% of camera radius.
+
+    SaveModels: boolean
+    Save the trained RF in a file to use them anytime. 
+    
+    path_models: string
+    path to store the trained RF
+
+    Returns:
+    --------
+    RandomForestRegressor: RFreg_Energy
+    RandomForestRegressor: RFreg_Disp
+    RandomForestClassifier: RFcls_GH
+    """
+    
+    df_gamma = pd.read_hdf(filegammas,
+                           key='gamma_events')
+    df_proton = pd.read_hdf(fileprotons,
+                            key='proton_events')
+
+    #Apply cuts in intensity and r
+
+    df_gamma = df_gamma[abs(df_gamma['r'])<rCut]
+    df_proton = df_proton[abs(df_proton['r'])<rCut]
+
+    #Cut showers with low intensity
+    df_gamma = df_gamma[abs(df_gamma['intensity'])>np.log10(IntensityCut)]
+    df_proton = df_proton[abs(df_proton['intensity'])>np.log10(IntensityCut)]
+    
+    #Train regressors for energy and disp reconstruction, only with gammas
+    
+    RFreg_Energy, RFreg_Disp = trainRFreco(df_gamma,
+                                           features)
+
+    #Train classifier for gamma/hadron separation. We need to use half
+    #of the gammas for training regressors and have Erec and Disp rec
+    #for training the classifier.
+
+    train, testg = split_traintest(df_gamma,
+                                   0.5)
+    test = testg.append(df_proton,
+                        ignore_index=True)
+
+    tempRFreg_Energy, tempRFreg_Disp = trainRFreco(train,features)
+    
+    #Apply the regressors to the test set
+
+    test['Erec'] = tempRFreg_Energy.predict(test[features])
+    test['Disprec'] = tempRFreg_Disp.predict(test[features])
+    
+    #Apply cut in reconstructed energy. New train set is the previous
+    #test with energy and disp reconstructed.
+    
+    train = test[test['mcEnergy']>EnergyCut]
+    
+    del tempRFreg_Energy, tempRFreg_Disp
+    
+    #Add Erec and Disprec to features.
+    features_sep = features
+    features_sep.append('Erec')
+    features_sep.append('Disprec')
+    
+    #Train the Classifier
+
+    RFcls_GH = trainRFsep(train,
+                          features_sep) 
+    
+    if SaveModels==True:
+        fileE = path_models+"RFreg_Energy.sav"
+        fileD = path_models+"RFreg_Disp.sav"
+        fileH = path_models+"RFcls_GH.sav"
+        joblib.dump(RFreg_Energy, fileE)
+        joblib.dump(RFreg_Disp, fileD)
+        joblib.dump(RFcls_GH, fileH)
+        
+    features.remove('Erec')
+    features.remove('Disprec')
+    return RFreg_Energy,RFreg_Disp,RFcls_GH
+
+def ApplyModels(dl1,dl2,features,RFcls_GH,RFreg_Energy,RFreg_Disp):
+    """Apply previously trained Random Forests to a set of data
+    depending on a set of features.
+
+    Parameters:
+    -----------
+    data: Pandas DataFrame
+    
+    features: list
+
+    RFcls_GH: Random Forest Classifier
+    RF for Gamma/Hadron separation
+
+    RFreg_Energy: Random Forest Regressor
+    RF for Energy reconstruction
+
+    RFreg_Disp: Random Forest Regressor
+    RF for Disp reconstruction
+
+    """
+    dl2 = dl1
+    #Reconstruction of Energy and Disp distance
+    dl2['Erec'] = RFreg_Energy.predict(dl2[features])
+    dl2['Disprec'] = RFreg_Disp.predict(dl2[features])
+   
+    #Construction of Source position in camera coordinates from Disp distance.
+    #WARNING: For not it only works fine for POINT SOURCE events
+    dl2['SrcXrec'],dl2['SrcYrec'] = utils.Disp_to_Pos(dl2['Disprec'],
+                                                                  dl2['x'],
+                                                                  dl2['y'],
+                                                                  dl2['psi'])
+    
+    features.append('Erec')
+    features.append('Disprec')
+    dl2['Hadrorec'] = RFcls_GH.predict(dl2[features])
+    
+

--- a/reco/transformations.py
+++ b/reco/transformations.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 '''
-Module for calculating Source position in camera coordinates, and Disp distance.
+Module with auxiliar functions:
+Transform AltAz coordinates into Camera coordinates (This should be implemented already in ctapipe but I haven't managed to find how to do it)
+Calculate source position from Disp distance.
+Calculate Disp distance from source position.
+
 Usage:
-import Disp
+
+"import transformations"
 
 '''
 

--- a/reco/utils.py
+++ b/reco/utils.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Module with auxiliar functions:
+Transform AltAz coordinates into Camera coordinates (This should be
+implemented already in ctapipe but I haven't managed to find how to
+do it)
+Calculate source position from Disp distance.
+Calculate Disp distance from source position.
+
+Usage:
+
+"import utils"
+"""
+
+import numpy as np
+import ctapipe.coordinates as c
+import astropy.units as u
+
+def alt_to_theta(alt):
+    """Transforms altitude (angle from the horizon upwards) to theta
+    (angle from z-axis) for simtel array coordinate systems                                  
+    Parameters:
+    -----------
+    alt: float
+
+    Returns:
+    --------
+    float: theta
+    
+    """
+    
+    return (90 * u.deg - alt).to(alt.unit)
+
+
+def az_to_phi(az):
+    """Transforms azimuth (angle from north towards east)                
+    to phi (angle from x-axis towards y-axis)                            
+    for simtel array coordinate systems                                  
+    Parameters:
+    -----------
+    az: float
+    
+    Returns:
+    --------
+    az: float
+    """
+    return -az
+
+        
+def calc_CamSourcePos(mcAlt,mcAz,mcAlttel,mcAztel,focal_length):
+    """Transform Alt-Az source position into Camera(x,y) coordinates
+    source position. 
+    
+    Parameters:
+    -----------
+    mcAlt: float
+    Alt coordinate of the event
+
+    mcAz: float
+    Az coordinate of the event
+
+    mcAlttel: float
+    Alt coordinate of the telescope pointing
+
+    mcAztel: float
+    Az coordinate of the telescope pointing
+
+    focal_length: float
+    Focal length of the telescope
+    
+    Returns:
+    --------
+    float: Source_X1,
+
+    float: Source_X2
+    """
+
+    mcAlt = alt_to_theta(mcAlt*u.rad).value
+    mcAz = az_to_phi(mcAz*u.rad).value
+    mcAlttel = alt_to_theta(mcAlttel*u.rad).value
+    mcAztel = az_to_phi(mcAztel*u.rad).value
+        
+    #Sines and cosines of direction angles
+    cp = np.cos(mcAz)
+    sp = np.sin(mcAz)
+    ct = np.cos(mcAlt)
+    st = np.sin(mcAlt)
+    
+     #Shower direction coordinates
+
+    sourcex = st*cp
+    sourcey = st*sp
+    sourcez = ct
+
+    #print(sourcex)
+
+    source = np.array([sourcex,sourcey,sourcez])
+    source=source.T
+    
+    #Rotation matrices towars the camera frame
+    
+    rot_Matrix = np.empty((0,3,3))
+            
+    alttel = mcAlttel
+    aztel = mcAztel
+    mat_Y = np.array([[np.cos(alttel),0,np.sin(alttel)],
+                      [0,1,0], 
+                      [-np.sin(alttel),0,np.cos(alttel)]]).T
+        
+        
+    mat_Z = np.array([[np.cos(aztel),-np.sin(aztel),0],
+                      [np.sin(aztel),np.cos(aztel),0],
+                      [0,0,1]]).T
+        
+    rot_Matrix = np.matmul(mat_Y,mat_Z)
+    
+    res = np.einsum("...ji,...i",rot_Matrix,source)
+    res = res.T
+    
+    Source_X = -focal_length*res[0]/res[2]
+    Source_Y = -focal_length*res[1]/res[2]
+    return Source_X, Source_Y
+
+def calc_DISP(Source_X,Source_Y,cen_x,cen_y):
+    """
+    Calculates "Disp" distance from source position in camera
+    coordinates
+    
+    Parameters:
+    -----------
+    Source_X: float
+    Source coordinate X in camera frame
+
+    Source_Y: float
+    Source coordinate Y in camera frame
+
+    cen_x = float
+    Coordinate x of the center of gravity of Hillas ellipse
+
+    cen_y = float
+    Coordinate y of the center of gravity of Hillas ellipse
+
+    Returns:
+    --------
+    float: disp
+    """
+    disp = np.sqrt((Source_X-cen_x)**2
+                   +(Source_Y-cen_y)**2)
+    return disp
+
+def Disp_to_Pos(Disp,cen_x,cen_y,psi):
+    """
+    Calculates source position in camera coordinates(x,y) from "Disp"
+    distance.
+    For now, it only works for POINT GAMMAS, it doesn't take into
+    account the duplicity of the disp method.
+    
+    Parameters:
+    -----------
+    Disp: float
+    Disp distance
+
+    cen_x = float
+    Coordinate x of the center of gravity of Hillas ellipse
+
+    cen_y = float
+    Coordinate y of the center of gravity of Hillas ellipse
+
+    psi: float
+    Angle between semimajor axis of the Hillas ellipse and the
+    horizontal plane of the camera.
+
+    Returns:
+    --------
+    float: Source_X1
+
+    float: Source_X2
+    
+    """
+    
+    Source_X1 = cen_x - Disp*np.cos(psi)
+    Source_Y1 = cen_y - Disp*np.sin(psi)
+   
+    return Source_X1,Source_Y1
+        
+       

--- a/reco/visualization.py
+++ b/reco/visualization.py
@@ -1,0 +1,262 @@
+"""
+Model for plotting results from reconstruction.
+
+Usage:
+"import visualization"
+
+
+"""
+
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import scipy.stats
+from scipy.stats import norm
+from matplotlib import gridspec
+
+def plot_features(data,truehadroness=False):
+    """
+    Plot the distribution of different features that characterize events, such as hillas parameters or MC values
+
+    Parameters:
+    data: pandas DataFrame
+    
+    truehadroness:
+    True: True gammas and proton events are plotted (they are separated using true hadroness). 
+    False: Gammas and protons are separated using reconstructed hadroness (Hadrorec)
+    
+    """
+    hadro = "Hadrorec"
+    if truehadroness:
+        hadro = "hadroness"
+
+    #Energy distribution
+    plt.subplot(331)
+    plt.hist(data[data[hadro]<1]['mcEnergy'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(data[data[hadro]>0]['mcEnergy'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"$log_{10}E$(GeV)")
+    plt.legend()
+
+    #Disp distribution
+    plt.subplot(332)
+    plt.hist(data[data[hadro]<1]['disp'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(data[data[hadro]>0]['disp'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"Disp (m)")
+
+    #Intensity distribution
+    plt.subplot(333)
+    plt.hist(data[data[hadro]<1]['intensity'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(data[data[hadro]>0]['intensity'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"$log_{10}Intensity$")
+
+    dataforwl = data[data['intensity']>np.log10(200)]
+    #Width distribution
+    plt.subplot(334)
+    plt.hist(dataforwl[dataforwl[hadro]<1]['width'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(dataforwl[dataforwl[hadro]>0]['width'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"Width (º)")
+
+    #Length distribution
+    plt.subplot(335)
+    plt.hist(dataforwl[dataforwl[hadro]<1]['length'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(dataforwl[dataforwl[hadro]>0]['length'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"Length (º)")
+
+    #r distribution
+    plt.subplot(336)
+    plt.hist(data[data[hadro]<1]['r'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(data[data[hadro]>0]['r'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"r (m)")
+
+    #psi distribution
+
+    plt.subplot(337)
+    plt.hist(data[data[hadro]<1]['psi'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(data[data[hadro]>0]['psi'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"psi angle(rad)")
+    
+    #psi distribution
+
+    plt.subplot(338)
+    plt.hist(data[data[hadro]<1]['phi'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(data[data[hadro]>0]['phi'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"phi angle(m)")
+    
+    #Time gradient
+
+    plt.subplot(339)
+    plt.hist(data[data[hadro]<1]['time_gradient'],histtype=u'step',bins=100,label="Gammas")
+    plt.hist(data[data[hadro]>0]['time_gradient'],histtype=u'step',bins=100,label="Protons")
+    plt.ylabel(r'# of events',fontsize=15)
+    plt.xlabel(r"Time gradient")
+
+
+def plot_E(data,truehadroness=False):
+    
+    """
+    Plot the performance of reconstructed Energy. 
+
+    Parameters:
+    data: pandas DataFrame
+    
+    truehadroness:
+    True: True gammas and proton events are plotted (they are separated using true hadroness). 
+    False: Gammas and protons are separated using reconstructed hadroness (Hadrorec)
+    
+    """
+    hadro = "Hadrorec"
+    if truehadroness:
+        hadro = "hadroness"
+    
+    gammas = data[data[hadro]==0] 
+    
+    plt.subplot(221)
+    difE = ((gammas['mcEnergy']-gammas['Erec'])*np.log(10))
+    section = difE[abs(difE) < 1.5]
+    mu,sigma = norm.fit(section)
+    print(mu,sigma)
+    n, bins, patches = plt.hist(difE,100,density=1,alpha=0.75)
+    y = norm.pdf( bins, mu, sigma)
+    l = plt.plot(bins, y, 'r--', linewidth=2)
+    plt.xlabel('$(log_{10}(E_{gammas})-log_{10}(E_{rec}))*log_{N}(10)$',fontsize=10)
+    plt.figtext(0.15,0.7,'Mean: '+str(round(mu,4)),fontsize=10)
+    plt.figtext(0.15,0.65,'Std: '+str(round(sigma,4)),fontsize=10)
+    
+    plt.subplot(222)
+    hE = plt.hist2d(gammas['mcEnergy'],gammas['Erec'],bins=100)
+    plt.colorbar(hE[3])
+    plt.xlabel('$log_{10}E_{gammas}$',fontsize=15)
+    plt.ylabel('$log_{10}E_{rec}$',fontsize=15)
+    plt.plot(gammas['mcEnergy'],gammas['mcEnergy'],"-",color='red')
+
+    #Plot a profile
+    subplot = plt.subplot(223)
+    means_result = scipy.stats.binned_statistic(gammas['mcEnergy'], [difE, difE**2], bins=50, 
+                                                range=(1,6), statistic='mean')
+    means, means2 = means_result.statistic
+    standard_deviations = np.sqrt(means2 - means**2)
+    bin_edges = means_result.bin_edges
+    bin_centers = (bin_edges[:-1] + bin_edges[1:])/2.
+    
+    #fig = plt.figure()
+    gs = gridspec.GridSpecFromSubplotSpec(2, 1, height_ratios=[2, 1],subplot_spec=subplot)
+    ax0 = plt.subplot(gs[0])
+    plot0 = ax0.errorbar(x=bin_centers, y=means, yerr=standard_deviations, linestyle='none', marker='.')
+    plt.ylabel('$(log_{10}(E_{true})-log_{10}(E_{rec}))*log_{N}(10)$',fontsize=10)
+    
+    ax1 = plt.subplot(gs[1], sharex = ax0)
+    plot1 = ax1.plot(bin_centers, standard_deviations,marker='+',linestyle='None')
+    plt.setp(ax0.get_xticklabels(), visible=False)
+    yticks = ax1.yaxis.get_major_ticks()
+    yticks[-1].label1.set_visible(False)
+    plt.ylabel("Std",fontsize=10)
+    plt.xlabel('$log_{10}E_{true}$',fontsize=10)
+
+    plt.subplots_adjust(hspace=.0)
+    
+def plot_Disp(data,truehadroness=False):
+    
+    """
+    Plot the performance of reconstructed position
+
+    Parameters:
+    data: pandas DataFrame
+    
+    truehadroness: boolean
+    True: True gammas and proton events are plotted (they are separated using true hadroness). 
+    False: Gammas and protons are separated using reconstructed hadroness (Hadrorec)
+    
+    """
+    hadro = "Hadrorec"
+    if truehadroness:
+        hadro = "hadroness"
+
+    gammas = data[data[hadro]==0] 
+
+    plt.subplot(221)
+    difD = ((gammas['disp']-gammas['Disprec'])/gammas['disp'])
+    section = difD[abs(difD) < 0.5]
+    mu,sigma = norm.fit(section)
+    print(mu,sigma)
+    n,bins,patches = plt.hist(difD,100,density=1,alpha=0.75,range=[-2,1.5])
+    y = norm.pdf( bins, mu, sigma)
+    l = plt.plot(bins, y, 'r--', linewidth=2)
+    plt.xlabel('$\\frac{Disp_{gammas}-Disp_{rec}}{Disp_{gammas}}$',fontsize=15)
+    plt.figtext(0.15,0.7,'Mean: '+str(round(mu,4)),fontsize=12)
+    plt.figtext(0.15,0.65,'Std: '+str(round(sigma,4)),fontsize=12)
+                
+    plt.subplot(222)
+    hD = plt.hist2d(gammas['disp'],gammas['Disprec'],bins=100,range=([0,1.1],[0,1.1]))
+    plt.colorbar(hD[3])
+    plt.xlabel('$Disp_{gammas}$',fontsize=15)
+    plt.ylabel('$Disp_{rec}$',fontsize=15)
+    plt.plot(gammas['disp'],gammas['disp'],"-",color='red')   
+ 
+    plt.subplot(223)
+    theta2 = (gammas['SrcX']-gammas['SrcXrec'])**2+(gammas['SrcY']-gammas['SrcY'])**2
+    plt.hist(theta2,bins=100,range=[0,0.1],histtype=u'step')
+    plt.xlabel(r'$\theta^{2}(º)$',fontsize=15)
+    plt.ylabel(r'# of events',fontsize=15)
+    
+
+def plot_pos(data,truehadroness=False):
+    
+    """
+    Plot the performance of reconstructed position
+
+    Parameters:
+    data: pandas DataFrame
+    
+    truehadroness: boolean
+    True: True gammas and proton events are plotted (they are separated using true hadroness). 
+    False: Gammas and protons are separated using reconstructed hadroness (Hadrorec)
+    
+    """
+    hadro = "Hadrorec"
+    if truehadroness:
+        hadro = "hadroness"
+
+    #True position
+    trueX = data[data[hadro]==0]['SrcX']
+    trueY = data[data[hadro]==0]['SrcY']
+    trueXprot = data[data[hadro]==1]['SrcX']
+    trueYprot = data[data[hadro]==1]['SrcY']
+    #Reconstructed position
+    recX = data[data[hadro]==0]['SrcXrec']
+    recY = data[data[hadro]==0]['SrcYrec']
+    recXprot = data[data[hadro]==1]['SrcXrec']
+    recYprot = data[data[hadro]==1]['SrcYrec']
+
+    plt.subplot(221)
+    plt.hist2d(trueXprot,trueYprot,bins=100,label="Protons")
+    plt.colorbar()
+    plt.title("True position Protons")
+    plt.xlabel("x(m)")
+    plt.ylabel("y (m)")
+    plt.subplot(222)
+    plt.hist2d(trueX,trueY,bins=100,label="Gammas",range=np.array([(-1, 1), (-1, 1)]))
+    plt.colorbar()
+    plt.title("True position Gammas")
+    plt.xlabel("x (m)")
+    plt.ylabel("y (m)")
+    plt.subplot(223)
+    plt.hist2d(recXprot,recYprot,bins=100,label="Protons",range=np.array([(-1, 1), (-1, 1)]))
+    plt.colorbar()
+    plt.title("Reconstructed position Protons")
+    plt.xlabel("x (m)")
+    plt.ylabel("y (m)")
+    plt.subplot(224)
+    plt.hist2d(recX,recY,bins=100,label="Gammas",range=np.array([(-1, 1), (-1, 1)]))
+    plt.colorbar()
+    plt.title("Reconstructed position Gammas ")
+    plt.xlabel("x (m)")
+    plt.ylabel("y (m)")


### PR DESCRIPTION
Hello everyone,

As some of you know, I was asked by Andrea Bulgarelli and the team dedicated to the CTA Real-Time analysis to provide a full working pipeline with all the codes from cta-lstchain.

They need to easily get events in DL3 format so they can store them in their database and apply their workflow. I tried to do something that will allow anyone to give as an input a raw LST1 event (or a simtelarray file with events) and have as an output DL3 data with all the parameters of the shower and its reconstrued energy, position and hadroness. 

To do so, I've rearranged all the scripts that we've been using in cta-lstchain/reco into modules with functions that can be easily called to perfom the different tasks from the chain.

I've created four basic modules(with very dull names, please suggest something more catchy!):

- **"parameters.py":**

 This one does the same task as the script "LST1_Hillas.py". It contains the function "get_events(...)" that takes as imput a simtelarray file and does the data reduction, hillas and timing parameters calculation and stores the result in a pandas DataFrame that can be stored in an hdf5 file. I've  simplified the structure avoiding using python Tables, and now it directly stores the data into a DataFrame.

- **"transformations.py"**:

 This module contains the same functions as "Disp.py" with a minor change in the function calc_CamSourcePos() which makes it work faster but must be runned event by event.

- **"reconstruction.py"**:

 This module contains functions to train the Random Forest, store them and apply them to a certain set of data.

- **"visualization.py"**:

 This is for plotting results (like the plots I showed in the LST1 meeting)

I've also written three simple pipelines as examples on using the modules:

- **"lst-trainpipe.py"**:

 Trains the random forests using gamma and hadron events already reduced to hdf5 files. The RF can be stored in files so they can be used later for any set of data.

- **"lst-recopipe.py"**:

 Performs the reconstruction of a set of data read from a "simtelarray" file, using Random Forest that are saved into files. It also plots the results 

- **"lstpipe.py"**:

 Is a fusion of the ones before, it trains the RF on the go and applies them to data read fom a simtelarray file. 

The pipeline that the RTA team will need would look something similar to "lst-recopipe.py", where in the end they can add the lines of their code to save the events in their database format. 

To run this pipelines, it is necessary to have the files "gamma_events_point.hdf5" and "proton_events.hdf5" which I have tried to upload to "cta-lstchain-extra" but they are too heavy and github doesn't allow me to do ti. If anyone know how to deal with heavy files, I will thank very much your help. 

Please, tell me if you think this structure is ok and maybe we can start working in this codes and deprecate the old scripts that are much less user friendly.
If you think there are something that can be improved, please feel free to do your own commits. 

Also, I haven't yet added any change of the ones pointed out by Satoshi about the time gradient and the impact parameter, I will wait until his full commit is reviewed so we can merge it in the new module.

Thank you for your collaboration! I look forward to hear your comments and suggestions.  
Regards,

Mab. 
