### PR TITLE
Add pipto env file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - cta-observatory
   - conda-forge
 dependencies:
+  - pip
   - ctapipe=0.7.0
   - gammapy
   - h5py


### PR DESCRIPTION
Fixes conda warning:
```
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
```