### PR TITLE
Add astropy units to pointing AltAz

### DIFF
--- a/lstchain/pointing/pointings.py
+++ b/lstchain/pointing/pointings.py
@@ -81,8 +81,8 @@ class PointingPosition(Component):
             run_azimuth = drive_container.azimuth_avg[time_in_window]
             run_altitude = drive_container.altitude_avg[time_in_window]
 
-            ev_azimuth = np.interp(ev_time, run_times, run_azimuth)
-            ev_altitude = np.interp(ev_time, run_times, run_altitude)
+            ev_azimuth = np.interp(ev_time, run_times, run_azimuth) * u.deg
+            ev_altitude = np.interp(ev_time, run_times, run_altitude) * u.deg
             return ev_azimuth, ev_altitude
         else:
             raise Exception("No drive time in the range of event times")

--- a/lstchain/pointing/pointings.py
+++ b/lstchain/pointing/pointings.py
@@ -4,6 +4,7 @@ from ctapipe.core import Component
 from ctapipe_io_lst.containers import LSTMonitoringContainer, LSTDriveContainer
 from ctapipe.core.traits import Unicode, Int
 from astropy.io import ascii
+from astropy import units as u
 
 
 __all__ = [


### PR DESCRIPTION
Solve #282 
I assigned astropy units to AltAz pointing coordinates.

I tested setting later on `dl1_container.az_tel = azimuth.to(u.rad).value` in lstchain/reco/dl0_to_dl1.py and lstchain/reco/dl1_to_dl2.py was working fine with no errors. In principle, since `dl1_container.az_tel` container (idem for alt_tel) has already the units defined, there is no need to change the latter part.

I could reconstruct the Alt Az properly with actual pointing coordinates.

![coordinates](https://user-images.githubusercontent.com/32680689/74459379-7d6df400-4e8b-11ea-87c1-b69c537d4ef5.png)


