### PR TITLE
Update comment with current status of TS info

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -107,5 +107,5 @@
      "window_shift": 4,
      "window_width":8
     },
-  "timestamps_pointing":"gps"
+  "timestamps_pointing":"ucts"
 }

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -107,5 +107,5 @@
      "window_shift": 4,
      "window_width":8
     },
-  "timestamps_pointing":"ucts"
+  "timestamps_pointing":"gps"
 }

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -304,13 +304,15 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                     dl1_container.gps_time = event.trig.gps_time.value
 
                     if not is_simu:
-                        # GPS time is not available for the time being. Meanwhile,
-                        # timestamps can be extracted from the UCTS and alternatively
-                        # calculated from the TIB/Dragon modules counters + NTP time
-                        # corresponding to the start of the run. For the time being,
-                        # we will store the three of them in the dl1 files.
-                        # This will be deprecated and modified back to directly use
-                        # gps_time whenever the GPS starts working reliably.
+                        # GPS + WRS + UCTS is now working in its nominal configuration. 
+                        # These TS are stored into ucts_time container.
+                        # TS can be alternatively calculated from the TIB/Dragon 
+                        # modules counters + NTP time corresponding to the start 
+                        # of the run (just for cross-checks). For the time being,
+                        # the three TS will be stored in the DL1 files.
+                        # This will be deprecated and modified back to uniquely use
+                        # gps_time whenever the GPS + WRS + UCTS info reliably and stably
+                        # arrives at the EvB side.
 
                         # gps_time = event.r0.tel[telescope_id].trigger_time
 

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -304,13 +304,16 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                     dl1_container.gps_time = event.trig.gps_time.value
 
                     if not is_simu:
-                        # GPS time is not available for the time being. Meanwhile,
-                        # timestamps can be extracted from the UCTS and alternatively
-                        # calculated from the TIB/Dragon modules counters + NTP time
-                        # corresponding to the start of the run. For the time being,
-                        # we will store the three of them in the dl1 files.
-                        # This will be deprecated and modified back to directly use
-                        # gps_time whenever the GPS starts working reliably.
+                        # GPS + WRS + UCTS is now working in its nominal configuration,
+                        # providing timestamps with 50 ns accuracy. These TS are 
+                        # stored into ucts_time container.
+                        # TS can be alternatively calculated from the TIB/Dragon 
+                        # modules counters + NTP time corresponding to the start 
+                        # of the run (just for cross-checks). For the time being,
+                        # the three TS will be stored in the DL1 files.
+                        # This will be deprecated and modified back to uniquely use
+                        # gps_time whenever the GPS + WRS + UCTS info reliably and stably
+                        # arrives at the EvB side.
 
                         # gps_time = event.r0.tel[telescope_id].trigger_time
 

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -317,7 +317,7 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
 
                         # gps_time = event.r0.tel[telescope_id].trigger_time
 
-                        ucts_time = event.lst.tel[telescope_id].evt.ucts_timestamp * 1e-9 # nsecs
+                        gps_time = event.lst.tel[telescope_id].evt.ucts_timestamp * 1e-9 # nsecs
 
                         # Get counters from the central Dragon module
                         module_id = 82
@@ -332,21 +332,20 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                                 event.lst.tel[telescope_id].evt.tib_pps_counter +
                                 event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10**(-7))
 
-                        #dl1_container.gps_time = gps_time
+                        dl1_container.gps_time = gps_time
                         dl1_container.tib_time = tib_time
-                        dl1_container.ucts_time = ucts_time
                         dl1_container.dragon_time = dragon_time
 
                         # Select the timestamps to be used for pointing interpolation
-                        if config['timestamps_pointing'] == "ucts":
-                            event_timestamps = ucts_time
+                        if config['timestamps_pointing'] == "gps":
+                            event_timestamps = gps_time
                         elif config['timestamps_pointing'] == "dragon":
                             event_timestamps = dragon_time
                         elif config['timestamps_pointing'] == "tib":
                             event_timestamps = tib_time
                         else:
                             raise ValueError("The timestamps_pointing option is not a valid one. \
-                                    Try ucts (default), dragon or tib.")
+                                    Try gps (default), dragon or tib.")
 
                         if pointing_file_path and event_timestamps > 0:
                             azimuth, altitude = pointings.cal_pointingposition(event_timestamps, drive_data)


### PR DESCRIPTION
I updated the comment explaining the current status of time-stamp info in the code itself. Now, the GPS-WRS-UCTS system is providing timestamps with 50 ns accuracy which are still stored in the `ucts_time` container/variable instead of `gps_time`.

I did not change this and the other two TS (TIB and Dragon -based) are still being kept since UCTS TS info does not stably arrive at the data stream yet. Sometimes these TS are still missing.

@rlopezcoto, what do you think? Should we still keep the three TS or rename the `ucts_time` as `gps_time` already?