### PR TITLE
Avoid NaNs in width, and small corrections

### DIFF
--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -150,8 +150,9 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'), out
                     l = np.rad2deg(np.arctan2(dl1_container.length, foclen))
                     dl1_container.width = w.value
                     dl1_container.length = l.value
-
-                    writer.write(camera.cam_id, [dl1_container])
+                    
+                    if w>=0:
+                        writer.write(camera.cam_id, [dl1_container])
 
 
     

--- a/lstchain/reco/reco_dl1_to_dl2.py
+++ b/lstchain/reco/reco_dl1_to_dl2.py
@@ -154,7 +154,7 @@ def buildModels(filegammas, fileprotons, features,
     Returns:
     --------
     RandomForestRegressor: RFreg_Energy
-    RandomForestRegressor: RFreg_disp
+    RandomForestRegressor: RFreg_Disp
     RandomForestClassifier: RFcls_GH
     """
     if not os.path.exists(path_models):
@@ -176,7 +176,7 @@ def buildModels(filegammas, fileprotons, features,
     
     #Train regressors for energy and disp reconstruction, only with gammas
     
-    RFreg_Energy, RFreg_disp = trainRFreco(df_gamma,
+    RFreg_Energy, RFreg_Disp = trainRFreco(df_gamma,
                                            features)
 
     #Train classifier for gamma/hadron separation. We need to use half
@@ -188,19 +188,19 @@ def buildModels(filegammas, fileprotons, features,
     test = testg.append(df_proton,
                         ignore_index=True)
 
-    tempRFreg_Energy, tempRFreg_disp = trainRFreco(train, features_)
+    tempRFreg_Energy, tempRFreg_Disp = trainRFreco(train, features_)
     
     #Apply the regressors to the test set
 
     test['e_rec'] = tempRFreg_Energy.predict(test[features_])
-    test['disp_rec'] = tempRFreg_disp.predict(test[features_])
+    test['disp_rec'] = tempRFreg_Disp.predict(test[features_])
     
     #Apply cut in reconstructed energy. New train set is the previous
     #test with energy and disp reconstructed.
     
     train = test[test['mc_energy']>EnergyCut]
     
-    del tempRFreg_Energy, tempRFreg_disp
+    del tempRFreg_Energy, tempRFreg_Disp
     
     #Add e_rec and disp_rec to features.
     features_sep = features_
@@ -214,16 +214,16 @@ def buildModels(filegammas, fileprotons, features,
     
     if SaveModels:
         fileE = path_models + "/RFreg_Energy.sav"
-        fileD = path_models + "/RFreg_disp.sav"
+        fileD = path_models + "/RFreg_Disp.sav"
         fileH = path_models + "/RFcls_GH.sav"
         joblib.dump(RFreg_Energy, fileE)
-        joblib.dump(RFreg_disp, fileD)
+        joblib.dump(RFreg_Disp, fileD)
         joblib.dump(RFcls_GH, fileH)
 
-    return RFreg_Energy, RFreg_disp, RFcls_GH
+    return RFreg_Energy, RFreg_Disp, RFcls_GH
 
 
-def ApplyModels(dl1, features, RFcls_GH, RFreg_Energy, RFreg_disp):
+def ApplyModels(dl1, features, RFcls_GH, RFreg_Energy, RFreg_Disp):
     """Apply previously trained Random Forests to a set of data
     depending on a set of features.
 
@@ -239,7 +239,7 @@ def ApplyModels(dl1, features, RFcls_GH, RFreg_Energy, RFreg_disp):
     RFreg_Energy: Random Forest Regressor
     RF for Energy reconstruction
 
-    RFreg_disp: Random Forest Regressor
+    RFreg_Disp: Random Forest Regressor
     RF for disp reconstruction
 
     """
@@ -248,9 +248,9 @@ def ApplyModels(dl1, features, RFcls_GH, RFreg_Energy, RFreg_disp):
     dl2 = dl1.copy()
     #Reconstruction of Energy and disp distance
     dl2['e_rec'] = RFreg_Energy.predict(dl2[features_])
-    dl2['disp_rec'] = RFreg_disp.predict(dl2[features_])
+    dl2['disp_rec'] = RFreg_Disp.predict(dl2[features_])
    
-    #Construction of Source position in camera coordinates from disp_ distance.
+    #Construction of Source position in camera coordinates from disp distance.
     #WARNING: For not it only works fine for POINT SOURCE events
     dl2['src_x_rec'], dl2['src_y_rec'] = utils.disp_to_pos(dl2['disp_rec'],
                                                                   dl2['x'],

--- a/lstchain/visualization/plot_dl2.py
+++ b/lstchain/visualization/plot_dl2.py
@@ -132,7 +132,7 @@ def plot_features(data,truehadroness=False):
     plt.xlabel(r"Time gradient")
 
 
-def plot_E(data,truehadroness=False):
+def plot_e(data,truehadroness=False):
     
     """Plot the performance of reconstructed Energy. 
 
@@ -211,7 +211,7 @@ def plot_E(data,truehadroness=False):
     plt.subplots_adjust(hspace=.0)
 
     
-def plot_disp_(data,truehadroness=False):
+def plot_disp(data,truehadroness=False):
     
     """Plot the performance of reconstructed position
 

--- a/scripts/lst-trainpipe.py
+++ b/scripts/lst-trainpipe.py
@@ -7,6 +7,8 @@ Usage:
 $> python lst-trainpipe arg1 arg2 ...
 
 """
+import sys                                                   
+sys.path.insert(0, '../')
 import argparse
 from lstchain.reco import reco_dl1_to_dl2
 
@@ -47,7 +49,7 @@ if __name__ == '__main__':
                 'psi']
 
 
-    RFreg_Energy, RFreg_disp, RFcls_GH = reco_dl1_to_dl2.buildModels(
+    RFreg_Energy, RFreg_Disp, RFcls_GH = reco_dl1_to_dl2.buildModels(
         args.gammafile,
         args.protonfile,
         features,


### PR DESCRIPTION
I redid the old PR with the changes I needed to make all scripts run. 

- I included the if statement for the NaNs, it is necessary for running on larger simtelarray files other than the example one from ctapipe., until we decide how to manage it better.
- Just for aesthetics and coherence with cta-lstchain-extra: RFreg_disp -> RFreg_Disp
- Usage of "r0_to_dl1()" in lst-recopipe instead of get_events()
- Added a new argument to lst-recopipe, to limit the maximum number of events to analyze (for quick tests on larger simtelarray files)
- In visualization: plot_disp_ -> plot_disp, plot_E() -->  plot_e()
