### PR TITLE
forcing filters for dl1 dataset to enable compression

### DIFF
--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -274,6 +274,8 @@ def r0_to_dl1(
     )
 
     with writer:
+        # forcing filters for the dl1 dataset
+        writer._h5file.filters = filters
         print("USING FILTERS: ", writer._h5file.filters)
 
         for i, event in enumerate(source):
@@ -473,7 +475,7 @@ def r0_to_dl1(
                         image = tel.image*(~bad_pixels)
 
                         # process only promising events, in terms of # of pixels with large signals:
-                        if tag_pix_thr(image): 
+                        if tag_pix_thr(image):
 
                             # re-calibrate r1 to obtain new dl1, using a more adequate pulse integrator for muon rings
                             numsamples = event.r1.tel[telescope_id].waveform.shape[2] # not necessarily the same as in r0!

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -275,7 +275,7 @@ def r0_to_dl1(
 
     with writer:
         # Forcing filters for the dl1 dataset that are currently read from the pre-existing files
-        # This should be fixed in ctapipe and the corrected here
+        # This should be fixed in ctapipe and then corrected here
         writer._h5file.filters = filters
         print("USING FILTERS: ", writer._h5file.filters)
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -274,7 +274,8 @@ def r0_to_dl1(
     )
 
     with writer:
-        # forcing filters for the dl1 dataset
+        # Forcing filters for the dl1 dataset that are currently read from the pre-existing files
+        # This should be fixed in ctapipe and the corrected here
         writer._h5file.filters = filters
         print("USING FILTERS: ", writer._h5file.filters)
 


### PR DESCRIPTION
It seems that the `HDF5TableWriter` is reading the filters from the file if it already exists.
However, the writer is able to use filters per dataset, hence I could overwrite them after its instantiation. 
This will allow the compression and save ~10% of disk use.

Solves #352 