### PR TITLE
Error when reading a simtel file with no defined telescope or camera name

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -361,7 +361,7 @@ def write_array_info(event, output_filename):
         if len(ids) > 0:  # only write if there is a telescope with this camera
             tel_id = list(ids)[0]
             camera = sub.tel[tel_id].camera
-            camera_name = str(sub.tel[tel_id])
+            camera_name = str(camera)
             with tables.open_file(output_filename, mode='r') as f:
                 telescope_chidren = f.root['instrument/telescope']._v_children.keys()
                 if 'camera' in telescope_chidren:

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -361,9 +361,17 @@ def write_array_info(event, output_filename):
         if len(ids) > 0:  # only write if there is a telescope with this camera
             tel_id = list(ids)[0]
             camera = sub.tel[tel_id].camera
-            camera_name = str(camera)
-            if camera_name is 'UNKNOWN':
-                continue
+            camera_name = str(sub.tel[tel_id])
+            with tables.open_file(output_filename, mode='r') as f:
+                telescope_chidren = f.root['instrument/telescope']._v_children.keys()
+                if 'camera' in telescope_chidren:
+                    cameras_name = f.root['instrument/telescope/camera']._v_children.keys()
+                    if camera_name in cameras_name:
+                        print(
+                            f'WARNING during lstchain.io.write_array_info():',
+                            f'camera {camera_name} seems to be already present in the h5 file.'
+                        )
+                        continue
             camera.to_table().write(
                 output_filename,
                 path=f'/instrument/telescope/camera/{camera_name}',

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -361,9 +361,12 @@ def write_array_info(event, output_filename):
         if len(ids) > 0:  # only write if there is a telescope with this camera
             tel_id = list(ids)[0]
             camera = sub.tel[tel_id].camera
+            camera_name = str(camera)
+            if camera_name is 'UNKNOWN':
+                continue
             camera.to_table().write(
                 output_filename,
-                path=f'/instrument/telescope/camera/{camera}',
+                path=f'/instrument/telescope/camera/{camera_name}',
                 append=True,
                 serialize_meta=serialize_meta,
             )
@@ -450,7 +453,7 @@ def write_metadata(metadata, output_filename):
     # So this metadata is written in the file attributes
     with open_file(output_filename, mode='a') as file:
         for k, item in metadata.as_dict().items():
-            if k in file.root._v_attrs and type(item) is list:
+            if k in file.root._v_attrs and type(file.root._v_attrs) is list:
                 attribute = file.root._v_attrs[k].extend(metadata[k])
                 file.root._v_attrs[k] = attribute
             else:

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -160,6 +160,8 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
         output_filename = (
             'dl1_' + os.path.basename(input_filename).split('.')[0] + '.h5'
         )
+    if os.path.exists(output_filename):
+        raise AttributeError(output_filename + ' exists, exiting.')
 
     config = replace_config(standard_config, custom_config)
 
@@ -209,8 +211,6 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
     extra_im.prefix = ''  # get rid of the prefix
 
     event = next(iter(source))
-
-
 
     write_array_info(event, output_filename)
     ### Write extra information to the DL1 file
@@ -370,7 +370,6 @@ def r0_to_dl1(input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
                         add_global_metadata(container, metadata)
 
                     event.r0.prefix = ''
-
                     writer.write(table_name=f'telescope/image/{tel_name}',
                                  containers=[event.r0, tel, extra_im])
                     writer.write(table_name=f'telescope/parameters/{tel_name}',


### PR DESCRIPTION
Hello,
I produced simtel files where the name of some of the telescopes, some of the cameras was not defined. When I tried to convert them to dl1 I the following error:
`OSError: Table /instrument/telescope/camera/UNKNOWN already exists`
This PR fixes the issue (which was reported here): https://github.com/cta-observatory/cta-lstchain/issues/294
I also raised an explicit exception when trying to create an DL1 file which already exist. Otherwise it would fail later with some obscure error similar to the one above.