### PR TITLE
alt_tel missing

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -18,6 +18,7 @@ from . import disp
 from ..io import standard_config, replace_config
 import astropy.units as u
 from ..io.io import dl1_params_lstcam_key
+from ctapipe.instrument import OpticsDescription
 
 __all__ = [
     'train_energy',
@@ -383,18 +384,21 @@ def apply_models(dl1, classifier, reg_energy, reg_disp_vector, custom_config={})
     #Construction of Source position in camera coordinates from disp_norm distance.
 
     dl2['reco_src_x'], dl2['reco_src_y'] = disp.disp_to_pos(dl2.reco_disp_dx,
-                                                             dl2.reco_disp_dy,
-                                                             dl2.x,
-                                                             dl2.y,
-                                                             )
+                                                            dl2.reco_disp_dy,
+                                                            dl2.x,
+                                                            dl2.y,
+                                                            )
 
-    focal_length = 28 * u.m
+    focal_length = OpticsDescription.from_name('LST').equivalent_focal_length
     if 'mc_alt_tel' in dl2.columns:
         alt_tel = dl2['mc_alt_tel'].values
         az_tel = dl2['mc_az_tel'].values
-    else:
+    elif 'alt_tel' in dl2.columns:
         alt_tel = dl2['alt_tel'].values
         az_tel = dl2['az_tel'].values
+    else:
+        alt_tel = np.zeros(len(dl2))
+        az_tel = np.zeros(len(dl2))
 
 
     src_pos_reco = utils.reco_source_position_sky(dl2.x.values * u.m,


### PR DESCRIPTION
Partly fix issue #285 
- avoid issue when alt_tel is not in the dl2 parameters
- load LST focal length from ctapipe (rather than having it hardcoded)
