### PR TITLE
Transform unix timestamps from TAI to UTC scale

### DIFF
--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -385,12 +385,9 @@ def r0_to_dl1(input_filename = get_dataset_path('gamma_test_large.simtel.gz'),
                                 event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10**(-7))
 
                         # FIXME: directly use unix_tai format whenever astropy v4.1 is out
-                        ucts_time_tai = Time(ucts_time, format='unix', scale='tai') 
-                        ucts_time_utc = Time(ucts_time_tai.utc.jd, format='jd', scale='tai')
-                        dragon_time_tai = Time(dragon_time, format='unix', scale='tai') 
-                        dragon_time_utc = Time(dragon_time_tai.utc.jd, format='jd', scale='tai')
-                        tib_time_tai = Time(tib_time, format='unix', scale='tai') 
-                        tib_time_utc = Time(tib_time_tai.utc.jd, format='jd', scale='tai')
+                        ucts_time_utc = unix_tai_to_utc(ucts_time)
+                        dragon_time_utc = unix_tai_to_utc(dragon_time)
+                        tib_time_utc = unix_tai_to_utc(tib_time)
 
                         dl1_container.ucts_time = ucts_time_utc.unix
                         dl1_container.dragon_time = dragon_time_utc.unix
@@ -583,3 +580,9 @@ def add_disp_to_parameters_table(dl1_file, table_path, focal):
         add_column_table(tab, tables.Float32Col, 'src_x', source_pos_in_camera.x.value)
         tab = file.root[table_path]
         add_column_table(tab, tables.Float32Col, 'src_y', source_pos_in_camera.y.value)
+
+
+def unix_tai_to_utc(timestamp):
+    '''Workaround for unix time in scale TAI'''
+    tai = Time(timestamp, format='unix', scale='tai')
+    return Time(tai.utc.jd, format='jd', scale='tai')

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -45,6 +45,7 @@ import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
 from .utils import sky_to_camera
+from .utils import unix_tai_to_utc
 from ctapipe.instrument import OpticsDescription
 from traitlets.config.loader import Config
 from ..calib.camera.calibrator import LSTCameraCalibrator
@@ -580,9 +581,3 @@ def add_disp_to_parameters_table(dl1_file, table_path, focal):
         add_column_table(tab, tables.Float32Col, 'src_x', source_pos_in_camera.x.value)
         tab = file.root[table_path]
         add_column_table(tab, tables.Float32Col, 'src_y', source_pos_in_camera.y.value)
-
-
-def unix_tai_to_utc(timestamp):
-    '''Workaround for unix time in scale TAI'''
-    tai = Time(timestamp, format='unix', scale='tai')
-    return Time(tai.utc.jd, format='jd', scale='tai')

--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -1,5 +1,6 @@
 from lstchain.reco import utils
 import astropy.units as u
+from astropy.time import Time
 import numpy as np
 import pandas as pd
 
@@ -52,3 +53,10 @@ def test_impute_pointing():
     df = utils.impute_pointing(df)
     np.testing.assert_allclose(df.alt_tel, [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.8])
     np.testing.assert_allclose(df.az_tel, [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.8])
+
+
+def test_unix_tai_to_utc():
+    timestamp_tai = 1579376359.3225002
+    leap_seconds = 37
+    utc_time = utils.unix_tai_to_utc(timestamp_tai)
+    np.testing.assert_allclose(utc_time.unix, timestamp_tai - leap_seconds, rtol=1e-12)

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -33,6 +33,7 @@ __all__ = [
     'polar_to_cartesian',
     'cartesian_to_polar',
     'predict_source_position_in_camera',
+    'unix_tai_to_utc'
 ]
 
 
@@ -361,8 +362,6 @@ def predict_source_position_in_camera(cog_x, cog_y, disp_dx, disp_dy):
     return reco_src_x, reco_src_y
 
 
-
-
 def expand_tel_list(tel_list, max_tels):
     """
     transform for the telescope list (to turn it into a telescope pattern)
@@ -461,9 +460,16 @@ def impute_pointing(dl1_data, missing_values=np.nan):
         dl1_data[k] = linear_imputer(dl1_data[k].values, missing_values=missing_values)
     return dl1_data
 
+
 def clip_alt(alt):
     """
     Make sure altitude is not larger than 90 deg (it happens in some MC files for zenith=0),
     to keep astropy happy
     """
     return np.clip(alt, -90.*u.deg, 90.*u.deg)
+
+
+def unix_tai_to_utc(timestamp):
+    '''Workaround for unix time in scale TAI'''
+    tai = Time(timestamp, format='unix', scale='tai')
+    return Time(tai.utc.jd, format='jd', scale='tai')

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -470,6 +470,9 @@ def clip_alt(alt):
 
 
 def unix_tai_to_utc(timestamp):
-    '''Workaround for unix time in scale TAI'''
-    tai = Time(timestamp, format='unix', scale='tai')
-    return Time(tai.utc.jd, format='jd', scale='tai')
+    """
+    Transform unix time from TAI to UTC scale considering the leap seconds
+    by adding the timestamp in seconds to the epoch value.
+    """
+    UCTS_EPOCH = Time('1970-01-01T00:00:00', scale='tai', format='isot')
+    return UCTS_EPOCH + u.Quantity(timestamp, u.s, copy=False)


### PR DESCRIPTION
As decided in #288, here is the workaround to transform Unix timestamps from TAI to UTC scale using `jd` format as an intermediate step. Whenever astropy v4.1 is ready we should simply use the new `unix_tai` format that automatically considers the leap seconds (current `unix` format does not). See #324.

As of now, with this transformation:
- event timestamps will be compared to the ones in the drive logs using UTC scale in both cases.
- UCTS, Dragon and TIB- based event timestamps will be stored in UTC scale (37 secs behind TAI scale) from now on.