### PR TITLE
WIP: R1 calibration

### DIFF
--- a/lstchain/calib/camera/r0.py
+++ b/lstchain/calib/camera/r0.py
@@ -148,7 +148,7 @@ class LSTR0Corrections(CameraR0Calibrator):
 
             event.r1.tel[tel_id].trigger_time = event.r0.tel[tel_id].trigger_time
 
-            samples = event.r0.tel[tel_id].waveform[:, :, self.r1_sample_start:self.r1_sample_end]
+            samples = event.r1.tel[tel_id].waveform[:, :, self.r1_sample_start:self.r1_sample_end]
 
             event.r1.tel[tel_id].waveform = samples.astype('int16') - self.offset
 
@@ -178,7 +178,7 @@ class LSTR0Corrections(CameraR0Calibrator):
                                         n_modules)
 
         event.r1.tel[self.tel_id].trigger_type = event.r0.tel[self.tel_id].trigger_type
-        event.r1.tel[self.tel_id].trigger_time = event.r0.tel[self.tel_id].trigger_time
+        event.r1.tel[self.tel_id].trigger_time = event.r1.tel[self.tel_id].trigger_time
         event.r1.tel[self.tel_id].waveform = samples[:, :, :]
 
 

--- a/lstchain/calib/camera/r0.py
+++ b/lstchain/calib/camera/r0.py
@@ -315,15 +315,14 @@ class LSTR0Corrections(CameraR0Calibrator):
         if not isinstance(event.r1.tel[tel_id].waveform, np.ndarray):
             return
 
-        waveforms = event.r1.tel[tel_id].waveform
-        event.mon.tel[tel_id].calibration = self.mon_data.tel[tel_id].calibration
-        event.mon.tel[tel_id].pixel_status = self.mon_data.tel[tel_id].pixel_status
+        mon_data_tel = self.mon_data.tel[tel_id]
+        event.mon.tel[tel_id].calibration = mon_data_tel.calibration
+        event.mon.tel[tel_id].pixel_status = mon_data_tel.pixel_status
 
         # subtract the pedestal per sample (should we do it?) and multiply for the calibration coefficients
         #
-        pedestal_per_sample = self.mon_data.tel[tel_id].calibration.pedestal_per_sample[:, :, np.newaxis]
-        dc_to_pe = self.mon_data.tel[tel_id].calibration.dc_to_pe[:, :, np.newaxis]
-        event.r1.tel[tel_id].waveform = (waveforms - pedestal_per_sample) * dc_to_pe
+        event.r1.tel[tel_id].waveform -= mon_data_tel.calibration.pedestal_per_sample[:, :, np.newaxis]
+        event.r1.tel[tel_id].waveform *= mon_data_tel.calibration.dc_to_pe[:, :, np.newaxis]
 
 
     @staticmethod

--- a/lstchain/calib/camera/r0.py
+++ b/lstchain/calib/camera/r0.py
@@ -474,7 +474,8 @@ class LSTR0Corrections(CameraR0Calibrator):
                     table = '/tel_' + str(telid) + '/pixel_status'
                     next(h5_table.read(table, self.mon_data.tel[telid].pixel_status))
         except:
-            self.log.error(f"Problem in reading calibration file {self.calibration_path}")
+            self.log.exception(f"Problem in reading calibration file {self.calibration_path}")
+            raise FileNotFoundError(f"Problem in reading calibration file {self.calibration_path}")
 
 
     def _get_first_capacitor(self, event, nr_module, tel_id):

--- a/lstchain/calib/camera/r0.py
+++ b/lstchain/calib/camera/r0.py
@@ -148,7 +148,7 @@ class LSTR0Corrections(CameraR0Calibrator):
 
             event.r1.tel[tel_id].trigger_time = event.r0.tel[tel_id].trigger_time
 
-            samples = event.r1.tel[tel_id].waveform[:, :, self.r1_sample_start:self.r1_sample_end]
+            samples = event.r0.tel[tel_id].waveform[:, :, self.r1_sample_start:self.r1_sample_end]
 
             event.r1.tel[tel_id].waveform = samples.astype('int16') - self.offset
 
@@ -178,7 +178,7 @@ class LSTR0Corrections(CameraR0Calibrator):
                                         n_modules)
 
         event.r1.tel[self.tel_id].trigger_type = event.r0.tel[self.tel_id].trigger_type
-        event.r1.tel[self.tel_id].trigger_time = event.r1.tel[self.tel_id].trigger_time
+        event.r1.tel[self.tel_id].trigger_time = event.r0.tel[self.tel_id].trigger_time
         event.r1.tel[self.tel_id].waveform = samples[:, :, :]
 
 

--- a/lstchain/data/onsite_camera_calibration_param.json
+++ b/lstchain/data/onsite_camera_calibration_param.json
@@ -1,45 +1,48 @@
 {
-   "version": 1,
-   
-   "CalibrationHDF5Writer": {
-     "minimum_hg_charge_median": 5000,
-     "maximum_lg_charge_std": 300,
-     "one_event": true,
-     "flatfield_product": "FlasherFlatFieldCalculator",
-     "pedestal_product": "PedestalIntegrator",
-     "r0calibrator_product": "LSTR0Corrections",
-     "log_level":"DEBUG"
-   },         
+  "version": 1,
+
+  "CalibrationHDF5Writer": {
+    "minimum_hg_charge_median": 5000,
+    "maximum_lg_charge_std": 300,
+    "one_event": true,
+    "flatfield_product": "FlasherFlatFieldCalculator",
+    "pedestal_product": "PedestalIntegrator",
+    "r0calibrator_product": "LSTR0Corrections",
+    "log_level":"DEBUG"
+  },
+  "EventSource": {
+    "max_events": 1000
+  },
   "PedestalCalculator":{
-      "sample_duration":100000,
-      "tel_id":1,
-     "charge_median_cut_outliers": [-10,10],
-     "charge_std_cut_outliers": [-10,10],
-     "charge_product":"FixedWindowSum"
-   },
-    "FlatFieldCalculator":{
-      "sample_duration":100000,
-     "tel_id":1,
-      "charge_product":"LocalPeakWindowSum",
-      "charge_median_cut_outliers": [-0.5,0.5],
-       "charge_std_cut_outliers": [-10,10],
-     "time_cut_outliers": [2,38]
-   },
-     "LSTR0Corrections": {
-      "r1_sample_start": 2,
-       "tel_id":1,
-      "r1_sample_end": 38
-   },
-     "TimeCorrectionCalculate": {
-       "tel_id":1,
-       "charge_product":"LocalPeakWindowSum"
-   },
-    "LocalPeakWindowSum":{
-     "window_shift": 5,
-     "window_width":12
-    },
-    "FixedWindowSum":{
-     "window_start": 12,
-     "window_width":12
-    }
+    "sample_duration":100000,
+    "tel_id":1,
+    "charge_median_cut_outliers": [-10,10],
+    "charge_std_cut_outliers": [-10,10],
+    "charge_product":"FixedWindowSum"
+  },
+  "FlatFieldCalculator":{
+    "sample_duration":100000,
+    "tel_id":1,
+    "charge_product":"LocalPeakWindowSum",
+    "charge_median_cut_outliers": [-0.5,0.5],
+    "charge_std_cut_outliers": [-10,10],
+    "time_cut_outliers": [2,38]
+  },
+  "LSTR0Corrections": {
+    "r1_sample_start": 2,
+    "tel_id":1,
+    "r1_sample_end": 38
+  },
+  "TimeCorrectionCalculate": {
+    "tel_id":1,
+    "charge_product":"LocalPeakWindowSum"
+  },
+  "LocalPeakWindowSum":{
+    "window_shift": 5,
+    "window_width":12
+  },
+  "FixedWindowSum":{
+    "window_start": 12,
+    "window_width":12
+  }
 }

--- a/lstchain/mc/sensitivity.py
+++ b/lstchain/mc/sensitivity.py
@@ -5,11 +5,15 @@ from .plot_utils import sensitivity_minimization_plot, plot_positions_survived_e
 from .mc import rate, weight
 from lstchain.spectra.crab import crab_hegra,crab_magic
 from lstchain.spectra.proton import proton_bess
-from gammapy.stats import WStatCountsStatistic
 from lstchain.reco.utils import reco_source_position_sky
 from astropy.coordinates.angle_utilities import angular_separation
 from lstchain.io import read_simu_info_merged_hdf5
 from lstchain.io.io import dl2_params_lstcam_key
+try:
+    from gammapy.stats import WStatCountsStatistic
+except ImportError:
+    from gammapy.stats import wstat as WStatCountsStatistic
+
 
 __all__ = ['read_sim_par',
            'process_mc',

--- a/lstchain/mc/sensitivity.py
+++ b/lstchain/mc/sensitivity.py
@@ -9,10 +9,7 @@ from lstchain.reco.utils import reco_source_position_sky
 from astropy.coordinates.angle_utilities import angular_separation
 from lstchain.io import read_simu_info_merged_hdf5
 from lstchain.io.io import dl2_params_lstcam_key
-try:
-    from gammapy.stats import WStatCountsStatistic
-except ImportError:
-    from gammapy.stats import wstat as WStatCountsStatistic
+from gammapy.stats import WStatCountsStatistic
 
 
 __all__ = ['read_sim_par',

--- a/lstchain/reco/dl0_to_dl1.py
+++ b/lstchain/reco/dl0_to_dl1.py
@@ -221,11 +221,11 @@ def r0_to_dl1(input_filename = get_dataset_path('gamma_test_large.simtel.gz'),
 
         # TODO : add DRS4 calibration config in config file, read it and pass it here
         r0_r1_calibrator = LSTR0Corrections(pedestal_path = pedestal_path,
+                                            calibration_path=calibration_path,
                                             tel_id = 1)
 
         # all this will be cleaned up in a next PR related to the configuration files
-        r1_dl1_calibrator = LSTCameraCalibrator(calibration_path = calibration_path,
-                                                time_calibration_path = time_calibration_path,
+        r1_dl1_calibrator = LSTCameraCalibrator(time_calibration_path = time_calibration_path,
                                                 extractor_product = config['image_extractor'],
                                                 gain_threshold = Config(config).gain_selector_config['threshold'],
                                                 config = Config(config),
@@ -234,8 +234,7 @@ def r0_to_dl1(input_filename = get_dataset_path('gamma_test_large.simtel.gz'),
 
         # Pulse extractor for muon ring analysis. Same parameters (window_width and _shift) as the one for showers, but
         # using GlobalPeakWindowSum, since the signal for the rings is expected to be very isochronous
-        r1_dl1_calibrator_for_muon_rings = LSTCameraCalibrator(calibration_path = calibration_path,
-                                                               time_calibration_path = time_calibration_path,
+        r1_dl1_calibrator_for_muon_rings = LSTCameraCalibrator(time_calibration_path = time_calibration_path,
                                                                extractor_product = config['image_extractor_for_muons'],
                                                                gain_threshold = Config(config).gain_selector_config['threshold'],
                                                                config = Config(config),

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -10,8 +10,8 @@ Usage:
 import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.externals import joblib
 from sklearn.model_selection import train_test_split
+import joblib
 import os
 from . import utils
 from . import disp

--- a/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_mc_dl1_to_dl2.py
@@ -10,7 +10,7 @@ $> python lst-recopipe arg1 arg2 ...
 """
 
 from lstchain.reco import dl1_to_dl2
-from sklearn.externals import joblib
+import joblib
 import argparse
 import os
 import shutil

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -103,7 +103,7 @@ def test_build_models():
 
     reg_energy, reg_disp, cls_gh = build_models(infile, infile, custom_config=custom_config, save_models=False)
 
-    from sklearn.externals import joblib
+    import joblib
     joblib.dump(reg_energy, file_model_energy)
     joblib.dump(reg_disp, file_model_disp)
     joblib.dump(cls_gh, file_model_gh_sep)
@@ -112,7 +112,7 @@ def test_build_models():
 @pytest.mark.run(order=3)
 def test_apply_models():
     from lstchain.reco.dl1_to_dl2 import apply_models
-    from sklearn.externals import joblib
+    import joblib
 
     dl1 = pd.read_hdf(dl1_file, key=dl1_params_lstcam_key)
     dl1 = filter_events(dl1, filters=custom_config["events_filters"])

--- a/lstchain/tools/camera_calibration_param.json
+++ b/lstchain/tools/camera_calibration_param.json
@@ -17,7 +17,7 @@
   "PedestalCalculator":{
      "sample_size": 100,
      "sample_duration":1000,
-     "tel_id":0,
+     "tel_id":1,
      "charge_median_cut_outliers": [-5,5],
      "charge_std_cut_outliers": [-5,5],
      "charge_product":"FixedWindowSum"
@@ -25,7 +25,7 @@
     "FlatFieldCalculator":{
      "sample_size": 100,
      "sample_duration":1000,
-     "tel_id":0,
+     "tel_id":1,
       "charge_product":"LocalPeakWindowSum",
       "charge_median_cut_outliers": [-0.5,0.5],
       "charge_std_cut_outliers": [-5,5],
@@ -33,7 +33,7 @@
    },
      "LSTR0Corrections": {
       "pedestal_path": "/ctadata/franca/LST/pedestal_file_run446_0000.fits",
-      "tel_id": 0,
+      "tel_id": 1,
        "r1_sample_start": 2,
       "r1_sample_end": 38
    },

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
     install_requires=[
       'ctapipe',
       'h5py',
-      'seaborn'
+      'seaborn',
+      'joblib',
     ],
     package_data={
       'lstchain': ['data/lstchain_standard_config.json']

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
       'h5py',
       'seaborn',
       'joblib',
+      'gammapy>=0.17'
     ],
     package_data={
       'lstchain': ['data/lstchain_standard_config.json']

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
       'h5py',
       'seaborn',
       'joblib',
-      'gammapy>=0.17'
     ],
     package_data={
       'lstchain': ['data/lstchain_standard_config.json']


### PR DESCRIPTION
In the context of looking at stars in LST1 data ( https://indico.cta-observatory.org/event/2700/contributions/23482/attachments/17239/22795/pointing_300320_upload.pdf ), I have been looking at the calibration from R0 to R1.
I'm working with data from the 28th of February, and I corrected some small issues and warnings I found during the conversion of R0 to DL1.
To do the correction, I do:
```
lstchain_data_create_drs4_pedestal_file --input_file LST-1.1.Run02034.0000.fits.fz --output_file drs4_pedestal.fits
lstchain_data_create_calibration_file --input_file LST-1.1.Run02035.0000.fits.fz --output_file calibration.h5 --pedestal_file drs4_pedestal.fits --config lstchain/data/onsite_camera_calibration_param.json
lstchain_data_create_time_calibration_file --input_file LST-1.1.Run02035.0000.fits.fz -ped drs4_pedestal.fits --output_file time_calibration.fits
```
then I can finally do:
```
lstchain_data_r0_to_dl1 -f LST-1.1.Run02036.0000.fits.fz -o . -pedestal drs4_pedestal.fits -calib calibration.h5 -time_calib time_calibration.fits
```

I'm not sure which config to use for the calibration step as there are 2 which seems to be done for that: 
- lstchain/data/onsite_camera_calibration_param.json
- lstchain/tools/camera_calibration_param.json

Both gave error when I was using them and I fixed both, but it would be less confusing to have only one.

That PR is still a work in progress as I intend also to move the flat-fielding in the R0 to R1 step since for the study on the star we need calibrated wave-forms.  (I also believe R1 has to be flat-fielded as a CTA requirement)