### PR TITLE
use pixels of only main island for hillas calculation

### DIFF
--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -108,6 +108,9 @@ def get_dl1(calibrated_event, telescope_id, dl1_container=None, custom_config={}
             max_island_label = np.argmax(n_pixels_on_island)
             signal_pixels[island_labels!=max_island_label] = False
 
+        if np.sum(signal_pixels) < 3 :
+            return None
+
         hillas = hillas_parameters(camera[signal_pixels], image[signal_pixels])
 
         # Fill container

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -108,9 +108,6 @@ def get_dl1(calibrated_event, telescope_id, dl1_container=None, custom_config={}
             max_island_label = np.argmax(n_pixels_on_island)
             signal_pixels[island_labels!=max_island_label] = False
 
-        if np.sum(signal_pixels) < 3 :
-            return None
-
         hillas = hillas_parameters(camera[signal_pixels], image[signal_pixels])
 
         # Fill container


### PR DESCRIPTION
Hello, this is the first pull request for my life :)

All survived pixels after image cleaning are used for hillas calculation with the current lstchain. If so, the estimation of shower axis could be bad when multiple islands exist, then all of the parameter could be useless.
With this branch, the number of island is calculated at first, then pixels in only main island which has maximum intensity is used for the parameter calculation later.
Please have a check.
![Screenshot from 2019-07-24 04-25-33](https://user-images.githubusercontent.com/31307823/66127562-f2503800-e626-11e9-805f-6cdbb77090be.png)
