### PR TITLE
modified telescope description in lsteventsource.py

### DIFF
--- a/lstchain/io/lsteventsource.py
+++ b/lstchain/io/lsteventsource.py
@@ -90,7 +90,7 @@ class LSTEventSource(EventSource):
             geometry_version = 2
             camera = CameraGeometry.from_name("LSTCam", geometry_version)
 
-            tel_descr = TelescopeDescription(optics, camera)
+            tel_descr = TelescopeDescription("LST", "LST", optics, camera)
 
             self.n_camera_pixels = tel_descr.camera.n_pixels
             tels = {tel_id: tel_descr}


### PR DESCRIPTION
I got an error when I was trying to read zfits data in the following code.

`from lstchain.io.lsteventsource import LSTEventSource`
`from ctapipe.io import EventSeeker`
`source = LSTEventSource(input_url='.../LST1.1.Run00088.0000.fits.fz',max_events=30)`
`seeker = EventSeeker(source)`
`for i, event in enumerate(seeker):`
`    print('Event: {}'.format(event.r0.event_id))`

The error occured at `for i,event in enumerate(seeker)` and
error messages are the following.
 
`Traceback (most recent call last):`
`File "CheckCameraGeometry.py", line 21, in <module>`
 `for event,i in enumerate(seeker):`
...
  `File "/home/shunsuke.sakurai/AnalysisTool/anaconda/envs/cta-dev/lib/python3.7/site-packages/lstchain-0.1-py3.7.egg/lstchain/io/lsteventsource.py", line 93, in _generator`
`TypeError: __init__() missing 2 required positional arguments: 'optics' and 'camera'`

So, I checked line 93 in lsteventsource.py
`ctapipe.instrument.TelescopeDescription()` was called at there.

Then, I looked a code of the function in `ctapipe/instrument/telescope.py`
I found that we need 2 more arguments `name` and `type`.
I tried adding argument, `TelescopeDescription("LST", "LST",optics,camera)` in lsteventsource.py

After that my code has worked.

