### PR TITLE
Modify environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,5 @@ dependencies:
   - pip:
       - pytest_runner
       - pytest-ordering
-      - https://github.com/cta-observatory/ctapipe_io_lst/archive/v0.4.1.tar.gz
+      - git+git://github.com/cta-observatory/ctapipe_io_lst@v0.4.1
+

--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,4 @@ dependencies:
   - pip:
       - pytest_runner
       - pytest-ordering
-      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
       - https://github.com/cta-observatory/ctapipe_io_lst/archive/v0.4.1.tar.gz


### PR DESCRIPTION
1. Eliminate `protozfitsreader` since it is already included in [ctapipe_io_lst](https://github.com/cta-observatory/ctapipe_io_lst/blob/240ae6f8ce3b7c09ea855f779077d592f4049ec5/py3.6_env.yaml#L34)
2. As found by @MaxNoe, include the installation of `ctapipe_io_lst` that conserves the automatic versioning from git