### PR TITLE
Correcting a mistake in particle numbering 

### DIFF
--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -221,7 +221,7 @@ def particle_number(particle_name):
         'gamma': 0,
         'proton': 1,
         'electron': 2,
-        'proton': 3,
+        'muon': 3,
     }[particle_name]
 
 


### PR DESCRIPTION
A typo was giving 3 a particle number to protons.