### PR TITLE
Add ucts trigger to the DL1 container

### DIFF
--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -195,6 +195,7 @@ class ExtraImageInfo(Container):
     """ attach the tel_id """
     tel_id = Field(0, "Telescope ID")
     trigger_type = Field(None, "trigger type")
+    ucts_trigger_type = Field(None, "UCTS trigger type")
     trigger_time = Field(None, "trigger time")
     num_trig_pix = Field(None, "Number of trigger groups (sectors) listed")
     trig_pix_id = Field(None, "pixels involved in the camera trigger")

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -369,6 +369,10 @@ def r0_to_dl1(input_filename = get_dataset_path('gamma_test_large.simtel.gz'),
                             dl1_container.az_tel = u.Quantity(np.nan, u.rad)
                             dl1_container.alt_tel = u.Quantity(np.nan, u.rad)
 
+                            # Until the TIB trigger_type is fully reliable, we also add
+                            # the ucts_trigger_type to the data
+                            extra_im.ucts_trigger_type = event.lst.tel[telescope_id].evt.ucts_trigger_type
+
                     foclen = event.inst.subarray.tel[telescope_id].optics.equivalent_focal_length
                     width = np.rad2deg(np.arctan2(dl1_container.width, foclen))
                     length = np.rad2deg(np.arctan2(dl1_container.length, foclen))


### PR DESCRIPTION
After talking to @FrancaCassol about the `trigger_type` and its reliability, she suggested that, for the time being, we could also add the `ucts_trigger_type` to the DL1 data containers. 
This variable should not substitute the current `trigger_type`, but complement it for expert checks in the DL1 data. 