### PR TITLE
Updating the scripts to adapt zenith from the drive log

### DIFF
--- a/lstchain/pointing/pointings.py
+++ b/lstchain/pointing/pointings.py
@@ -47,7 +47,7 @@ class PointingPosition(Component):
             # these information it self
                 data['col6'].name = 'time'
                 data['col8'].name = 'azimuth_avg'
-                data['col13'].name = 'altitude_avg'
+                data['col13'].name = 'zenith_avg'
                 return data
         else:
             raise Exception("No drive report file found")
@@ -67,7 +67,8 @@ class PointingPosition(Component):
         drive_container = LSTDriveContainer()
         drive_container.time = drive_data['time'].data
         drive_container.azimuth_avg = drive_data['azimuth_avg'].data
-        drive_container.altitude_avg = drive_data['altitude_avg'].data
+        drive_container.zenith_avg =  drive_data['zenith_avg'].data 
+      
 
         xp = drive_container.time
         lower_drive_time = xp[xp < ev_time].max()
@@ -78,11 +79,11 @@ class PointingPosition(Component):
 
         if len(run_times) > 1:
             run_azimuth = drive_container.azimuth_avg[time_in_window]
-            run_altitude = drive_container.altitude_avg[time_in_window]
+            run_zenith = drive_container.zenith_avg[time_in_window]
 
             ev_azimuth = np.interp(ev_time, run_times, run_azimuth)
-            ev_altitude = np.interp(ev_time, run_times, run_altitude)
-            return ev_azimuth, ev_altitude
+            ev_zenith = np.interp(ev_time, run_times, run_zenith)
+            return ev_azimuth, ev_zenith
         else:
             raise Exception("No drive time in the range of event times")
 

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -346,11 +346,11 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                                     Try ucts (default), dragon or tib.")
 
                         if pointing_file_path and event_timestamps > 0:
-                            azimuth, altitude = pointings.cal_pointingposition(event_timestamps, drive_data)
+                            azimuth, zenith = pointings.cal_pointingposition(event_timestamps, drive_data)
                             event.pointing[telescope_id].azimuth = azimuth
-                            event.pointing[telescope_id].altitude = altitude
+                            event.pointing[telescope_id].altitude = 90.0 - zenith
                             dl1_container.az_tel = azimuth
-                            dl1_container.alt_tel = altitude
+                            dl1_container.alt_tel = 90.0 - zenith
 
                     foclen = event.inst.subarray.tel[telescope_id].optics.equivalent_focal_length
                     width = np.rad2deg(np.arctan2(dl1_container.width, foclen))


### PR DESCRIPTION
Regarding the pointing information. This PR now considers "Elevation" as  "zenith" angle. Then we calculate Altitude  which is equal to `"90 - zenith"`
We could have changed everything in the `pointings.py` file and get the altitude from that one. However, I want to keep is explicit that we get `Azimuth` and `Zenith` from the drive report. Hence I changed also to `dl0_to_dl1` file