### PR TITLE
Adding simulation info to DL1 files

### DIFF
--- a/lstchain/io/__init__.py
+++ b/lstchain/io/__init__.py
@@ -1,2 +1,3 @@
 from .config import *
 from .lstcontainers import *
+from .io import *

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1,10 +1,12 @@
 from ctapipe.io import HDF5TableReader
 from ctapipe.io.containers import MCHeaderContainer
 from tables import open_file
+import h5py
 import numpy as np
 
 __all__ = ['read_simu_info_hdf5',
            'read_simu_info_merged_hdf5',
+           'get_dataset_keys',
            ]
 
 def read_simu_info_hdf5(filename):
@@ -53,3 +55,25 @@ def read_simu_info_merged_hdf5(filename):
     combined_mcheader['num_showers'] = num_showers
     return combined_mcheader
 
+
+def get_dataset_keys(filename):
+    """
+    Return a list of all dataset keys in a HDF5 file
+
+    Parameters
+    ----------
+    filename: str - path to the HDF5 file
+
+    Returns
+    -------
+    list of keys
+    """
+    dataset_keys = []
+    def walk(name, obj):
+        if type(obj) == h5py._hl.dataset.Dataset:
+            dataset_keys.append(name)
+
+    with h5py.File(filename,'r') as file:
+        file.visititems(walk)
+
+    return dataset_keys

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1,0 +1,55 @@
+from ctapipe.io import HDF5TableReader
+from ctapipe.io.containers import MCHeaderContainer
+from tables import open_file
+import numpy as np
+
+__all__ = ['read_simu_info_hdf5',
+           'read_simu_info_merged_hdf5',
+           ]
+
+def read_simu_info_hdf5(filename):
+    """
+    Read simu info from an hdf5 file
+
+    Returns
+    -------
+    `ctapipe.containers.MCHeaderContainer`
+    """
+
+    with HDF5TableReader(filename) as reader:
+        mcheader = reader.read('/simulation/run_config', MCHeaderContainer())
+        mc = next(mcheader)
+
+    return mc
+
+
+def read_simu_info_merged_hdf5(filename):
+    """
+    Read simu info from a merged hdf5 file.
+    Check that simu info are the same for all runs from merged file
+    Combine relevant simu info such as num_showers (sum)
+    Note: works for a single run file as well
+
+    Parameters
+    ----------
+    filename: path to an hdf5 merged file
+
+    Returns
+    -------
+    `ctapipe.containers.MCHeaderContainer`
+
+    """
+    with open_file(filename) as file:
+        simu_info = file.root['simulation/run_config']
+        colnames = simu_info.colnames
+        colnames.remove('num_showers')
+        colnames.remove('shower_prog_start')
+        colnames.remove('detector_prog_start')
+        for k in colnames:
+            assert np.all(simu_info[:][k] == simu_info[0][k])
+        num_showers = simu_info[:]['num_showers'].sum()
+
+    combined_mcheader = read_simu_info_hdf5(filename)
+    combined_mcheader['num_showers'] = num_showers
+    return combined_mcheader
+

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -198,6 +198,9 @@ def r0_to_dl1(
                         camera = event.inst.subarray.tel[telescope_id].camera
                         writer.write(camera.cam_id, [dl1_container])
 
+    with HDF5TableWriter(filename=output_filename, group_name="simulation", mode="a") as writer:
+        writer.write("run_config", [event.mcheader])
+
 
 def get_events(filename, storedata=False, test=False,
                concatenate=False, storeimg=False, outdir='./results/'):

--- a/scripts/merge_hdf5_files.py
+++ b/scripts/merge_hdf5_files.py
@@ -63,9 +63,5 @@ if __name__ == '__main__':
 
         for ii, node in nodes.items():
             for children in node:
-                print(ii)
-                print(type(ii))
-                print(node)
-                print(type(node))
                 p = os.path.join(ii, children.name)
                 node[children.name].append(file.root[p].read())

--- a/scripts/merge_hdf5_files.py
+++ b/scripts/merge_hdf5_files.py
@@ -36,9 +36,8 @@ if __name__ == '__main__':
 
 
     for filename in file_list[1:]:
-        file = tables.open_file(filename)
-
-        for ii, node in nodes.items():
-            for children in node:
-                p = os.path.join(ii, children.name)
-                node[children.name].append(file.root[p].read())
+        with tables.open_file(filename) as file:
+            for ii, node in nodes.items():
+                for children in node:
+                    p = os.path.join(ii, children.name)
+                    node[children.name].append(file.root[p].read())

--- a/scripts/merge_hdf5_files.py
+++ b/scripts/merge_hdf5_files.py
@@ -1,7 +1,7 @@
 import argparse
 import os
-import h5py
 import tables
+from lstchain.io import get_dataset_keys
 
 parser = argparse.ArgumentParser(description="Merge all HDF5 files resulting from parallel reconstructions \
  present in a directory. Every dataset in the files must be readable with pandas.")
@@ -18,29 +18,6 @@ parser.add_argument('--outfile', '-o', action='store', type=str,
                     default='merge.h5')
 
 args = parser.parse_args()
-
-
-def get_dataset_keys(filename):
-    """
-    Return a list of all dataset keys in a HDF5 file
-
-    Parameters
-    ----------
-    filename: str - path to the HDF5 file
-
-    Returns
-    -------
-    list of keys
-    """
-    dataset_keys = []
-    def walk(name, obj):
-        if type(obj) == h5py._hl.dataset.Dataset:
-            dataset_keys.append(name)
-
-    with h5py.File(filename,'r') as file:
-        file.visititems(walk)
-
-    return dataset_keys
 
 
 

--- a/scripts/merge_hdf5_files.py
+++ b/scripts/merge_hdf5_files.py
@@ -1,7 +1,7 @@
-import pandas as pd
 import argparse
 import os
 import h5py
+import tables
 
 parser = argparse.ArgumentParser(description="Merge all HDF5 files resulting from parallel reconstructions \
  present in a directory. Every dataset in the files must be readable with pandas.")
@@ -43,20 +43,29 @@ def get_dataset_keys(filename):
     return dataset_keys
 
 
-if __name__ == '__main__':
 
+if __name__ == '__main__':
     file_list = [args.srcdir + '/' + f for f in os.listdir(args.srcdir) if f.endswith('.h5')]
 
-    dataframes = {}
+    keys = get_dataset_keys(file_list[0])
+    groups = set([k.split('/')[0] for k in keys])
 
-    for file in file_list:
-        keys = get_dataset_keys(file)
-        for k in keys:
-            if k in dataframes:
-                dataframes[k] = pd.concat([dataframes[k], pd.read_hdf(file, key=k)])
-            else:
-                dataframes[k] = pd.read_hdf(file, key=k)
+    f1 = tables.open_file(file_list[0])
+    merge_file = tables.open_file(args.outfile, 'w')
 
-    for k, df in dataframes.items():
-        df.to_hdf(args.outfile, key=k)
+    nodes = {}
+    for g in groups:
+        nodes[g] = f1.copy_node('/', name=g, newparent=merge_file.root, newname=g, recursive=True)
 
+
+    for filename in file_list[1:]:
+        file = tables.open_file(filename)
+
+        for ii, node in nodes.items():
+            for children in node:
+                print(ii)
+                print(type(ii))
+                print(node)
+                print(type(node))
+                p = os.path.join(ii, children.name)
+                node[children.name].append(file.root[p].read())

--- a/scripts/merge_hdf5_files.py
+++ b/scripts/merge_hdf5_files.py
@@ -37,7 +37,10 @@ if __name__ == '__main__':
 
     for filename in file_list[1:]:
         with tables.open_file(filename) as file:
-            for ii, node in nodes.items():
-                for children in node:
-                    p = os.path.join(ii, children.name)
-                    node[children.name].append(file.root[p].read())
+            try:
+                for ii, node in nodes.items():
+                    for children in node:
+                        p = os.path.join(ii, children.name)
+                        node[children.name].append(file.root[p].read())
+            except:
+                print("Can't merge {}".format(filename))


### PR DESCRIPTION
This PR only adds simulation infos to DL1 files following the structure in v5 discussed in https://github.com/cta-observatory/ctapipe/issues/1059
Somehow fixes #119 .

As the DL1 structure is still being discussed, I think we can move forward with the simu info part to at least have this info available to create IRFs.

The events table structure stays untouched so the rest of the code will still work without any change.

I also modify the merge script to append the simu info from each merged file.