### PR TITLE
Set the default timestamps in config file

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -94,7 +94,7 @@
   ],
 
   "allowed_tels": [1, 2, 3, 4],
-  "max_events": 10000,
+  "max_events": null,
   "custom_calibration": false,
   "write_pe_image": false,
   "image_extractor": "LocalPeakWindowSum",

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -94,7 +94,7 @@
   ],
 
   "allowed_tels": [1, 2, 3, 4],
-  "max_events": null,
+  "max_events": 10000,
   "custom_calibration": false,
   "write_pe_image": false,
   "image_extractor": "LocalPeakWindowSum",
@@ -106,5 +106,6 @@
   "LocalPeakWindowSum":{
      "window_shift": 4,
      "window_width":8
-    }
+    },
+  "timestamps_pointing":"ucts"
 }

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -334,8 +334,16 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                         dl1_container.ucts_time = ucts_time
                         dl1_container.dragon_time = dragon_time
 
-                        if pointing_file_path and dragon_time > 0:
-                            azimuth, altitude = pointings.cal_pointingposition(dragon_time, drive_data)
+                        # Select the timestamps to be used for pointing interpolation
+                        if config['timestamps_pointing'] == "ucts":
+                            event_timestamps = ucts_time
+                        elif config['timestamps_pointing'] == "dragon":
+                            event_timestamps = dragon_time
+                        elif config['timestamps_pointing'] == "tib":
+                            event_timestamps = tib_time
+
+                        if pointing_file_path and event_timestamps > 0:
+                            azimuth, altitude = pointings.cal_pointingposition(event_timestamps, drive_data)
                             event.pointing[telescope_id].azimuth = azimuth
                             event.pointing[telescope_id].altitude = altitude
                             dl1_container.az_tel = azimuth

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -341,6 +341,9 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                             event_timestamps = dragon_time
                         elif config['timestamps_pointing'] == "tib":
                             event_timestamps = tib_time
+                        else:
+                            raise ValueError("The timestamps_pointing option is not a valid one. \
+                                    Try ucts (default), dragon or tib.")
 
                         if pointing_file_path and event_timestamps > 0:
                             azimuth, altitude = pointings.cal_pointingposition(event_timestamps, drive_data)


### PR DESCRIPTION
In order to be able to use any of the three available timestamps for pointing interpolation, I propose these changes (suggested by @rlopezcoto). I do not know if the nomenclature is the most convenient or not.

 - Add the `timestamps_pointing` variable in the standard config file
 - Use the timestamps defined in the config file (either `ucts`, `dragon` or `tib`) for pointing interpolation instead of having one of them hardcoded.

In this way, it will be possible to analyze old data using the required timestamps without having to change the code each time.