### PR TITLE
applying cleaning to image before computing timing features

### DIFF
--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -133,9 +133,13 @@ class DL1ParametersContainer(Container):
         self.disp_miss = disp.miss
 
     def set_timing_features(self, geom, image, pulse_time, hillas):
-        timepars = time.timing_parameters(geom, image, pulse_time, hillas)
-        self.time_gradient = timepars.slope.value
-        self.intercept = timepars.intercept
+        try:    # if np.polyfit fails (e.g. len(image) < deg + 1)
+            timepars = time.timing_parameters(geom, image, pulse_time, hillas)
+            self.time_gradient = timepars.slope.value
+            self.intercept = timepars.intercept
+        except ValueError:
+            self.time_gradient = np.nan
+            self.intercept = np.nan
 
     def set_leakage(self, geom, image, clean):
         leakage_c = leakage(geom, image, clean)

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -81,7 +81,10 @@ def get_dl1(calibrated_event, telescope_id, dl1_container=None, custom_config={}
         dl1_container.fill_event_info(calibrated_event)
         dl1_container.set_mc_core_distance(calibrated_event, telescope_id)
         dl1_container.set_mc_type(calibrated_event)
-        dl1_container.set_timing_features(camera, image, pulse_time, hillas)
+        dl1_container.set_timing_features(camera[signal_pixels],
+                                          image[signal_pixels],
+                                          pulse_time[signal_pixels],
+                                          hillas)
         dl1_container.set_leakage(camera, image, signal_pixels)
         dl1_container.set_n_islands(camera, signal_pixels)
         dl1_container.set_source_camera_position(


### PR DESCRIPTION
Hi

Working on something different with @garciagenrique (thanks!), we discovered a small bug in the chain: the cleaning was not applied to the charge and pulse_time images before computing the timing parameters.
