### PR TITLE
Framework for the search for muons on real data

### DIFF
--- a/lstchain/__init__.py
+++ b/lstchain/__init__.py
@@ -4,6 +4,7 @@ from . import visualization
 from . import calib
 from . import mc
 from . import spectra
+from . import image
 
 from .io import standard_config
 

--- a/lstchain/image/__init__
+++ b/lstchain/image/__init__
@@ -1,0 +1,1 @@
+from .muon import *

--- a/lstchain/image/muon/__init__.py
+++ b/lstchain/image/muon/__init__.py
@@ -1,0 +1,2 @@
+from .plot_muon import *
+from .muon_analysis import *

--- a/lstchain/image/muon/muon_analysis.py
+++ b/lstchain/image/muon/muon_analysis.py
@@ -1,0 +1,235 @@
+import numpy as np
+from ctapipe.image.muon.features import ring_containment 
+from ctapipe.image.muon.features import ring_completeness
+from ctapipe.image.muon.features import npix_above_threshold
+from ctapipe.image.muon.features import npix_composing_ring
+from ctapipe.image.muon.muon_integrator import MuonLineIntegrate
+from ctapipe.image.cleaning import tailcuts_clean
+
+from astropy.coordinates import Angle, SkyCoord, AltAz
+from ctapipe.image.muon.muon_ring_finder import ChaudhuriKunduRingFitter
+from ctapipe.coordinates import CameraFrame, NominalFrame
+from astropy import units as u
+
+__all__ = ['get_muon_center',
+           'fit_muon',
+           'analyze_muon_event',
+           ]
+
+def get_muon_center(geom):
+    """
+    Get the x,y coordinates of the center of the muon ring
+    in the NominalFrame
+
+    Paramenters
+    ---------
+    geom: CameraGeometry
+
+    Returns
+    ---------
+    x, y:    `floats` coordinates in  the NominalFrame
+    """
+
+    x, y = geom.pix_x, geom.pix_y
+
+    telescope_pointing = SkyCoord(
+            alt=70 * u.deg,
+            az=0 * u.deg,
+            frame=AltAz()
+        )
+
+    camera_coord = SkyCoord(
+            x=x, y=y,
+            frame=CameraFrame(
+                focal_length=teldes.optics.equivalent_focal_length,
+                rotation=geom.pix_rotation,
+                telescope_pointing=telescope_pointing
+            )
+    )
+    nom_coord = camera_coord.transform_to(
+            NominalFrame(origin=telescope_pointing)
+        )
+
+
+    x = nom_coord.delta_az.to(u.deg)
+    y = nom_coord.delta_alt.to(u.deg)
+
+    return x, y
+
+def fit_muon(x, y, image, geom):
+    """
+    Fit the muon ring
+
+    Paramenters
+    ---------
+    x, y:    `floats` coordinates in  the NominalFrame
+    image:   `np.ndarray` number of photoelectrons in each pixel
+    geom:    CameraGeometry
+
+    Returns
+    ---------
+    muonringparam: ``
+    clean_mask:    `np.ndarray` mask after cleaning
+    dist:          `np.ndarray` distance of every pixel 
+                    to the center of the muon ring
+    image_clean:   `np.ndarray` image after cleaning
+    """
+
+    muonring = ChaudhuriKunduRingFitter(None)
+    clean_mask = tailcuts_clean(geom, image, picture_thresh=tailcuts[0],
+                                    boundary_thresh=tailcuts[1])
+    image_clean = image * clean_mask
+    muonringparam = muonring.fit(x, y, image_clean)
+
+    dist = np.sqrt(np.power(x - muonringparam.ring_center_x, 2)
+                       + np.power(y - muonringparam.ring_center_y, 2))
+    ring_dist = np.abs(dist - muonringparam.ring_radius)
+    muonringparam = muonring.fit(
+            x, y, image_clean * (ring_dist < muonringparam.ring_radius * 0.4)
+        )
+
+    dist = np.sqrt(np.power(x - muonringparam.ring_center_x, 2) +
+                       np.power(y - muonringparam.ring_center_y, 2))
+    ring_dist = np.abs(dist - muonringparam.ring_radius)
+
+    muonringparam = muonring.fit(
+            x, y, image_clean * (ring_dist < muonringparam.ring_radius * 0.4)
+        )
+    
+    return muonringparam, clean_mask, dist, image_clean
+
+def analyze_muon_event(event_id, image, geom, plot_ring):
+    """
+    Analyze an event to fit a muon ring
+
+    Paramenters
+    ---------
+    event_id:  `int` id of the analyzed event
+    image:     `np.ndarray` number of photoelectrons in each pixel
+    geom:      CameraGeometry
+    plot_ring: `bool` plot the muon ring
+
+    Returns
+    ---------
+    muonintensityoutput ``
+    muonringparam       ``
+    impact_condition    `bool` 
+
+    TODO: several hard-coded quantities that can go into a configuration file
+    """
+
+    tailcuts = [5, 10]
+
+    cam_rad = 2.26 * u.deg
+    min_pix = 148  # 8%
+
+    x, y = get_muon_center(geom)
+    muonringparam, clean_mask, dist, image = fit_muon(x, y, image[0], geom)
+
+    mir_rad = np.sqrt(teldes.optics.mirror_area.to("m2") / np.pi)
+    dist_mask = np.abs(dist - muonringparam.ring_radius
+                    ) < muonringparam.ring_radius * 0.4
+    pix_im = image[0] * dist_mask
+    nom_dist = np.sqrt(np.power(muonringparam.ring_center_x,2) 
+                    + np.power(muonringparam.ring_center_y, 2))
+
+    if(npix_above_threshold(pix_im, tailcuts[0]) > 0.1 * min_pix
+       and npix_composing_ring(pix_im) > min_pix
+       and nom_dist < cam_rad  
+       and muonringparam.ring_radius < 1.5 * u.deg
+       and muonringparam.ring_radius > 1. * u.deg):
+        muonringparam.ring_containment = ring_containment(
+            muonringparam.ring_radius,
+            cam_rad,
+            muonringparam.ring_center_x,
+            muonringparam.ring_center_y)
+
+
+    ctel = MuonLineIntegrate(
+                mir_rad, hole_radius = 0.308 * u.m,
+                pixel_width=0.1 * u.deg,
+                sct_flag=False,
+                secondary_radius = 0. * u.m
+            )
+
+    muonintensityoutput = ctel.fit_muon(muonringparam.ring_center_x,
+                                    muonringparam.ring_center_y,
+                                    muonringparam.ring_radius,
+                                    x[dist_mask], y[dist_mask],
+                                    image[0][dist_mask])
+    muonintensityoutput.mask = dist_mask
+    idx_ring = np.nonzero(pix_im)
+    muonintensityoutput.ring_completeness = ring_completeness(
+                    x[idx_ring], y[idx_ring], pix_im[idx_ring],
+                    muonringparam.ring_radius,
+                    muonringparam.ring_center_x,
+                    muonringparam.ring_center_y,
+                    threshold=30,
+                    bins=30)
+    muonintensityoutput.ring_size = np.sum(pix_im)
+    dist_ringwidth_mask = np.abs(dist - muonringparam.ring_radius
+                                             ) < (muonintensityoutput.ring_width)
+    pix_ringwidth_im = image[0] * dist_ringwidth_mask
+    idx_ringwidth = np.nonzero(pix_ringwidth_im)
+
+    muonintensityoutput.ring_pix_completeness = npix_above_threshold(
+                    pix_ringwidth_im[idx_ringwidth], tailcuts[0]) / len(
+                    pix_im[idx_ringwidth])
+
+    print("Impact parameter = %s"
+                             "ring_width=%s, ring radius=%s, ring completeness=%s"% (
+                             muonintensityoutput.impact_parameter,
+                             muonintensityoutput.ring_width,
+                             muonringparam.ring_radius,
+                             muonintensityoutput.ring_completeness))
+
+    conditions = [
+        muonintensityoutput.impact_parameter <
+        0.9 * mir_rad,  # 90% inside the mirror
+        
+        muonintensityoutput.impact_parameter >
+        0.2 * mir_rad  # 20% inside the mirror
+        
+        # TODO: To be applied when we have decent optics
+        # muonintensityoutput.ring_width
+        # < 0.08,
+        
+        # muonintensityoutput.ring_width
+        # > 0.04
+                ]
+
+    muonintensityparam = muonintensityoutput 
+    if all(conditions):
+        impact_condition = True
+    else:
+        impact_condition = False
+
+    if(plot_ring):
+        altaz = AltAz(alt = 70 * u.deg, az = 0 * u.deg)
+        flen = event.inst.subarray.tel[0].optics.equivalent_focal_length
+        ring_nominal = SkyCoord(
+                delta_az=muonringparam.ring_center_x,
+                delta_alt=muonringparam.ring_center_y,
+                frame=NominalFrame(origin=altaz)
+            )
+
+        ring_camcoord = ring_nominal.transform_to(CameraFrame(
+                focal_length=flen,
+                rotation=geom.pix_rotation,
+                telescope_pointing=altaz))
+        centroid = (ring_camcoord.x.value, ring_camcoord.y.value)
+        radius = muonringparam.ring_radius
+        width = muonintensityoutput.ring_width
+        ringrad_camcoord = 2 * radius.to(u.rad) * flen
+        ringwidthfrac = width / radius
+        ringrad_inner = ringrad_camcoord * (1. - ringwidthfrac)
+        ringrad_outer = ringrad_camcoord * (1. + ringwidthfrac)
+
+        fig, ax = plt.subplots(figsize=(10,10))
+        plot_event(ax, geom, image, centroid, ringrad_camcoord, ringrad_inner, ringrad_outer,
+                   event_id)
+
+        fig.savefig('figures/Event_{}_fitted.png'.format(event_id))
+
+
+    return muonintensityparam, muonringparam, impact_condition

--- a/lstchain/image/muon/muon_analysis.py
+++ b/lstchain/image/muon/muon_analysis.py
@@ -226,8 +226,8 @@ def analyze_muon_event(event_id, image, geom, plot_ring):
         ringrad_outer = ringrad_camcoord * (1. + ringwidthfrac)
 
         fig, ax = plt.subplots(figsize=(10,10))
-        plot_event(ax, geom, image, centroid, ringrad_camcoord, ringrad_inner, ringrad_outer,
-                   event_id)
+        plot_muon_event(ax, geom, image, centroid, ringrad_camcoord, 
+                        ringrad_inner, ringrad_outer, event_id)
 
         fig.savefig('figures/Event_{}_fitted.png'.format(event_id))
 

--- a/lstchain/image/muon/plot_muon.py
+++ b/lstchain/image/muon/plot_muon.py
@@ -1,0 +1,18 @@
+from ctapipe.visualization import CameraDisplay
+
+def plot_event(ax, geom, phe, centroid, ringrad_camcoord, ringrad_inner, ringrad_outer, event_id):
+    disp0 = CameraDisplay(geom, ax=ax)
+    disp0.image = phe[0]
+    disp0.cmap = 'viridis'
+    disp0.add_colorbar(ax=ax)
+    disp0.add_ellipse(centroid, ringrad_camcoord.value,
+                  ringrad_camcoord.value, 0., 0., color="red")
+    disp0.add_ellipse(centroid, ringrad_inner.value,
+                                    ringrad_inner.value, 0., 0.,
+                                    color="magenta")
+    disp0.add_ellipse(centroid, ringrad_outer.value,
+                                    ringrad_outer.value, 0., 0.,
+                                    color="magenta")
+    ax.set_title(f"Event {event_id}")
+
+    return ax

--- a/lstchain/image/muon/plot_muon.py
+++ b/lstchain/image/muon/plot_muon.py
@@ -1,8 +1,30 @@
 from ctapipe.visualization import CameraDisplay
 
-def plot_event(ax, geom, phe, centroid, ringrad_camcoord, ringrad_inner, ringrad_outer, event_id):
+__all__ = ['plot_muon_event',
+           ]
+
+def plot_muon_event(ax, geom, image, centroid, ringrad_camcoord, 
+                    ringrad_inner, ringrad_outer, event_id):
+    """
+    
+
+    Paramenters
+    ---------
+    ax:               `matplotlib.pyplot.axis`
+    geom:             CameraGeometry  
+    centroid:         `float` centroid of the muon ring
+    ringrad_camcoord: `float` ring radius in camera coordinates
+    ringrad_inner:    `float` inner ring radius in camera coordinates
+    ringrad_outer:    `float` outer ring radius in camera coordinates
+    event_id:         `int` id of the analyzed event
+
+    Returns
+    ---------
+    ax:               `matplotlib.pyplot.axis`
+    """
+
     disp0 = CameraDisplay(geom, ax=ax)
-    disp0.image = phe[0]
+    disp0.image = image[0]
     disp0.cmap = 'viridis'
     disp0.add_colorbar(ax=ax)
     disp0.add_ellipse(centroid, ringrad_camcoord.value,

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -18,7 +18,6 @@ from lstchain.calib.camera.r0 import LSTR0Corrections
 from lstchain.image.muon import analyze_muon_event
 
 from astropy.table import Table
-import matplotlib.pyplot as plt
 
 
 '''
@@ -33,22 +32,30 @@ python lstchain_data_muon_analysis.py --input_file LST-1.4.Run00442.0001.fits.fz
 parser = argparse.ArgumentParser()
 
 # Required arguments
-parser.add_argument("--input_file", help="Path to fits.fz data file.",
-                    type=str, default="")
+parser.add_argument("--input_file", help = "Path to fits.fz data file.",
+                    type = str, default = "")
 
-parser.add_argument("--output_file", help="Path to create the output fits table with muon parameters",
-                    type=str)
+parser.add_argument("--output_file", help = "Path to create the output fits table with muon parameters",
+                    type = str)
 
-parser.add_argument("--pedestal_file", help="Path to the pedestal file",
-                    type=str)
+parser.add_argument("--pedestal_file", help = "Path to the pedestal file",
+                    type = str)
 
-parser.add_argument("--calibration_file", help="Path to the file containing the calibration constants",
-                    type=str)
+parser.add_argument("--calibration_file", help = "Path to the file containing the calibration constants",
+                    type = str)
 
 # Optional argument
-parser.add_argument("--max_events", help="Maximum numbers of events to read."
+parser.add_argument("--max_events", help = "Maximum numbers of events to read."
                                          "Default = 100",
-                    type=int, default=100)
+                    type = int, default = 100)
+
+parser.add_argument("--plot_rings", help = "Plot figures of the stored rings", 
+                    default = False, action='store_true')
+
+parser.add_argument("--plots_path", help = "Path to the plots",
+                    default = None, type = str)
+
+
 
 args = parser.parse_args()
 
@@ -122,10 +129,9 @@ if __name__ == '__main__':
         if((np.size(image[0][image[0]>10.]) > 300) or (np.size(image[0][image[0]>10.]) < 50)):
             continue
 
-        plot_ring = False
-
         muonintensityparam, muonringparam, impact_condition = \
-            analyze_muon_event(event_id, image, geom, teldes, plot_ring)
+            analyze_muon_event(event_id, image, geom, teldes, 
+                               args.plot_rings, args.plots_path)
         #if not (impact_condition):
         #    continue
         print("Number of muons found, EventID", num_muons, event_id)

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -95,6 +95,7 @@ if __name__ == '__main__':
                          'size_outside': [],
                          'ring_radius': [],
                          'ring_width': [],
+                         'good_ring': [],
                          'muon_efficiency': [],
                          'ring_containment': [],
                          'ring_completeness': [],
@@ -102,7 +103,6 @@ if __name__ == '__main__':
                          'impact_parameter': [],
                          'impact_x_array': [],
                          'impact_y_array': [],
-                         'good_ring': [],
                          }
 
     num_muons = 0
@@ -140,6 +140,8 @@ if __name__ == '__main__':
         muonringparam.ring_radius.value)
         output_parameters['ring_width'].append(
         muonintensityparam.ring_width.value)
+        output_parameters['good_ring'].append(
+        good_ring)
         output_parameters['muon_efficiency'].append(
         muonintensityparam.optical_efficiency_muon)
         output_parameters['ring_containment'].append(
@@ -154,8 +156,6 @@ if __name__ == '__main__':
         muonintensityparam.impact_parameter_pos_x.value)
         output_parameters['impact_y_array'].append(
         muonintensityparam.impact_parameter_pos_y.value)
-        output_parameters['good_ring'].append(
-        good_ring)
 
     table = Table(output_parameters)
     if os.path.exists(args.output_file):

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -94,28 +94,28 @@ if __name__ == '__main__':
 
         num_muons = num_muons + 1
 
+        output_parameters['Event_id'].append(
+        event_id)
+        output_parameters['RingSize'].append(
+        muonintensityoutput.ring_size)
+        output_parameters['RingRadius'].append(
+        muonringparam.ring_radius.value)
         output_parameters['MuonEff'].append(
-        muonintensityparam.optical_efficiency_muon)
+        muonintensityoutput.optical_efficiency_muon)
         output_parameters['ImpactP'].append(
-        muonintensityparam.impact_parameter.value)
+        muonintensityoutput.impact_parameter.value)
         output_parameters['RingWidth'].append(
-        muonintensityparam.ring_width.value)
+        muonintensityoutput.ring_width.value)
         output_parameters['RingCont'].append(
         muonringparam.ring_containment)
         output_parameters['RingComp'].append(
-        muonintensityparam.ring_completeness)
+        muonintensityoutput.ring_completeness)
         output_parameters['RingPixComp'].append(
-        muonintensityparam.ring_pix_completeness)
+        muonintensityoutput.ring_pix_completeness)
         output_parameters['Impact_x_arr'].append(
-        muonintensityparam.impact_parameter_pos_x.value)
+        muonintensityoutput.impact_parameter_pos_x.value)
         output_parameters['Impact_y_arr'].append(
-        muonintensityparam.impact_parameter_pos_y.value)
-        output_parameters['RingSize'].append(
-        muonintensityparam.ring_size)
-        output_parameters['RingRadius'].append(
-        muonringparam.ring_radius.value)
-        output_parameters['Event_id'].append(
-        event_id)
+        muonintensityoutput.impact_parameter_pos_y.value)
 
     table = Table(output_parameters)
     outname = "./Data_table.fits"

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -1,0 +1,123 @@
+import sys, os
+import numpy as np
+from ctapipe.image.extractor import LocalPeakWindowSum
+from ctapipe.image.muon.features import ring_containment 
+from ctapipe.image.muon.features import ring_completeness
+from ctapipe.image.muon.features import npix_above_threshold
+from ctapipe.image.muon.features import npix_composing_ring
+from ctapipe.image.muon.muon_integrator import MuonLineIntegrate
+from ctapipe.image.cleaning import tailcuts_clean
+from ctapipe.instrument import CameraGeometry
+
+from ctapipe.io.hdf5tableio import HDF5TableReader
+from ctapipe.io.containers import FlatFieldContainer, WaveformCalibrationContainer, PedestalContainer
+from ctapipe.io import event_source
+from ctapipe.io import EventSeeker
+
+from lstchain.calib.camera.r0 import LSTR0Corrections
+from astropy.table import Table
+import matplotlib.pyplot as plt
+
+
+if __name__ == '__main__':
+    
+    if sys.argv[1:]:
+        run_name = sys.argv[1]
+        #max_events = sys.argv[2]
+        max_events = 10000
+    else:
+        run_name = "/fefs/onsite/data/20190527/LST-1.4.Run00442.0001.fits.fz"
+        max_events = None
+
+    r0calib = LSTR0Corrections(
+        #pedestal_path="Data/pedestal_run436.fits",
+        #pedestal_path="./Calibration/pedestal_file_run446_0000.fits",
+        pedestal_path="/Users/rlopezcoto/Desktop/Data_LST_local/20190604/Data/pedestal_file_run446_0000.fits",
+        r1_sample_start=2,r1_sample_end=38)
+
+
+    ff_data = FlatFieldContainer()
+    cal_data =  WaveformCalibrationContainer()
+    ped_data =  PedestalContainer()
+
+    dc_to_pe = []
+    ped_median = []
+
+    with HDF5TableReader('/Users/rlopezcoto/Desktop/Data_LST_local/20190604/Calibration/calibration.hdf5') as h5_table:
+        assert h5_table._h5file.isopen == True
+        for cont in h5_table.read('/tel_0/pedestal', ped_data):
+                ped_median = cont.charge_median
+                
+        for calib in h5_table.read('/tel_0/calibration', cal_data):
+                dc_to_pe = calib['dc_to_pe']
+    h5_table.close()
+
+    geom = CameraGeometry.from_name("LSTCam-002")
+    
+    source = event_source(input_url = run_name, max_events = None)
+    output_parameters = {'MuonEff': [],
+                         'ImpactP': [],
+                         'RingWidth': [],
+                         'RingCont': [],
+                         'RingComp': [],
+                         'RingPixComp': [],
+                         'Impact_x_arr': [],
+                         'Impact_y_arr': [],
+                         'RingSize': [],
+                         'RingRadius': [],
+                         'Event_id': []}
+
+    num_muons = 0
+    for event in source:
+
+        event_id = event.lst.tel[0].evt.event_id
+        teldes = event.inst.subarray.tel[0]
+        r0calib.calibrate(event)
+        pedcorrectedsamples = event.r1.tel[0].waveform
+        integrator = LocalPeakWindowSum(window_shift=4, window_width=9)
+        integration, pulse_time = integrator(pedcorrectedsamples)
+        image = (integration - ped_median)*dc_to_pe
+
+        print("Event {}. Number of pixels above 10 phe: {}".format(event_id,
+                                                                  np.size(image[0][image[0] > 10.])))
+        if((np.size(image[0][image[0]>10.]) > 300) or (np.size(image[0][image[0]>10.]) < 50)):
+            continue
+
+        plot_ring = False
+        muonintensityparam, muonringparam, impact_condition = \
+            analyze_muon_event(event_id, image, geom, plot_ring)
+
+        #if not (impact_condition):
+        #    continue
+        print("Number of muons found, EventID", num_muons, event_id)
+
+        num_muons = num_muons + 1
+
+        output_parameters['MuonEff'].append(
+        muonintensityparam.optical_efficiency_muon)
+        output_parameters['ImpactP'].append(
+        muonintensityparam.impact_parameter.value)
+        output_parameters['RingWidth'].append(
+        muonintensityparam.ring_width.value)
+        output_parameters['RingCont'].append(
+        muonringparam.ring_containment)
+        output_parameters['RingComp'].append(
+        muonintensityparam.ring_completeness)
+        output_parameters['RingPixComp'].append(
+        muonintensityparam.ring_pix_completeness)
+        output_parameters['Impact_x_arr'].append(
+        muonintensityparam.impact_parameter_pos_x.value)
+        output_parameters['Impact_y_arr'].append(
+        muonintensityparam.impact_parameter_pos_y.value)
+        output_parameters['RingSize'].append(
+        muonintensityparam.ring_size)
+        output_parameters['RingRadius'].append(
+        muonringparam.ring_radius.value)
+        output_parameters['Event_id'].append(
+        event_id)
+
+    table = Table(output_parameters)
+    outname = "./Data_table.fits"
+    if os.path.exists(outname):
+            os.remove(outname)
+    table.write(outname,format='fits')

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -93,7 +93,10 @@ if __name__ == '__main__':
     geom = CameraGeometry.from_name("LSTCam-002")
     
     source = event_source(input_url = args.input_file, max_events = args.max_events)
-    output_parameters = {'MuonEff': [],
+    output_parameters = {'Event_id': [],
+                         'RingSize': [],
+                         'RingRadius': [],
+                         'MuonEff': [],
                          'ImpactP': [],
                          'RingWidth': [],
                          'RingCont': [],
@@ -101,9 +104,7 @@ if __name__ == '__main__':
                          'RingPixComp': [],
                          'Impact_x_arr': [],
                          'Impact_y_arr': [],
-                         'RingSize': [],
-                         'RingRadius': [],
-                         'Event_id': []}
+                         }
 
     num_muons = 0
     for event in source:

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -89,7 +89,12 @@ if __name__ == '__main__':
 
     geom = CameraGeometry.from_name("LSTCam-002")
     
-    source = event_source(input_url = args.input_file, max_events = args.max_events)
+    if (args.max_events):
+        max_events = args.max_events
+    else:
+        max_events = None
+
+    source = event_source(input_url = args.input_file, max_events = max_events)
     output_parameters = {'event_id': [],
                          'ring_size': [],
                          'size_outside': [],

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -100,17 +100,19 @@ if __name__ == '__main__':
     geom = CameraGeometry.from_name("LSTCam-002")
     
     source = event_source(input_url = args.input_file, max_events = args.max_events)
-    output_parameters = {'Event_id': [],
-                         'RingSize': [],
-                         'RingRadius': [],
-                         'MuonEff': [],
-                         'ImpactP': [],
-                         'RingWidth': [],
-                         'RingCont': [],
-                         'RingComp': [],
-                         'RingPixComp': [],
-                         'Impact_x_arr': [],
-                         'Impact_y_arr': [],
+    output_parameters = {'event_id': [],
+                         'ring_size': [],
+                         'size_outside': [],
+                         'ring_radius': [],
+                         'ring_width': [],
+                         'muon_efficiency': [],
+                         'ring_containment': [],
+                         'ring_completeness': [],
+                         'ring_pixel_completeness': [],
+                         'impact_parameter': [],
+                         'impact_x_array': [],
+                         'impact_y_array': [],
+                         'good_ring': [],
                          }
 
     num_muons = 0
@@ -129,37 +131,41 @@ if __name__ == '__main__':
         if((np.size(image[0][image[0]>10.]) > 300) or (np.size(image[0][image[0]>10.]) < 50)):
             continue
 
-        muonintensityparam, muonringparam, impact_condition = \
+        muonintensityparam, size_outside_ring, muonringparam, good_ring = \
             analyze_muon_event(event_id, image, geom, teldes, 
                                args.plot_rings, args.plots_path)
-        #if not (impact_condition):
+        #if not (good_ring):
         #    continue
-        print("Number of muons found, EventID", num_muons, event_id)
+        print("Number of muons found {}, EventID {}".format(num_muons, event_id))
 
         num_muons = num_muons + 1
 
-        output_parameters['Event_id'].append(
+        output_parameters['event_id'].append(
         event_id)
-        output_parameters['RingSize'].append(
+        output_parameters['ring_size'].append(
         muonintensityparam.ring_size)
-        output_parameters['RingRadius'].append(
+        output_parameters['size_outside'].append(
+        size_outside_ring)
+        output_parameters['ring_radius'].append(
         muonringparam.ring_radius.value)
-        output_parameters['MuonEff'].append(
-        muonintensityparam.optical_efficiency_muon)
-        output_parameters['ImpactP'].append(
-        muonintensityparam.impact_parameter.value)
-        output_parameters['RingWidth'].append(
+        output_parameters['ring_width'].append(
         muonintensityparam.ring_width.value)
-        output_parameters['RingCont'].append(
+        output_parameters['muon_efficiency'].append(
+        muonintensityparam.optical_efficiency_muon)
+        output_parameters['ring_containment'].append(
         muonringparam.ring_containment)
-        output_parameters['RingComp'].append(
+        output_parameters['ring_completeness'].append(
         muonintensityparam.ring_completeness)
-        output_parameters['RingPixComp'].append(
+        output_parameters['ring_pixel_completeness'].append(
         muonintensityparam.ring_pix_completeness)
-        output_parameters['Impact_x_arr'].append(
+        output_parameters['impact_parameter'].append(
+        muonintensityparam.impact_parameter.value)
+        output_parameters['impact_x_array'].append(
         muonintensityparam.impact_parameter_pos_x.value)
-        output_parameters['Impact_y_arr'].append(
+        output_parameters['impact_y_array'].append(
         muonintensityparam.impact_parameter_pos_y.value)
+        output_parameters['good_ring'].append(
+        good_ring)
 
     table = Table(output_parameters)
     if os.path.exists(args.output_file):

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -66,19 +66,10 @@ if __name__ == '__main__':
     print("calibration file: {}".format(args.calibration_file))
     print("max events: {}".format(args.max_events))
     
-    #if sys.argv[1:]:
-    #    run_name = sys.argv[1]
-        #max_events = sys.argv[2]
-    #    max_events = 10000
-    #else:
-    #    run_name = "/fefs/onsite/data/20190527/LST-1.4.Run00442.0001.fits.fz"
-    #    max_events = None
 
     r0calib = LSTR0Corrections(
-        #pedestal_path="/Users/rlopezcoto/Desktop/Data_LST_local/20190604/Data/pedestal_file_run446_0000.fits",
         pedestal_path = args.pedestal_file,
         r1_sample_start=2,r1_sample_end=38)
-
 
     ff_data = FlatFieldContainer()
     cal_data =  WaveformCalibrationContainer()
@@ -87,7 +78,6 @@ if __name__ == '__main__':
     dc_to_pe = []
     ped_median = []
 
-    #with HDF5TableReader('/Users/rlopezcoto/Desktop/Data_LST_local/20190604/Calibration/calibration.hdf5') as h5_table:
     with HDF5TableReader(args.calibration_file) as h5_table:
         assert h5_table._h5file.isopen == True
         for cont in h5_table.read('/tel_0/pedestal', ped_data):

--- a/scripts/lstchain_data_muon_analysis.py
+++ b/scripts/lstchain_data_muon_analysis.py
@@ -8,13 +8,14 @@ from ctapipe.image.muon.features import npix_composing_ring
 from ctapipe.image.muon.muon_integrator import MuonLineIntegrate
 from ctapipe.image.cleaning import tailcuts_clean
 from ctapipe.instrument import CameraGeometry
-
 from ctapipe.io.hdf5tableio import HDF5TableReader
 from ctapipe.io.containers import FlatFieldContainer, WaveformCalibrationContainer, PedestalContainer
 from ctapipe.io import event_source
 from ctapipe.io import EventSeeker
 
 from lstchain.calib.camera.r0 import LSTR0Corrections
+from lstchain.image.muon import analyze_muon_event
+
 from astropy.table import Table
 import matplotlib.pyplot as plt
 
@@ -84,9 +85,9 @@ if __name__ == '__main__':
             continue
 
         plot_ring = False
-        muonintensityparam, muonringparam, impact_condition = \
-            analyze_muon_event(event_id, image, geom, plot_ring)
 
+        muonintensityparam, muonringparam, impact_condition = \
+            analyze_muon_event(event_id, image, geom, teldes, plot_ring)
         #if not (impact_condition):
         #    continue
         print("Number of muons found, EventID", num_muons, event_id)

--- a/scripts/lstchain_data_muon_analysis_dl1.py
+++ b/scripts/lstchain_data_muon_analysis_dl1.py
@@ -1,0 +1,132 @@
+import argparse
+import sys, os
+import numpy as np
+from ctapipe.image.muon.features import ring_containment 
+from ctapipe.image.muon.features import ring_completeness
+from ctapipe.image.muon.features import npix_above_threshold
+from ctapipe.image.muon.features import npix_composing_ring
+from ctapipe.image.muon.muon_integrator import MuonLineIntegrate
+from ctapipe.image.cleaning import tailcuts_clean
+from ctapipe.instrument import CameraGeometry
+from ctapipe.io.hdf5tableio import HDF5TableReader
+from astropy import units as u
+
+from lstchain.image.muon import analyze_muon_event
+from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key
+
+from astropy.table import Table
+import pandas as pd
+import tables
+
+'''
+Script to perform the analysis of muon events.
+To run it, type:
+
+python lstchain_data_muon_analysis_dl1.py 
+--input_file dl1_Run01566_0322.h5 
+--output_file Data_table.fits 
+'''
+
+parser = argparse.ArgumentParser()
+
+# Required arguments
+parser.add_argument("--input_file", help = "Path to fits.fz data file.",
+                    type = str, default = "")
+
+parser.add_argument("--output_file", help = "Path to create the output fits table with muon parameters",
+                    type = str)
+
+# Optional argument
+parser.add_argument("--plot_rings", help = "Plot figures of the stored rings", 
+                    default = False, action='store_true')
+
+parser.add_argument("--plots_path", help = "Path to the plots",
+                    default = None, type = str)
+
+args = parser.parse_args()
+
+if __name__ == '__main__':
+    print("input file: {}".format(args.input_file))
+    print("output file: {}".format(args.output_file))
+
+    # Camera geometry
+    geom = CameraGeometry.from_name("LSTCam-002")
+
+    # Definition of the output parameters for the table
+    output_parameters = {'event_id': [],
+                         'ring_size': [],
+                         'size_outside': [],
+                         'ring_radius': [],
+                         'ring_width': [],
+                         'good_ring': [],
+                         'muon_efficiency': [],
+                         'ring_containment': [],
+                         'ring_completeness': [],
+                         'ring_pixel_completeness': [],
+                         'impact_parameter': [],
+                         'impact_x_array': [],
+                         'impact_y_array': [],
+                         }
+    
+    # image = pd.read_hdf(args.input_file, key = dl1_image_lstcam_key)
+    # For some reason the call above is not working, this is a fix using
+    # tables for the time being
+    file = tables.open_file(args.input_file).root 
+    group = file.dl1.event.telescope.image.LST_LSTCam  
+    images = [x['image'] for x in group.iterrows()]
+    
+    parameters = pd.read_hdf(args.input_file, key = dl1_params_lstcam_key)
+    telescope_description = pd.read_hdf(args.input_file, 
+                                        key='instrument/telescope/optics')
+    equivalent_focal_length = telescope_description['equivalent_focal_length'].values * u.m
+    mirror_area = telescope_description['mirror_area'].values * pow(u.m,2)
+
+    # File open
+    num_muons = 0
+    for image, event_id in zip(images, parameters['event_id']):
+
+        print("Event {}. Number of pixels above 10 phe: {}".format(event_id,
+                                                                  np.size(image[0][image[0] > 10.])))
+        if((np.size(image[0][image[0]>10.]) > 300) or (np.size(image[0][image[0]>10.]) < 50)):
+            continue
+
+        muonintensityparam, size_outside_ring, muonringparam, good_ring = \
+            analyze_muon_event(event_id, image, geom, equivalent_focal_length, 
+                               mirror_area, args.plot_rings, args.plots_path)
+        #if not (good_ring):
+        #    continue
+        print("Number of muons found {}, EventID {}".format(num_muons, event_id))
+
+        num_muons = num_muons + 1
+
+        output_parameters['event_id'].append(
+        event_id)
+        output_parameters['ring_size'].append(
+        muonintensityparam.ring_size)
+        output_parameters['size_outside'].append(
+        size_outside_ring)
+        output_parameters['ring_radius'].append(
+        muonringparam.ring_radius.value)
+        output_parameters['ring_width'].append(
+        muonintensityparam.ring_width.value)
+        output_parameters['good_ring'].append(
+        good_ring)
+        output_parameters['muon_efficiency'].append(
+        muonintensityparam.optical_efficiency_muon)
+        output_parameters['ring_containment'].append(
+        muonringparam.ring_containment)
+        output_parameters['ring_completeness'].append(
+        muonintensityparam.ring_completeness)
+        output_parameters['ring_pixel_completeness'].append(
+        muonintensityparam.ring_pix_completeness)
+        output_parameters['impact_parameter'].append(
+        muonintensityparam.impact_parameter.value)
+        output_parameters['impact_x_array'].append(
+        muonintensityparam.impact_parameter_pos_x.value)
+        output_parameters['impact_y_array'].append(
+        muonintensityparam.impact_parameter_pos_y.value)
+
+    table = Table(output_parameters)
+    if os.path.exists(args.output_file):
+            os.remove(args.output_file)
+    table.write(args.output_file, format='fits')

--- a/scripts/lstchain_data_muon_analysis_dl1.py
+++ b/scripts/lstchain_data_muon_analysis_dl1.py
@@ -30,7 +30,7 @@ python lstchain_data_muon_analysis_dl1.py
 parser = argparse.ArgumentParser()
 
 # Required arguments
-parser.add_argument("--input_file", help = "Path to fits.fz data file.",
+parser.add_argument("--input_file", help = "Path to DL1a data file (containing charge information).",
                     type = str, default = "")
 
 parser.add_argument("--output_file", help = "Path to create the output fits table with muon parameters",


### PR DESCRIPTION
In this PR there is the script for muon real analysis following some of the discussions in #196 and the suggestions by @vuillaut.
- It contains everything related to the muon analysis, the stored quantities needed for the analysis and a tag for good or bad rings to be used in the analysis.
- It also contains an additional quantity that is the size outside of the ring, suggested by @moralejo to find muons with the image of a hadron together.
- Right now a non-optimized muon tagging is used, but @pillera will work on the first of the bulletpoints discussed [here](https://github.com/cta-observatory/cta-lstchain/pull/196#issuecomment-550236451) to have some functions for the muon tagging.

Some of the functions of this PR are copied from [the muon analysis of ctapipe](https://github.com/cta-observatory/ctapipe/tree/master/ctapipe/image/muon). The code there is under discussion and [will be refactored](https://github.com/cta-observatory/ctapipe/pull/1154#issuecomment-548713583) at some point, but we need this now, so we will work on merging it with the general code later.