### PR TITLE
WIP modify __init__ files

### DIFF
--- a/lstchain/reco/__init__.py
+++ b/lstchain/reco/__init__.py
@@ -1,6 +1,70 @@
-from .utils import *
+from .utils import (
+    alt_to_theta,
+    az_to_phi,
+    cal_cam_source_pos,
+    get_event_pos_in_camera,
+    reco_source_position_sky,
+    camera_to_sky,
+    sky_to_camera,
+    source_side,
+    source_dx_dy,
+    polar_to_cartesian,
+    cartesian_to_polar,
+    predict_source_position_in_camera,
+    expand_tel_list,
+    filter_events,
+    linear_imputer,
+    impute_pointing,
+    clip_alt,
+    unix_tai_to_utc
+)
 from .r0_to_dl1 import get_dl1, add_disp_to_parameters_table
-from .dl1_to_dl2 import *
-from .volume_reducer import *
-from .disp import *
+from .dl1_to_dl2 import (
+    train_energy,
+    train_disp_norm,
+    train_disp_sign,
+    train_disp_vector,
+    train_reco,
+    train_sep,
+    build_models,
+    apply_models,
+    get_source_dependent_parameters,
+    get_expected_source_pos
+)
+from .volume_reducer import (
+    get_volume_reduction_method,
+    apply_volume_reduction,
+    zero_suppression_tailcut_dilation
+)
+from .disp import (
+    disp,
+    miss,
+    disp_parameters,
+    disp_parameters_event,
+    disp_vector,
+    disp_to_pos
+)
 
+__all__ = [
+    get_dl1,
+    add_disp_to_parameters_table,
+    train_energy,
+    train_disp_norm,
+    train_disp_sign,
+    train_disp_vector,
+    train_reco,
+    train_sep,
+    build_models,
+    apply_models,
+    get_source_dependent_parameters,
+    get_expected_source_pos,
+    get_volume_reduction_method,
+    apply_volume_reduction,
+    zero_suppression_tailcut_dilation,
+    disp,
+    miss,
+    disp_parameters,
+    disp_parameters_event,
+    disp_vector,
+    disp_to_pos,
+    ]


### PR DESCRIPTION
As discussed in #344, @MaxNoe requested to add `__all__` functions to the `__init__` files with wildcards for editors to be able to autocomplete these calls.

I explicitly added all the functions to the calls of `reco/__init__` and added `__all__` as well to the `__init__` file. If you are happy with this, I'll do it for the rest of the `__init__` files