### PR TITLE
Change conda env name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
     - conda info -a # Useful for debugging any issues with conda
 
 install:
-    - conda env create --name cta --file environment.yml
+    - conda env create --file environment.yml
     - conda activate lstchain
     - pip install https://github.com/cta-observatory/ctapipe/archive/$CTAPIPE_VERSION.tar.gz
     - pip install https://github.com/cta-observatory/ctapipe_io_lst/archive/$CTAPIPE_IO_LST_VERSION.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 
 install:
     - conda env create --name cta --file environment.yml
-    - conda activate cta
+    - conda activate lstchain
     - pip install https://github.com/cta-observatory/ctapipe/archive/$CTAPIPE_VERSION.tar.gz
     - pip install https://github.com/cta-observatory/ctapipe_io_lst/archive/$CTAPIPE_IO_LST_VERSION.tar.gz
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 
 install:
     - conda env create --file environment.yml
-    - conda activate lstchain
+    - conda activate lst-dev
     - pip install https://github.com/cta-observatory/ctapipe/archive/$CTAPIPE_VERSION.tar.gz
     - pip install https://github.com/cta-observatory/ctapipe_io_lst/archive/$CTAPIPE_IO_LST_VERSION.tar.gz
     - python setup.py install

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ are unit tested and should be working as long as the build status is passing.
 git clone https://github.com/cta-observatory/cta-lstchain.git
 cd cta-lstchain
 conda env create -f environment.yml
-source activate cta
+source activate lstchain
 ```
 
 - Install lstchain:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ are unit tested and should be working as long as the build status is passing.
 git clone https://github.com/cta-observatory/cta-lstchain.git
 cd cta-lstchain
 conda env create -f environment.yml
-source activate lstchain
+source activate lst-dev
 ```
 
 - Install lstchain:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ are unit tested and should be working as long as the build status is passing.
 git clone https://github.com/cta-observatory/cta-lstchain.git
 cd cta-lstchain
 conda env create -f environment.yml
-source activate lst-dev
+conda activate lst-dev
 ```
 
 - Install lstchain:

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: cta
+name: lstchain
 channels:
   - default
   - cta-observatory

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: lstchain
+name: lst-dev
 channels:
   - default
   - cta-observatory


### PR DESCRIPTION
As the title suggests this changes the name of the conda environment from "cta" to "lstchain". 
I think "cta" is too generic. I hope this does not affects user who got the habit to do `conda activate cta`.