### PR TITLE
set unit of energy to TeV in sensitivity code

### DIFF
--- a/lstchain/mc/sensitivity.py
+++ b/lstchain/mc/sensitivity.py
@@ -330,23 +330,23 @@ def find_best_cuts_sensitivity(simtelfile_gammas, simtelfile_protons,
     mc_par_g['sim_ev'] = mc_par_g['sim_ev'] * nfiles_gammas
     mc_par_p['sim_ev'] = mc_par_p['sim_ev'] * nfiles_protons
 
-    # Pass units to GeV and cm2
-    mc_par_g['emin'] = mc_par_g['emin'].to(u.GeV)
-    mc_par_g['emax'] = mc_par_g['emax'].to(u.GeV)
+    # Pass units to TeV and cm2
+    mc_par_g['emin'] = mc_par_g['emin'].to(u.TeV)
+    mc_par_g['emax'] = mc_par_g['emax'].to(u.TeV)
 
-    mc_par_p['emin'] = mc_par_p['emin'].to(u.GeV)
-    mc_par_p['emax'] = mc_par_p['emax'].to(u.GeV)
+    mc_par_p['emin'] = mc_par_p['emin'].to(u.TeV)
+    mc_par_p['emax'] = mc_par_p['emax'].to(u.TeV)
 
     mc_par_g['area_sim'] = mc_par_g['area_sim'].to(u.cm ** 2)
     mc_par_p['area_sim'] = mc_par_p['area_sim'].to(u.cm ** 2)
 
     # Set binning for sensitivity calculation
     # TODO: This information should be read from the files
-    emin_sensitivity = 10 ** 1 * u.GeV  # mc_par_g['emin']
-    emax_sensitivity = 10 ** 5 * u.GeV  # mc_par_g['emax']
+    emin_sensitivity = 0.01 * u.TeV  # mc_par_g['emin']
+    emax_sensitivity =  100 * u.TeV  # mc_par_g['emax']
 
     energy = np.logspace(np.log10(emin_sensitivity.to_value()),
-                         np.log10(emax_sensitivity.to_value()), n_bins_energy + 1) * u.GeV
+                         np.log10(emax_sensitivity.to_value()), n_bins_energy + 1) * u.TeV
 
     gammaness_bins, theta2_bins = bin_definition(n_bins_gammaness, n_bins_theta2)
 
@@ -385,9 +385,9 @@ def find_best_cuts_sensitivity(simtelfile_gammas, simtelfile_protons,
         print("These results will make no sense")
         w_g = w_g / u.sr  # Fix to make tests pass
 
-    rate_weighted_g = ((e_true_g / crab_par['e0'].to(u.TeV)) ** (crab_par['alpha'] - mc_par_g['sp_idx'])) \
+    rate_weighted_g = ((e_true_g / crab_par['e0']) ** (crab_par['alpha'] - mc_par_g['sp_idx'])) \
                       * w_g
-    rate_weighted_p = ((e_true_p / proton_par['e0'].to(u.TeV)) ** (proton_par['alpha'] - mc_par_p['sp_idx'])) \
+    rate_weighted_p = ((e_true_p / proton_par['e0']) ** (proton_par['alpha'] - mc_par_p['sp_idx'])) \
                       * w_p
 
     p_contained, ang_area_p = ring_containment(angdist2_p, 0.4 * u.deg, 0.3 * u.deg)
@@ -418,7 +418,7 @@ def find_best_cuts_sensitivity(simtelfile_gammas, simtelfile_protons,
     for i in range(0, n_bins_energy):  # binning in energy
         total_rate_proton_ebin = np.sum(rate_weighted_p[(e_reco_p < energy[i + 1]) & (e_reco_p > energy[i])])
 
-        print("******** Energy bin [GeV] *****")
+        print("******** Energy bin [TeV] *****")
         print(energy[i], energy[i + 1])
         total_rate_proton_ebin = np.sum(rate_weighted_p[(e_reco_p < energy[i+1]) & (e_reco_p > energy[i])])
         total_rate_gamma_ebin = np.sum(rate_weighted_g[(e_reco_g < energy[i+1]) & (e_reco_g > energy[i])])
@@ -574,22 +574,22 @@ def sensitivity(simtelfile_gammas, simtelfile_protons,
     mc_par_g['sim_ev'] = mc_par_g['sim_ev'] * nfiles_gammas
     mc_par_p['sim_ev'] = mc_par_p['sim_ev'] * nfiles_protons
 
-    # Pass units to GeV and cm2
-    mc_par_g['emin'] = mc_par_g['emin'].to(u.GeV)
-    mc_par_g['emax'] = mc_par_g['emax'].to(u.GeV)
+    # Pass units to TeV and cm2
+    mc_par_g['emin'] = mc_par_g['emin'].to(u.TeV)
+    mc_par_g['emax'] = mc_par_g['emax'].to(u.TeV)
 
-    mc_par_p['emin'] = mc_par_p['emin'].to(u.GeV)
-    mc_par_p['emax'] = mc_par_p['emax'].to(u.GeV)
+    mc_par_p['emin'] = mc_par_p['emin'].to(u.TeV)
+    mc_par_p['emax'] = mc_par_p['emax'].to(u.TeV)
 
     mc_par_g['area_sim'] = mc_par_g['area_sim'].to(u.cm ** 2)
     mc_par_p['area_sim'] = mc_par_p['area_sim'].to(u.cm ** 2)
 
     # Set binning for sensitivity calculation
-    emin_sensitivity = 10 ** 1 * u.GeV  # mc_par_g['emin']
-    emax_sensitivity = 10 ** 5 * u.GeV  # mc_par_g['emax']
+    emin_sensitivity = 0.01 * u.TeV  # mc_par_g['emin']
+    emax_sensitivity =  100 * u.TeV  # mc_par_g['emax']
 
     energy = np.logspace(np.log10(emin_sensitivity.to_value()),
-                         np.log10(emax_sensitivity.to_value()), n_bins_energy + 1) * u.GeV
+                         np.log10(emax_sensitivity.to_value()), n_bins_energy + 1) * u.TeV
 
     # Extract spectral parameters
     dFdE, crab_par = crab_hegra(energy)
@@ -625,9 +625,9 @@ def sensitivity(simtelfile_gammas, simtelfile_protons,
         print("These results will make no sense")
         w_g = w_g / u.sr  # Fix to make tests pass
 
-    rate_weighted_g = ((e_true_g / crab_par['e0'].to(u.TeV)) ** (crab_par['alpha'] - mc_par_g['sp_idx'])) \
+    rate_weighted_g = ((e_true_g / crab_par['e0']) ** (crab_par['alpha'] - mc_par_g['sp_idx'])) \
                       * w_g
-    rate_weighted_p = ((e_true_p / proton_par['e0'].to(u.TeV)) ** (proton_par['alpha'] - mc_par_p['sp_idx'])) \
+    rate_weighted_p = ((e_true_p / proton_par['e0']) ** (proton_par['alpha'] - mc_par_p['sp_idx'])) \
                       * w_p
 
     p_contained, ang_area_p = ring_containment(angdist2_p, 0.4 * u.deg, 0.3 * u.deg)
@@ -732,7 +732,7 @@ def sensitivity(simtelfile_gammas, simtelfile_protons,
     egeom = np.sqrt(energy[1:] * energy[:-1])
     dFdE, par = crab_hegra(egeom)
     sensitivity_flux = sensitivity / 100 * (dFdE * egeom * egeom).to(u.TeV / (u.cm ** 2 * u.s))
-    print("******** Energy [GeV] *********")
+    print("******** Energy [TeV] *********")
     print(egeom)
     print("**************")
     print("sensitivity ", sensitivity_flux)

--- a/lstchain/spectra/crab.py
+++ b/lstchain/spectra/crab.py
@@ -34,7 +34,7 @@ def crab_magic(E):
 
     dFdE  = f0 * np.power(E / e0, alpha + beta * np.log10(E/e0))
 
-    return dFdE.to(1/u.GeV / u.cm**2 / u.s), par
+    return dFdE.to(1/u.TeV / u.cm**2 / u.s), par
 
 def crab_hegra(E):
     """ From http://adsabs.harvard.edu/abs/2004ApJ...614..897A
@@ -61,4 +61,4 @@ def crab_hegra(E):
 
     dFdE  = f0 * np.power(E / e0, alpha)
 
-    return dFdE.to(1/u.GeV / u.cm**2 / u.s), par
+    return dFdE.to(1/u.TeV / u.cm**2 / u.s), par

--- a/lstchain/spectra/crab.py
+++ b/lstchain/spectra/crab.py
@@ -23,10 +23,10 @@ def crab_magic(E):
     par: `dict` with spectral parameters
     """
 
-    f0    = 3.23e-14 / u.GeV / u.cm**2 / u.s
+    f0    = 3.23e-11 / u.TeV / u.cm**2 / u.s
     alpha = -2.47
     beta  = -0.24
-    e0    = 1000 * u.GeV
+    e0    = 1. * u.TeV
 
     par_var = [f0, alpha, beta, e0]
     par_dic = ['f0', 'alpha', 'beta', 'e0']
@@ -51,9 +51,9 @@ def crab_hegra(E):
     par: `dict` with spectral parameters
     """
 
-    f0    = 2.83e-14 / u.GeV / u.cm**2 / u.s
+    f0    = 2.83e-11 / u.TeV / u.cm**2 / u.s
     alpha = -2.62
-    e0    = 1000 * u.GeV
+    e0    = 1. * u.TeV
 
     par_var = [f0, alpha, e0]
     par_dic = ['f0', 'alpha', 'e0']

--- a/lstchain/spectra/proton.py
+++ b/lstchain/spectra/proton.py
@@ -20,9 +20,9 @@ def proton_bess(E):
     par: `dict` with spectral parameters
     """
 
-    f0 = 9.6e-9 / u.GeV / u.cm**2 / u.s / u.sr
+    f0 = 9.6e-6 / u.TeV / u.cm**2 / u.s / u.sr
     alpha = -2.70
-    e0 = 1000. * u.GeV
+    e0 = 1. * u.TeV
 
     par_var = [f0, alpha, e0]
     par_dic = ['f0', 'alpha', 'e0']

--- a/lstchain/spectra/proton.py
+++ b/lstchain/spectra/proton.py
@@ -30,4 +30,4 @@ def proton_bess(E):
 
     dFdEdO = f0 * np.power(E/e0, alpha)
 
-    return dFdEdO.to(1 / u.GeV / u.cm**2 / u.s / u.sr), par
+    return dFdEdO.to(1 / u.TeV / u.cm**2 / u.s / u.sr), par


### PR DESCRIPTION
Now the unit of e_true & e_reco is set to TeV because the unit of mc_energy & reco_energy in DL2 is TeV. Almost all the codes are working well, but I found following the only one part which have a problem.

e_aftercuts_w = np.sum(np.power(e_aftercuts, crab_par['alpha'] - mc_par_g['sp_idx']))
eff_area[i] = e_aftercuts_w.to_value() / n_sim_bin[i] * mc_par_g['area_sim'].to(u.m ** 2).to_value()

e_aftercuts_w is calculated with TeV unit, and n_sim_bin is with GeV.
So here I'd like to propose to set e_true amd e_reco to GeV at first.