### PR TITLE
allow to load model not strictly indentical with the network

### DIFF
--- a/utils/gammalearn/gl_utils.py
+++ b/utils/gammalearn/gl_utils.py
@@ -55,7 +55,7 @@ def load_model(experiments_path, experiment_name, checkpoint, camera_parameters_
     net_parameters = exp_info['network'][net_name]
     net = model_net(net_parameters, camera_parameters)
 
-    net.load_state_dict(saved_model)
+    net.load_state_dict(saved_model, strict=False)
     net.eval()
 
     return net


### PR DESCRIPTION
Modification of the way to load pretrained deep learning models. The only file impacted is utils/gammalearn/gl_utils.py.