### PR TITLE
Calibration onsite scripts

### DIFF
--- a/lstchain/visualization/plot_calib.py
+++ b/lstchain/visualization/plot_calib.py
@@ -1,0 +1,339 @@
+
+from matplotlib import pyplot as plt
+from ctapipe.visualization import CameraDisplay
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from ctapipe.instrument import  CameraGeometry
+
+# read back the monitoring containers written with the tool calc_camera_calibration.py
+from ctapipe.io.containers import FlatFieldContainer, WaveformCalibrationContainer, PedestalContainer, \
+    PixelStatusContainer
+
+from ctapipe.io.hdf5tableio import HDF5TableReader
+
+__all__ = ['read_file',
+           'plot_all'
+           ]
+
+ff_data = FlatFieldContainer()
+ped_data = PedestalContainer()
+calib_data = WaveformCalibrationContainer()
+status_data = PixelStatusContainer()
+
+channel = ['HG', 'LG']
+
+plot_dir = "none"
+
+
+def read_file(file_name, tel_id=1):
+    """
+     read camera calibration quantities
+
+     Parameters
+     ----------
+     file_name:   calibration hdf5 file
+
+     tel_id:      telescope id
+     """
+    with HDF5TableReader(file_name) as h5_table:
+        assert h5_table._h5file.isopen==True
+
+        table = f"/tel_{tel_id}/flatfield"
+        next(h5_table.read(table, ff_data))
+        table = f"/tel_{tel_id}/calibration"
+        next(h5_table.read(table, calib_data))
+        table = f"/tel_{tel_id}/pedestal"
+        next(h5_table.read(table, ped_data))
+        table = f"/tel_{tel_id}/pixel_status"
+        next(h5_table.read(table, status_data))
+
+    h5_table.close()
+
+
+def plot_all(ped_data, ff_data, calib_data, run=0, plot_file="none"):
+    """
+     plot camera calibration quantities
+
+     Parameters
+     ----------
+     ped_data:   pedestal container PedestalContainer()
+
+     ff_data:    flat-field container FlatFieldContainer()
+
+     calib_data: calibration container WaveformCalibrationContainer()
+
+     """
+    camera = CameraGeometry.from_name("LSTCam", 2)
+
+    # plot open pdf
+    if plot_file != "none":
+        pp = PdfPages(plot_file)
+
+    plt.rc('font', size=15)
+    lposx=2.25
+
+    ### first figure
+    fig = plt.figure(1, figsize=(12, 24))
+    plt.tight_layout()
+    fig.suptitle(f"Run {run}", fontsize=25)
+    pad = 420
+    image = ff_data.charge_median
+    mask = ff_data.charge_median_outliers
+    for chan in (np.arange(2)):
+        pad += 1
+        plt.subplot(pad)
+        plt.tight_layout()
+        disp = CameraDisplay(camera)
+        mymin = np.median(image[chan]) - 2 * np.std(image[chan])
+        mymax = np.median(image[chan]) + 2 * np.std(image[chan])
+        disp.set_limits_minmax(mymin, mymax)
+        disp.highlight_pixels(mask[chan], linewidth=2)
+        disp.image = image[chan]
+        disp.cmap = plt.cm.coolwarm
+        #disp.axes.text(lposx, 0, f'{channel[chan]} signal charge (ADC)', rotation=90)
+        plt.title(f'{channel[chan]} signal charge [ADC]')
+        disp.add_colorbar()
+
+    image = ff_data.charge_std
+    mask = ff_data.charge_std_outliers
+    for chan in (np.arange(2)):
+        pad += 1
+        plt.subplot(pad)
+        plt.tight_layout()
+        disp = CameraDisplay(camera)
+        mymin = np.median(image[chan]) - 2 * np.std(image[chan])
+        mymax = np.median(image[chan]) + 2 * np.std(image[chan])
+        disp.set_limits_minmax(mymin, mymax)
+        disp.highlight_pixels(mask[chan], linewidth=2)
+        disp.image = image[chan]
+        disp.cmap = plt.cm.coolwarm
+        #disp.axes.text(lposx, 0, f'{channel[chan]} signal std [ADC]', rotation=90)
+        plt.title(f'{channel[chan]} signal std [ADC]')
+        disp.add_colorbar()
+
+    image = ped_data.charge_median
+    mask = ped_data.charge_median_outliers
+    for chan in (np.arange(2)):
+        pad += 1
+        plt.subplot(pad)
+        plt.tight_layout()
+        disp = CameraDisplay(camera)
+        mymin = np.median(image[chan]) - 2 * np.std(image[chan])
+        mymax = np.median(image[chan]) + 2 * np.std(image[chan])
+        disp.set_limits_minmax(mymin, mymax)
+        disp.highlight_pixels(mask[chan], linewidth=2)
+        disp.image = image[chan]
+        disp.cmap = plt.cm.coolwarm
+        #disp.axes.text(lposx, 0, f'{channel[chan]} pedestal [ADC]', rotation=90)
+        plt.title(f'{channel[chan]} pedestal [ADC]')
+        disp.add_colorbar()
+
+    image = ped_data.charge_std
+    mask =  ped_data.charge_std_outliers
+    for chan in (np.arange(2)):
+        pad += 1
+        plt.subplot(pad)
+        plt.tight_layout()
+        disp = CameraDisplay(camera)
+        mymin = np.median(image[chan]) - 2 * np.std(image[chan])
+        mymax = np.median(image[chan]) + 2 * np.std(image[chan])
+        disp.set_limits_minmax(mymin, mymax)
+        disp.highlight_pixels(mask[chan], linewidth=2)
+        disp.image = image[chan]
+        disp.cmap = plt.cm.coolwarm
+        #disp.axes.text(lposx, 0, f'{channel[chan]} pedestal std [ADC]', rotation=90)
+        plt.title(f'{channel[chan]} pedestal std [ADC]')
+        disp.add_colorbar()
+
+    plt.subplots_adjust(top=0.92)
+
+    if plot_file != "none":
+        pp.savefig()
+
+    ### second figure
+    fig = plt.figure(2, figsize=(12, 24))
+    plt.tight_layout()
+    fig.suptitle(f"Run {run}", fontsize=25)
+    pad=420
+
+    # time
+    image = ff_data.time_median
+    mask = ff_data.time_median_outliers
+    for chan in (np.arange(2)):
+        pad += 1
+        plt.subplot(pad)
+        plt.tight_layout()
+        disp = CameraDisplay(camera)
+        disp.highlight_pixels(mask[chan], linewidth=2)
+        disp.image = image[chan]
+        disp.cmap = plt.cm.coolwarm
+        #disp.axes.text(lposx, 0, f'{channel[chan]} time', rotation=90)
+        plt.title(f'{channel[chan]} time')
+        disp.add_colorbar()
+
+    image = ff_data.relative_gain_median
+    mask = calib_data.unusable_pixels
+    for chan in (np.arange(2)):
+        pad += 1
+        plt.subplot(pad)
+        plt.tight_layout()
+        disp = CameraDisplay(camera)
+        disp.highlight_pixels(mask[chan], linewidth=2)
+        mymin = np.median(image[chan]) - 2 * np.std(image[chan])
+        mymax = np.median(image[chan]) + 2 * np.std(image[chan])
+        disp.set_limits_minmax(mymin, mymax)
+        disp.image = image[chan]
+        disp.cmap = plt.cm.coolwarm
+        disp.set_limits_minmax(0.7, 1.3)
+        plt.title(f'{channel[chan]} relative gain')
+        #disp.axes.text(lposx, 0, f'{channel[chan]} relative gain', rotation=90)
+        disp.add_colorbar()
+
+    # pe
+    image = calib_data.n_pe
+    mask = calib_data.unusable_pixels
+    image = np.where(np.isnan(image), 0, image)
+    for chan in (np.arange(2)):
+        pad += 1
+        plt.subplot(pad)
+        plt.tight_layout()
+        disp = CameraDisplay(camera)
+        disp.highlight_pixels(mask[chan], linewidth=2)
+        disp.image = image[chan]
+        mymin= np.median(image[chan])- 2*np.std(image[chan])
+        mymax= np.median(image[chan])+ 2*np.std(image[chan])
+        disp.set_limits_minmax(mymin, mymax)
+        disp.cmap = plt.cm.coolwarm
+        plt.title(f'{channel[chan]} photon-electrons')
+        #disp.axes.text(lposx, 0, f'{channel[chan]} photon-electrons', rotation=90)
+        disp.add_colorbar()
+
+    # pe histogram
+    pad += 1
+    plt.subplot(pad)
+    plt.tight_layout()
+    for chan in np.arange(2):
+        n_pe = calib_data.n_pe[chan]
+        # select good pixels
+        select = np.logical_not(mask[chan])
+        median = int(np.median(n_pe[select]))
+        rms = np.std(n_pe[select])
+
+        label = f"{channel[chan]} Median {median:3.2f}, std {rms:5.2f}"
+        plt.hist(n_pe[select], label=label, histtype='step', range=(50, 110), bins=50, stacked=True, alpha=0.5,
+                 fill=True)
+        plt.legend()
+    plt.xlabel(f'pe', fontsize=20)
+    plt.ylabel('pixels', fontsize=20)
+
+    # pe scatter plot
+    pad += 1
+    plt.subplot(pad)
+    plt.tight_layout()
+    HG = calib_data.n_pe[0]
+    LG = calib_data.n_pe[1]
+    HG = np.where(np.isnan(HG), 0, HG)
+    LG = np.where(np.isnan(LG), 0, LG)
+    mymin = np.median(LG) - 2 * np.std(LG)
+    mymax = np.median(LG) + 2 * np.std(LG)
+    plt.hist2d(LG, HG, bins=[100, 100])
+    plt.xlabel("LG", fontsize=20)
+    plt.ylabel("HG", fontsize=20)
+
+    x = np.arange(mymin,mymax)
+    plt.plot(x, x)
+    plt.ylim(mymin, mymax)
+    plt.xlim(mymin, mymax)
+    plt.subplots_adjust(top=0.92)
+    if plot_file != "none":
+        pp.savefig()
+
+
+    ### figures 3 and 4 : histograms
+    for chan in np.arange(2):
+        n_pe = calib_data.n_pe[chan]
+
+        gain_median = ff_data.relative_gain_median[chan]
+        #charge_median = ff_data.charge_median[chan]
+        charge_mean = ff_data.charge_mean[chan]
+        charge_std = ff_data.charge_std[chan]
+        #median_ped = ped_data.charge_median[chan]
+        mean_ped = ped_data.charge_mean[chan]
+        ped_std = ped_data.charge_std[chan]
+
+        # select good pixels
+        select = np.logical_not(mask[chan])
+        fig = plt.figure(chan+10, figsize=(12, 18))
+        fig.tight_layout(rect=[0, 0.03, 1, 0.95])
+
+        fig.suptitle(f"Run {run} channel: {channel[chan]}", fontsize=25)
+
+        # charge
+        plt.subplot(321)
+        plt.tight_layout()
+        median = int(np.median(charge_mean[select]))
+        rms = np.std(charge_mean[select])
+        label=f"Median {median:3.2f}, std {rms:5.0f}"
+        plt.xlabel('charge (ADC)', fontsize=20)
+        plt.ylabel('pixels', fontsize=20)
+        plt.hist(charge_mean[select], bins=50,label=label)
+        plt.legend()
+
+        plt.subplot(322)
+        plt.tight_layout()
+        plt.ylabel('pixels', fontsize=20)
+        plt.xlabel('charge std', fontsize=20)
+        median = np.median(charge_std[select])
+        rms = np.std(charge_std[select])
+        label=f"Median {median:3.2f}, std {rms:3.2f}"
+        plt.hist(charge_std[select], bins=50,label=label)
+        plt.legend()
+
+        # pedestal charge
+        plt.subplot(323)
+        plt.tight_layout()
+        plt.ylabel('pixels', fontsize=20)
+        plt.xlabel('pedestal', fontsize=20)
+        median = np.median(mean_ped[select])
+        rms = np.std(mean_ped[select])
+        label=f"Median {median:3.2f}, std {rms:3.2f}"
+        plt.hist(mean_ped[select], bins=50,label=label)
+        plt.legend()
+
+        # pedestal std
+        plt.subplot(324)
+        plt.ylabel('pixels', fontsize=20)
+        plt.xlabel('pedestal std', fontsize=20)
+        median = np.median(ped_std[select])
+        rms = np.std(ped_std[select])
+        label=f"Median {median:3.2f}, std {rms:3.2f}"
+        plt.hist(ped_std[select], bins=50,label=label)
+        plt.legend()
+
+        # relative gain
+        plt.subplot(325)
+        plt.tight_layout()
+        plt.ylabel('pixels', fontsize=20)
+        plt.xlabel('relative gain', fontsize=20)
+        median = np.median(gain_median[select])
+        rms = np.std(gain_median[select])
+        label=f"Relative gain {median:3.2f}, std {rms:5.2f}"
+        plt.hist(gain_median[select], bins=50,label=label)
+        plt.legend()
+
+        # photon electrons
+        plt.subplot(326)
+        plt.tight_layout()
+        plt.ylabel('pixels', fontsize=20)
+        plt.xlabel('pe', fontsize=20)
+        median = np.median(n_pe[select])
+        rms = np.std(n_pe[select])
+        label=f"Median {median:3.2f}, std {rms:3.2f}"
+        plt.hist(n_pe[select], bins=50,label=label)
+        plt.legend()
+        plt.subplots_adjust(top=0.92)
+        if plot_file != "none":
+            pp.savefig(plt.gcf())
+
+    if plot_file != "none":
+        pp.close()

--- a/scripts/lstchain_data_create_pedestal_file.py
+++ b/scripts/lstchain_data_create_pedestal_file.py
@@ -2,7 +2,8 @@ import argparse
 import numpy as np
 from astropy.io import fits
 from numba import prange
-from ctapipe_io_lst import LSTEventSource
+
+from ctapipe.io import event_source
 from ctapipe.io import EventSeeker
 from distutils.util import strtobool
 from traitlets.config.loader import Config
@@ -39,11 +40,12 @@ parser.add_argument('--deltaT', '-s', type=lambda x: bool(strtobool(x)),
 
 args = parser.parse_args()
 
-if __name__ == '__main__':
-    print("input file: {}".format(args.input_file))
-    print("max events: {}".format(args.max_events))
-    reader = LSTEventSource(input_url=args.input_file, max_events=args.max_events)
-    print("---> Number of files", reader.multi_file.num_inputs())
+
+def main():
+    print("--> Input file: {}".format(args.input_file))
+    print("--> Number of events: {}".format(args.max_events))
+    reader = event_source(input_url=args.input_file, max_events=args.max_events)
+    print("--> Number of files", reader.multi_file.num_inputs())
 
     seeker = EventSeeker(reader)
     ev = seeker[0]
@@ -83,3 +85,8 @@ if __name__ == '__main__':
 
     hdulist = fits.HDUList([primaryhdu, secondhdu])
     hdulist.writeto(args.output_file)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/onsite/onsite_create_calibration_file.py
+++ b/scripts/onsite/onsite_create_calibration_file.py
@@ -1,0 +1,109 @@
+#!/usr//bin/env python
+
+"""
+ F. Cassol, 12/11/2019
+
+ Onsite script for creating a flat-field calibration file file to be run as a command line:
+
+ --> onsite_create_calibration_file
+
+"""
+
+import argparse
+from traitlets.config.loader import Config
+from pathlib import Path
+
+from lstchain.io.data_management import *
+import lstchain.visualization.plot_calib as calib
+
+# to be changed with the right one
+base_dir = '/ctadata/franca/fefs/aswg/real'
+
+# parse arguments
+parser = argparse.ArgumentParser(description='Create flat-field calibration files',
+                                 formatter_class = argparse.ArgumentDefaultsHelpFormatter)
+required = parser.add_argument_group('required arguments')
+optional = parser.add_argument_group('optional arguments')
+
+required.add_argument('-r', '--run_number', help="Run number if the flat-field data",
+                      type=int, required=True)
+required.add_argument('-p', '--pedestal_run', help="Run number of the drs4 pedestal run",
+                      type=int, required=True)
+
+optional.add_argument('-v', '--version', help="Version of the production",
+                      type=int, default=0)
+optional.add_argument('-s', '--statistics', help="Number of events for the flat-field and pedestal statistics",
+                      type=int, default=10000)
+
+args = parser.parse_args()
+run = args.run_number
+ped_run = args.pedestal_run
+prod_id = 'v%02d'%args.version
+stat_events = args.statistics
+max_events = 1000000
+
+
+def main():
+
+    print(f"\n--> Start calculating calibration from run {run}")
+
+    try:
+        # verify input file
+        file_list=sorted(Path(f"{base_dir}/R0").rglob(f'*{run}.0000*'))
+        if len(file_list) == 0:
+            print(f">>> Error: Run {run} not found\n")
+            raise NameError()
+        else:
+            input_file = file_list[0]
+
+        # find date
+        input_dir, name = os.path.split(os.path.abspath(input_file))
+        path, date = input_dir.rsplit('/', 1)
+
+        # verify output dir
+        output_dir = f"{base_dir}/calibration/{date}/{prod_id}"
+        if not os.path.exists(output_dir):
+            print(f">>> Error: The output directory {output_dir} do not exist")
+            print(f">>>        You must create the drs4 pedestal file to create it.\n Exit")
+            exit(0)
+
+        # search the pedestal calibration file
+        pedestal_file = f"{output_dir}/drs4_pedestal.Run{ped_run}.0000.fits"
+        if not os.path.exists(pedestal_file):
+            print(f">>> Error: The pedestal file {pedestal_file} do not exist.\n Exit")
+            exit(0)
+
+        # define output and log file
+        output_file = f"{output_dir}/calibration.Run{run}.0000.hdf5"
+        log_file = f"{output_dir}/log/calibration.Run{run}.0000.log"
+        print(f"\n--> Output file {output_file}")
+        print(f"\n--> Log file {output_file}")
+
+        # define config file
+        config_file = os.path.join(os.path.dirname(__file__), "../data/onsite_camera_calibration_param.json")
+        print(f"\n--> Config file {config_file}")
+
+        # run lstchain script
+        cmd = f"calc_camera_calibration " \
+              f"--input_file={input_file} --output_file={output_file} --pedestal_file={pedestal_file} " \
+              f"--FlatFieldCalculator.sample_size={stat_events} --PedestalCalculator.sample_size={stat_events}  " \
+              f"--EventSource.max_events={max_events} --config={config_file}  >  {log_file} 2>&1"
+        #print(cmd)
+        print("\n--> RUNNING...")
+
+        os.system(cmd)
+
+        # plot and save some results
+        plot_file=f"{output_dir}/log/calibration.Run{run}.0000.pdf"
+        print(f"\n--> PRODUCING PLOTS in {plot_file} ...")
+        calib.read_file(output_file)
+        calib.plot_all(calib.ped_data, calib.ff_data, calib.calib_data, run, plot_file)
+        print("\n--> END")
+
+    except Exception as e:
+        print(f"\n >>> Exception: {e}")
+
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/onsite/onsite_create_drs4_pedestal_file.py
+++ b/scripts/onsite/onsite_create_drs4_pedestal_file.py
@@ -1,0 +1,80 @@
+#!/usr//bin/env python
+
+"""
+ F. Cassol, 12/11/2019
+
+ Onsite script for creating drs4 pedestal file to be run as a command line:
+
+ --> onsite_create_calibration_file -h
+
+"""
+
+import argparse
+
+from lstchain.io.data_management import *
+from pathlib import Path
+
+
+# to be changed with the right one
+base_dir = '/ctadata/franca/fefs/aswg/real'
+
+# parse arguments
+parser = argparse.ArgumentParser(description='Create DRS4 pedestal file',
+                                 formatter_class = argparse.ArgumentDefaultsHelpFormatter)
+required = parser.add_argument_group('required arguments')
+optional = parser.add_argument_group('optional arguments')
+
+required.add_argument('-r', '--run_number', help="Run number with drs4 pedestals",
+                      type=int, required=True)
+optional.add_argument('-v', '--prod_version', help="Version of the production",
+                      type=int, default=0)
+optional.add_argument('-m', '--max_events', help="Number of events to be processed",
+                      type=int, default=5000)
+
+args = parser.parse_args()
+run = args.run_number
+prod_id = 'v%02d'%args.version
+max_events = args.max_events
+
+
+def main():
+    print(f"\n--> Start calculating DRS4 pedestals from run {run}\n")
+
+    try:
+        # verify input file
+        file_list=sorted(Path(f"{base_dir}/R0").rglob(f'*{run}.0000*'))
+        if len(file_list) == 0:
+            print(f">>> Error: Run {run} not found\n")
+            raise NameError()
+        else:
+            input_file = file_list[0]
+
+        # find date
+        input_dir, name = os.path.split(os.path.abspath(input_file))
+        path, date = input_dir.rsplit('/', 1)
+
+        # verify and make output dir
+        output_dir = f"{base_dir}/calibration/{date}/{prod_id}"
+        check_and_make_dir(output_dir)
+
+        # make log dir
+        log_dir = f"{output_dir}/log"
+        check_and_make_dir(log_dir)
+
+        # define output file
+        output_file = f"{output_dir}/drs4_pedestal.Run{run}.0000.fits"
+        print(f"--> Output file {output_file}")
+
+        # run lstchain script
+        cmd = f"lstchain_data_create_pedestal_file --input_file {input_file} " \
+              f"--output_file {output_file} --max_events {max_events}"
+        os.system(cmd)
+
+        print("\n--> END")
+
+    except Exception as e:
+        print(f"\n >>> Exception: {e}")
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,14 @@ def list_scripts():
     script_list = [f'{os.path.join(script_dir, f)}' for f in os.listdir(script_dir) if f.startswith('lstchain_')]
     return script_list
 
+entry_points = {}
+entry_points['console_scripts'] = [
+    'calc_camera_calibration = lstchain.tools.calc_camera_calibration:main',
+    'onsite_create_drs4_pedestal_file = scripts.onsite.onsite_create_drs4_pedestal_file:main',
+    'onsite_create_calibration_file = scripts.onsite.onsite_create_calibration_file:main',
+    'lstchain_data_create_pedestal_file = scripts.lstchain_data_create_pedestal_file:main'
+]
+
 
 setuptools.setup(name='lstchain',
                  version=lstchain.__version__,
@@ -26,5 +34,6 @@ setuptools.setup(name='lstchain',
                  url='https://github.com/cta-observatory/cta-lstchain',
                  long_description='',
                  classifiers=[],
+                 entry_points=entry_points,
                  scripts=list_scripts()
                  )


### PR DESCRIPTION
Hi @vuillaut, 

here a first version of the onsite calibration scripts for creating the drs4 calibration file and the flat-field calibration file in the onsite directory tree. 

In the case of the flat-field calibration, a pdf file with some plots is also created (in the log directory). I would like have something similar for the drs4 calibration.

You can test everything using run 1571 for the pedestals and run 1572 for the calibrations.
This is work on going, I will probably add some improvements in the next, but I would like to have your opinion with this preliminary version 
