### PR TITLE
Fix ctapipe version to v0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,26 @@
 language: python
 
+
+python:
+    - 3.6
+    - 3.7
+
+env:
+    - CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1"
+    - CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master"
+
 matrix:
-  include:
-    python: 3.7
-    os: linux
-    env:
-      - CTAPIPE_VERSION=v0.7.0
-      - PROTOZFITS_VERSION=v1.4.2
-      - CTAPIPE_IO_LST_VERSION=v0.1
-
   allow_failures:
-    python: 3.7
-    os: linux
-    env:
-      - CTAPIPE_VERSION=master
-      - PROTOZFITS_VERSION=v1.4.2
-      - CTAPIPE_IO_LST_VERSION=master
+      - python: 3.6
+        env: CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master"
+      - python: 3.7
+        env: CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master"
 
+  include:
+      - python: 3.6
+        env: CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1"
+      - python: 3.7
+        env: CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1"
 
 before_install:
 
@@ -37,12 +41,10 @@ install:
     - conda env create --name cta --file environment.yml
     - conda activate cta
     - pip install https://github.com/cta-observatory/ctapipe/archive/$CTAPIPE_VERSION.tar.gz
-    - pip install https://github.com/cta-sst-1m/protozfitsreader/archive/$PROTOZFITS_VERSION.tar.gz
     - pip install https://github.com/cta-observatory/ctapipe_io_lst/archive/$CTAPIPE_IO_LST_VERSION.tar.gz
     - python setup.py install
 
 
 script:
     - pytest
-
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,20 @@ language: python
 
 matrix:
   include:
+    python: 3.7
+    os: linux
+    env:
+      - CTAPIPE_VERSION=v0.7.0
+      - PROTOZFITS_VERSION=v1.4.2
+      - CTAPIPE_IO_LST_VERSION=v0.1
 
-    - python: 3.7
-      os: linux
-      env:
-          - CTAPIPE_VERSION=v0.7.0
-          - PROTOZFITS_VERSION=v1.4.2
-          - CTAPIPE_IO_LST_VERSION=v0.1
-
-    - python: 3.7
-      os: linux
-      env:
-          - CTAPIPE_VERSION=master
-          - PROTOZFITS_VERSION=v1.4.2
-          - CTAPIPE_IO_LST_VERSION=master
+  allow_failures:
+    python: 3.7
+    os: linux
+    env:
+      - CTAPIPE_VERSION=master
+      - PROTOZFITS_VERSION=v1.4.2
+      - CTAPIPE_IO_LST_VERSION=master
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,18 @@ language: python
 
 matrix:
     include:
-        python: 3.6
-        os: linux
-        env:
-            - CTAPIPE_VERSION=master
-            - PROTOZFITS_VERSION=v1.4.2
-            - CTAPIPE_IO_LST_VERSION=master
+        - python: 3.7
+            os: linux
+                - CTAPIPE_VERSION=v0.7.0
+                - PROTOZFITS_VERSION=v1.4.2
+                - CTAPIPE_IO_LST_VERSION=v0.1
+
+        - python: 3.7
+            os: linux
+            env:
+                - CTAPIPE_VERSION=master
+                - PROTOZFITS_VERSION=v1.4.2
+                - CTAPIPE_IO_LST_VERSION=master
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 
-
 python:
     - 3.6
     - 3.7
@@ -11,16 +10,11 @@ env:
 
 matrix:
   allow_failures:
-      - python: 3.6
-        env: CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master"
-      - python: 3.7
-        env: CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master"
+      - env: CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master"
 
   include:
-      - python: 3.6
-        env: CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1"
-      - python: 3.7
-        env: CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1"
+      - env: CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1"
+
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
     include:
         - python: 3.7
             os: linux
+            env:
                 - CTAPIPE_VERSION=v0.7.0
                 - PROTOZFITS_VERSION=v1.4.2
                 - CTAPIPE_IO_LST_VERSION=v0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ python:
     - 3.7
 
 env:
-    - CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1"
-    - CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master"
+    - CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1" PROTOZFITS_VERSION=v1.4.2
+    - CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master" PROTOZFITS_VERSION="master"
 
 matrix:
   allow_failures:
-      - env: CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master"
+      - env: CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master" PROTOZFITS_VERSION="master"
 
   include:
-      - env: CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1"
+      - env: CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.1" PROTOZFITS_VERSION=v1.4.2
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: python
 
 matrix:
-    include:
-        - python: 3.7
-            os: linux
-            env:
-                - CTAPIPE_VERSION=v0.7.0
-                - PROTOZFITS_VERSION=v1.4.2
-                - CTAPIPE_IO_LST_VERSION=v0.1
+  include:
 
-        - python: 3.7
-            os: linux
-            env:
-                - CTAPIPE_VERSION=master
-                - PROTOZFITS_VERSION=v1.4.2
-                - CTAPIPE_IO_LST_VERSION=master
+    - python: 3.7
+      os: linux
+      env:
+          - CTAPIPE_VERSION=v0.7.0
+          - PROTOZFITS_VERSION=v1.4.2
+          - CTAPIPE_IO_LST_VERSION=v0.1
+
+    - python: 3.7
+      os: linux
+      env:
+          - CTAPIPE_VERSION=master
+          - PROTOZFITS_VERSION=v1.4.2
+          - CTAPIPE_IO_LST_VERSION=master
 
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ The analysis is heavily based on [ctapipe](https://github.com/cta-observatory/ct
 
 master branch status: [![Build Status](https://travis-ci.org/cta-observatory/cta-lstchain.svg?branch=master)](https://travis-ci.org/cta-observatory/cta-lstchain)
 
-
+  
 Note that notebooks are currently not tested and not guaranteed to be up-to-date.   
-In doubt, refer to tested code and scripts.
-
+In doubt, refer to tested code and scripts: basic functions of lstchain (reduction steps R0-->DL1 and DL1-->DL2) 
+are unit tested and should be working as long as the build status is passing.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -6,41 +6,25 @@ The analysis is heavily based on [ctapipe](https://github.com/cta-observatory/ct
 master branch status: [![Build Status](https://travis-ci.org/cta-observatory/cta-lstchain.svg?branch=master)](https://travis-ci.org/cta-observatory/cta-lstchain)
 
 
-### Important message to lstchain users (May 4th 2019):
-*ctapipe* and *lstchain* are currently undergoing heavy and rapid changes.    
-The core developer team is trying to stay up-to-date with the master version of *ctapipe* before reaching *ctapipe v0.7* release.
-You might experience some issues if changes have been merged in *ctapipe* master before we could integrate these changes in *lstchain*. We are sorry for that. Do not hesitate to submit an issue or propose a patch through a pull request.
-
-- The basic functions of lstchain (reduction steps R0-->DL1 and DL1-->DL2) are unit tested and should be working as long as the build status is passing.    
-- However, the notebooks are not and might not be up-to-date before stable release. Do not rely on them for now.
-
+Note that notebooks are currently not tested and not guaranteed to be up-to-date.   
+In doubt, refer to tested code and scripts.
 
 
 ## Install
 
-> Old install procedure:
-> If you are a user and don't already have ctapipe installed:
-> ```
-> conda env create -f environment.yml
-> source activate cta
-> ```
-> This will create a conda environment called `cta` and install ctapipe with all dependencies.
+- You will need to install [anaconda](https://www.anaconda.com/distribution/#download-section) first. 
 
-> Then you can install the `lstchain` in this environment with:
-> ```
-> python setup.py install
-> ```
-
-Current `lstchain` build uses `ctapipe` master version.   
-Here is how you should install:
+- Create and activate the conda environment:
 ```
 git clone https://github.com/cta-observatory/cta-lstchain.git
 cd cta-lstchain
-conda env create --name cta --file environment.yml
-conda activate cta
-pip install https://github.com/cta-observatory/ctapipe/archive/master.tar.gz
-pip install https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
-pip install https://github.com/cta-observatory/ctapipe_io_lst/archive/master.tar.gz
+conda env create -f environment.yml
+source activate cta
+```
+
+- Install lstchain:
+
+```
 pip install -e .
 ```
 
@@ -49,12 +33,12 @@ pip install -e .
 
 All contribution are welcomed.
 
-Guidelines are the same as [ctapipe's ones](https://cta-observatory.github.io/ctapipe/development/index.html)
+Guidelines are the same as [ctapipe's ones](https://cta-observatory.github.io/ctapipe/development/index.html)    
 See [here](https://cta-observatory.github.io/ctapipe/development/pullrequests.html) how to make a pull request to contribute.
 
 
 ## Report issue / Ask a question
 
-Use GitHub Issues.
+Use [GitHub Issues](https://github.com/cta-observatory/cta-lstchain/issues).
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,10 @@ channels:
   - cta-observatory
   - conda-forge
 dependencies:
-  - python>3.5
   - ctapipe
   - gammapy
   - pip:
       - pytest_runner
       - pytest-ordering
       - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
+      - https://github.com/cta-observatory/ctapipe_io_lst/archive/v0.1.tar.gz

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - cta-observatory
   - conda-forge
 dependencies:
-  - ctapipe
+  - ctapipe=0.7.0
   - gammapy
   - pip:
       - pytest_runner


### PR DESCRIPTION
- Fixing ctapipe v0.7.0 in environment.yml
- Update travis config with two separate tests:
    - one with fixed ctapipe v0.7.0 and ctapipe_io_lst v.0.1
    - one testing ctapipe master and ctapipe_io_lst master.
This one is allowed to fail, meaning that it will not make the entire build fail but still warn us that the current code will not work with ctapipe master, allowing us to update it in the `ctapipe-master` branch.
- adding ctapipe_io_lst v0.1 to the install environment
- fixing python 3.7