### PR TITLE
Fix pointing bug #235

### DIFF
--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -316,7 +316,7 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                         gps_time = utc_time.gps
                         dl1_container.gps_time = gps_time
 
-                        if pointing_file_path:
+                        if pointing_file_path and tai_time > 0:
                             azimuth, altitude = pointings.cal_pointingposition(utc_time.unix, drive_data)
                             event.pointing[telescope_id].azimuth = azimuth
                             event.pointing[telescope_id].altitude = altitude


### PR DESCRIPTION
Skip the addition of pointing interpolated values when the timestamp of a given event is not available.
The code now checks if the timestamp is > 0 first, meaning that these time values are correct (presence flag is OK)