### PR TITLE
Muons: Fix wrong rotation in CameraFrame

### DIFF
--- a/lstchain/_version_cache.py
+++ b/lstchain/_version_cache.py
@@ -1,0 +1,1 @@
+version='0.4.5.post23+gite9b21b4'

--- a/lstchain/image/muon/muon_analysis.py
+++ b/lstchain/image/muon/muon_analysis.py
@@ -47,7 +47,7 @@ def pixel_coords_to_telescope(geom, equivalent_focal_length):
         y=geom.pix_y,
         frame=CameraFrame(
             focal_length=equivalent_focal_length,
-            rotation=geom.camera_rotation,
+            rotation=geom.cam_rotation,
         )
     )
     tel_coord = camera_coord.transform_to(TelescopeFrame())

--- a/lstchain/image/muon/muon_analysis.py
+++ b/lstchain/image/muon/muon_analysis.py
@@ -85,21 +85,23 @@ def fit_muon(x, y, image, geom, tailcuts):
     ring = fitter.fit(x, y, image_clean)
 
     max_allowed_outliers_distance = 0.4
-    # Do an iterative fit removing pixels which are beyond max_allowed_outliers_distance*ring_radius
-    # of the ring (along the radial direction):
-    # The goal is to improve fit for good rings with very few additional non-ring bright pixels.
 
+    # Do an iterative fit removing pixels which are beyond
+    # max_allowed_outliers_distance * ring_radius of the ring
+    # (along the radial direction)
+    # The goal is to improve fit for good rings
+    # with very few additional non-ring bright pixels.
     for _ in (0, 0):  # just to iterate the fit twice more
         dist = np.sqrt(
             (x - ring.ring_center_x)**2 + (y - ring.ring_center_y)**2
         )
         ring_dist = np.abs(dist - ring.ring_radius)
-        muonringparam = fitter.fit(
+        ring = fitter.fit(
             x, y,
             image_clean * (ring_dist < ring.ring_radius * max_allowed_outliers_distance)
         )
 
-    return muonringparam, clean_mask, dist, image_clean
+    return ring, clean_mask, dist, image_clean
 
 
 def analyze_muon_event(event_id, image, geom, equivalent_focal_length,

--- a/lstchain/image/muon/muon_analysis.py
+++ b/lstchain/image/muon/muon_analysis.py
@@ -39,7 +39,7 @@ def pixel_coords_to_telescope(geom, equivalent_focal_length):
 
     Returns
     ---------
-    x, y:    `floats` coordinates in  the NominalFrame
+    delta_az, delta_alt:    `floats` coordinates in  the TelescopeFrame
     """
 
     camera_coord = SkyCoord(
@@ -61,7 +61,7 @@ def fit_muon(x, y, image, geom, tailcuts):
 
     Paramenters
     ---------
-    x, y:    `floats` coordinates in  the NominalFrame
+    x, y:    `floats` coordinates in  the TelescopeFrame
     image:   `np.ndarray` number of photoelectrons in each pixel
     geom:    CameraGeometry
     image:   `list` tail cuts for image cleaning
@@ -262,18 +262,17 @@ def analyze_muon_event(event_id, image, geom, equivalent_focal_length,
         good_ring = False
 
     if(plot_rings and plots_path and good_ring):
-        altaz = AltAz(alt = 70 * u.deg, az = 0 * u.deg)
         focal_length = equivalent_focal_length
-        ring_nominal = SkyCoord(
-                delta_az = muonringparam.ring_center_x,
-                delta_alt = muonringparam.ring_center_y,
-                frame = NominalFrame(origin=altaz)
-            )
+        ring_telescope = SkyCoord(
+            delta_az=muonringparam.ring_center_x,
+            delta_alt=muonringparam.ring_center_y,
+            frame=TelescopeFrame()
+        )
 
-        ring_camcoord = ring_nominal.transform_to(CameraFrame(
-                focal_length = focal_length,
-                rotation = geom.pix_rotation,
-                telescope_pointing = altaz))
+        ring_camcoord = ring_telescope.transform_to(CameraFrame(
+            focal_length=focal_length,
+            rotation=geom.cam_rotation,
+        ))
         centroid = (ring_camcoord.x.value, ring_camcoord.y.value)
         radius = muonringparam.ring_radius
         width = muonintensityoutput.ring_width
@@ -282,7 +281,7 @@ def analyze_muon_event(event_id, image, geom, equivalent_focal_length,
         ringrad_inner = ringrad_camcoord * (1. - ringwidthfrac)
         ringrad_outer = ringrad_camcoord * (1. + ringwidthfrac)
 
-        fig, ax = plt.subplots(figsize=(10,10))
+        fig, ax = plt.subplots(figsize=(10, 10))
         plot_muon_event(ax, geom, image * clean_mask, centroid, ringrad_camcoord,
                         ringrad_inner, ringrad_outer, event_id)
 

--- a/lstchain/image/muon/tests/test_muon_analysis.py
+++ b/lstchain/image/muon/tests/test_muon_analysis.py
@@ -1,0 +1,11 @@
+import astropy.units as u
+
+
+def test_pixel_to_telescope():
+    from ctapipe_io_lst import load_camera_geometry
+    from lstchain.image.muon import pixel_coords_to_telescope
+
+    cam = load_camera_geometry()
+    x, y = pixel_coords_to_telescope(cam, 38 * u.m)
+
+    assert x.unit == y.unit == u.deg


### PR DESCRIPTION
* get_muon_ring_center actually transformed pixel positions into nominal frame
* It needlessly transformed into nominal frame (which needs an array pointing positoin), changed that to `TelescopeFrame`, which is the same if there is no divergent pointing and does not need an array pointing direction
* some style improvements