### PR TITLE
Impute pointing values with linear interpolation

### DIFF
--- a/lstchain/pointing/pointings.py
+++ b/lstchain/pointing/pointings.py
@@ -87,4 +87,5 @@ class PointingPosition(Component):
             return ev_azimuth, ev_altitude
         else:
             raise Exception("No drive time in the range of event times")
+            return np.nan, np.nan
 

--- a/lstchain/pointing/pointings.py
+++ b/lstchain/pointing/pointings.py
@@ -87,5 +87,4 @@ class PointingPosition(Component):
             return ev_azimuth, ev_altitude
         else:
             raise Exception("No drive time in the range of event times")
-            return np.nan, np.nan
 

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -351,6 +351,9 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                             event.pointing[telescope_id].altitude = altitude
                             dl1_container.az_tel = azimuth
                             dl1_container.alt_tel = altitude
+                        else:
+                            dl1_container.az_tel = np.nan
+                            dl1_container.alt_tel = np.nan
 
                     foclen = event.inst.subarray.tel[telescope_id].optics.equivalent_focal_length
                     width = np.rad2deg(np.arctan2(dl1_container.width, foclen))

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -352,8 +352,8 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                             dl1_container.az_tel = azimuth
                             dl1_container.alt_tel = altitude
                         else:
-                            dl1_container.az_tel = np.nan
-                            dl1_container.alt_tel = np.nan
+                            dl1_container.az_tel = u.Quantity(np.nan, u.rad)
+                            dl1_container.alt_tel = u.Quantity(np.nan, u.rad)
 
                     foclen = event.inst.subarray.tel[telescope_id].optics.equivalent_focal_length
                     width = np.rad2deg(np.arctan2(dl1_container.width, foclen))

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -397,8 +397,8 @@ def apply_models(dl1, classifier, reg_energy, reg_disp_vector, custom_config={})
         alt_tel = dl2['alt_tel'].values
         az_tel = dl2['az_tel'].values
     else:
-        alt_tel = np.zeros(len(dl2))
-        az_tel = np.zeros(len(dl2))
+        alt_tel = - np.pi/2. * np.ones(len(dl2))
+        az_tel = - np.pi/2. * np.ones(len(dl2))
 
 
     src_pos_reco = utils.reco_source_position_sky(dl2.x.values * u.m,

--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -46,8 +46,9 @@ def test_linear_imputer():
 
 
 def test_impute_pointing():
+    event_id = np.arange(5, 14, dtype=int)
     a = np.array([0.2, 0.3, np.nan, np.nan, np.nan, 0.7, np.nan, 0.8, np.nan])
-    df = pd.DataFrame(np.transpose([a, a]), columns=['alt_tel', 'az_tel'])
-    utils.impute_pointing(df)
+    df = pd.DataFrame(np.transpose([event_id, a, a]), columns=['event_id', 'alt_tel', 'az_tel'])
+    df = utils.impute_pointing(df)
     np.testing.assert_allclose(df.alt_tel, [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.8])
     np.testing.assert_allclose(df.az_tel, [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.8])

--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -1,7 +1,7 @@
 from lstchain.reco import utils
 import astropy.units as u
 import numpy as np
-
+import pandas as pd
 
 
 def test_camera_to_sky():
@@ -38,3 +38,16 @@ def test_sky_to_camera():
     np.testing.assert_allclose(camera_coords.x.value, np.array([0, 0]), rtol=1e-4, atol=1e-4)
     np.testing.assert_allclose(camera_coords.y.value, np.array([0, 0]), rtol=1e-4, atol=1e-4)
 
+
+def test_linear_imputer():
+    a = np.array([0.2, 0.3, np.nan, np.nan, np.nan, 0.7, np.nan, 0.8, np.nan])
+    utils.linear_imputer(a, missing_values=np.nan, copy=False)
+    np.testing.assert_allclose(a, [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.8])
+
+
+def test_impute_pointing():
+    a = np.array([0.2, 0.3, np.nan, np.nan, np.nan, 0.7, np.nan, 0.8, np.nan])
+    df = pd.DataFrame(np.transpose([a, a]), columns=['alt_tel', 'az_tel'])
+    utils.impute_pointing(df)
+    np.testing.assert_allclose(df.alt_tel, [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.8])
+    np.testing.assert_allclose(df.az_tel, [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.8])

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -18,6 +18,7 @@ from astropy.utils import deprecated
 from astropy.coordinates import AltAz, SkyCoord, EarthLocation
 from astropy.time import Time
 from . import disp
+from warnings import warn
 
 __all__ = [
     'alt_to_theta',
@@ -450,6 +451,10 @@ def impute_pointing(dl1_data, missing_values=np.nan):
     missing_values: number, string, np.nan or None, default=`np.nan`
         The placeholder for the missing values. All occurrences of `missing_values` will be imputed.
     """
+    if len(set(dl1_data.event_id)) != len(dl1_data.event_id):
+        warn("Beware, the data has been resorted by `event_id` to interpolate invalid pointing values but there are "
+             "several events with the same `event_id` in the data, thus probably leading to unexpected behaviour",
+             UserWarning)
     dl1_data = dl1_data.sort_values(by='event_id')
     for k in ['alt_tel', 'az_tel']:
         dl1_data[k] = linear_imputer(dl1_data[k].values, missing_values=missing_values)

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -410,3 +410,45 @@ def filter_events(events,
         return events[filter].dropna()
     else:
         return events[filter]
+
+
+def linear_imputer(y, missing_values=np.nan, copy=True):
+    """
+    Replace missing values in y with values from a linear interpolation on their position in the array.
+    Parameters
+    ----------
+    y: list or `numpy.array`
+    missing_values: number, string, np.nan or None, default=`np.nan`
+        The placeholder for the missing values. All occurrences of `missing_values` will be imputed.
+    copy : bool, default=True
+        If True, a copy of X will be created. If False, imputation will be done in-place whenever possible.
+    Returns
+    -------
+    `numpy.array` : array with `missing_values` imputed
+    """
+    x = np.arange(len(y))
+    if missing_values is np.nan:
+        mask_missing = np.isnan(y)
+    else:
+        mask_missing = y == missing_values
+    imputed_values = np.interp(x[mask_missing], x[~mask_missing], y[~mask_missing])
+    if copy:
+        yy = np.copy(y)
+        yy[mask_missing] = imputed_values
+        return yy
+    else:
+        y[mask_missing] = imputed_values
+        return y
+
+
+def impute_pointing(dl1_data, missing_values=np.nan):
+    """
+    Impute missing pointing values using `linear_imputer` and replace them inplace
+    Parameters
+    ----------
+    dl1_data: `pandas.DataFrame`
+    missing_values: number, string, np.nan or None, default=`np.nan`
+        The placeholder for the missing values. All occurrences of `missing_values` will be imputed.
+    """
+    for k in ['alt_tel', 'az_tel']:
+        dl1_data[k] = linear_imputer(dl1_data[k], missing_values=missing_values)

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -450,6 +450,7 @@ def impute_pointing(dl1_data, missing_values=np.nan):
     missing_values: number, string, np.nan or None, default=`np.nan`
         The placeholder for the missing values. All occurrences of `missing_values` will be imputed.
     """
-    dl1_data = dl1_data.sort_index(by='event_id')
+    dl1_data = dl1_data.sort_values(by='event_id')
     for k in ['alt_tel', 'az_tel']:
         dl1_data[k] = linear_imputer(dl1_data[k].values, missing_values=missing_values)
+    return dl1_data

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -450,5 +450,6 @@ def impute_pointing(dl1_data, missing_values=np.nan):
     missing_values: number, string, np.nan or None, default=`np.nan`
         The placeholder for the missing values. All occurrences of `missing_values` will be imputed.
     """
+    dl1_data = dl1_data.sort_index(by='event_id')
     for k in ['alt_tel', 'az_tel']:
-        dl1_data[k] = linear_imputer(dl1_data[k], missing_values=missing_values)
+        dl1_data[k] = linear_imputer(dl1_data[k].values, missing_values=missing_values)

--- a/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
@@ -68,7 +68,7 @@ def main():
     if 'alt_tel' in data.columns and 'az_tel' in data.columns:
         # make sure there is a least one good pointing value to interp from.
         if np.isfinite(data.alt_tel).any() and np.isfinite(data.az_tel).any():
-            impute_pointing(data)
+            data = impute_pointing(data)
         else:
             data.alt_tel = - np.pi/2.
             data.az_tel = - np.pi/2.

--- a/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
@@ -70,8 +70,8 @@ def main():
         if np.isfinite(data.alt_tel).any() and np.isfinite(data.az_tel).any():
             impute_pointing(data)
         else:
-            data.alt_tel = u.Quantity(-90, u.deg)
-            data.az_tel = u.Quantity(-90, u.deg)
+            data.alt_tel = - np.pi/2.
+            data.az_tel = - np.pi/2.
     data = filter_events(data, filters=config["events_filters"])
 
 

--- a/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
@@ -19,7 +19,7 @@ from lstchain.reco.utils import filter_events, impute_pointing
 from lstchain.io import read_configuration_file, standard_config, replace_config
 from lstchain.io import write_dl2_dataframe
 from lstchain.io.io import dl1_params_lstcam_key
-
+import numpy as np
 
 parser = argparse.ArgumentParser(description="Reconstruct events")
 
@@ -62,8 +62,15 @@ def main():
     config = replace_config(standard_config, custom_config)
 
     data = pd.read_hdf(args.datafile, key=dl1_params_lstcam_key)
+
+    # Dealing with pointing errors
     if 'alt_tel' in data.columns and 'az_tel' in data.columns:
-        impute_pointing(data)
+        # make sure there is a least one good pointing value to interp from.
+        if np.isfinite(data.alt_tel).any() and np.isfinite(data.az_tel).any():
+            impute_pointing(data)
+        else:
+            data.alt_tel = 0
+            data.az_tel = 0
     data = filter_events(data, filters=config["events_filters"])
 
 

--- a/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
@@ -15,7 +15,7 @@ import argparse
 import os
 import shutil
 import pandas as pd
-from lstchain.reco.utils import filter_events
+from lstchain.reco.utils import filter_events, impute_pointing
 from lstchain.io import read_configuration_file, standard_config, replace_config
 from lstchain.io import write_dl2_dataframe
 from lstchain.io.io import dl1_params_lstcam_key
@@ -62,6 +62,8 @@ def main():
     config = replace_config(standard_config, custom_config)
 
     data = pd.read_hdf(args.datafile, key=dl1_params_lstcam_key)
+    if 'alt_tel' in data.columns and 'az_tel' in data.columns:
+        impute_pointing(data)
     data = filter_events(data, filters=config["events_filters"])
 
 

--- a/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
@@ -65,7 +65,8 @@ def main():
     data = pd.read_hdf(args.datafile, key=dl1_params_lstcam_key)
 
     # Dealing with pointing missing values. This happened when `ucts_time` was invalid.
-    if 'alt_tel' in data.columns and 'az_tel' in data.columns:
+    if 'alt_tel' in data.columns and 'az_tel' in data.columns \
+            and (np.isnan(data.alt_tel).any() or np.isnan(data.az_tel).any()):
         # make sure there is a least one good pointing value to interp from.
         if np.isfinite(data.alt_tel).any() and np.isfinite(data.az_tel).any():
             data = impute_pointing(data)

--- a/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
@@ -20,6 +20,7 @@ from lstchain.io import read_configuration_file, standard_config, replace_config
 from lstchain.io import write_dl2_dataframe
 from lstchain.io.io import dl1_params_lstcam_key
 import numpy as np
+import astropy.units as u
 
 parser = argparse.ArgumentParser(description="Reconstruct events")
 
@@ -63,14 +64,14 @@ def main():
 
     data = pd.read_hdf(args.datafile, key=dl1_params_lstcam_key)
 
-    # Dealing with pointing errors
+    # Dealing with pointing missing values. This happened when `ucts_time` was invalid.
     if 'alt_tel' in data.columns and 'az_tel' in data.columns:
         # make sure there is a least one good pointing value to interp from.
         if np.isfinite(data.alt_tel).any() and np.isfinite(data.az_tel).any():
             impute_pointing(data)
         else:
-            data.alt_tel = 0
-            data.az_tel = 0
+            data.alt_tel = u.Quantity(-90, u.deg)
+            data.az_tel = u.Quantity(-90, u.deg)
     data = filter_events(data, filters=config["events_filters"])
 
 


### PR DESCRIPTION
Fixes #285

- the pointing values are now `nan` instead of None in case of wrong timing info
- I propose a linear interpolation between pointing values when they are missing with the hypothesis that events are in order and come at a regular rate. Note that if a lot of values are missing, it might not be the best approach and feedback is welcome.