### PR TITLE
Fix def train_disp_sign

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -145,8 +145,8 @@ def train_disp_sign(train, custom_config={}, predict_feature='disp_sign'):
 
     config = replace_config(standard_config, custom_config)
     classification_args = config['random_forest_classifier_args']
-    features = config["regression_features"]
-    model = RandomForestRegressor
+    features = config["classification_features"]
+    model = RandomForestClassifier
 
     print("Given features: ", features)
     print("Number of events for training: ", train.shape[0])


### PR DESCRIPTION
Replaced model and features variables in def train_disp_sign(). The R…F_model was set as a RandomForestRegressor, when it should be a RandomForesetClassifier, as the definition and documentation specifies. Also, the features were changed from regression_ to classification_features.