### PR TITLE
Optimize pointing scripts

### DIFF
--- a/lstchain/pointing/pointings.py
+++ b/lstchain/pointing/pointings.py
@@ -52,7 +52,7 @@ class PointingPosition(Component):
         else:
             raise Exception("No drive report file found")
 
-    def cal_pointingposition(self, ev_time):
+    def cal_pointingposition(self, ev_time, drive_data):
         """
         Calculating pointing positions by interpolation
 
@@ -65,10 +65,9 @@ class PointingPosition(Component):
             a container filled with drive information
         """
         drive_container = LSTDriveContainer()
-        data = self._read_drive_report()
-        drive_container.time = data['time'].data
-        drive_container.azimuth_avg = data['azimuth_avg'].data
-        drive_container.altitude_avg = data['altitude_avg'].data
+        drive_container.time = drive_data['time'].data
+        drive_container.azimuth_avg = drive_data['azimuth_avg'].data
+        drive_container.altitude_avg = drive_data['altitude_avg'].data
 
         xp = drive_container.time
         lower_drive_time = xp[xp < ev_time].max()

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -199,6 +199,12 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
 
     dl1_container = DL1ParametersContainer()
 
+    if pointing_file_path:
+        # Open drive report
+        pointings = PointingPosition()
+        pointings.drive_path = pointing_file_path
+        drive_data = pointings._read_drive_report()
+
     extra_im = ExtraImageInfo()
     extra_im.prefix = ''  # get rid of the prefix
 
@@ -311,9 +317,7 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                         dl1_container.gps_time = gps_time
 
                         if pointing_file_path:
-                            pointings = PointingPosition()
-                            pointings.drive_path = pointing_file_path
-                            azimuth, altitude = pointings.cal_pointingposition(utc_time.unix)
+                            azimuth, altitude = pointings.cal_pointingposition(utc_time.unix, drive_data)
                             event.pointing[telescope_id].azimuth = azimuth
                             event.pointing[telescope_id].altitude = altitude
                             dl1_container.az_tel = azimuth


### PR DESCRIPTION
As @vuillaut reported in #231, the code related to the addition of pointing information to the data stream was terribly slowing down the performance. It was basically reading the drive report file for every event.

@labsaha and I modified the code in order for the drive file to be open only once at the beginning of the script and buffer it to be used later on.

@labsaha, @vuillaut and @rlopezcoto can you please take a look at the modifications?
