### PR TITLE
Fix python versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
 install:
     - conda env create --file environment.yml
     - conda activate lst-dev
+    - python --version
     - |
       pip install \
       https://github.com/cta-observatory/ctapipe/archive/$CTAPIPE_VERSION.tar.gz \

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
     - conda info -a  # Useful for debugging any issues with conda
 
 install:
+    - sed -i -e "s/- python=.*/python=$TRAVIS_PYTHON_VERSION/g" environment.yaml
     - conda env create --file environment.yml
     - conda activate lst-dev
     - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
     - conda info -a  # Useful for debugging any issues with conda
 
 install:
-    - sed -i -e "s/- python=.*/python=$TRAVIS_PYTHON_VERSION/g" environment.yml
+    - sed -i -e "s/- python=.*/- python=$TRAVIS_PYTHON_VERSION/g" environment.yml
     - conda env create --file environment.yml
     - conda activate lst-dev
     - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
     - conda info -a  # Useful for debugging any issues with conda
 
 install:
-    - sed -i -e "s/- python=.*/python=$TRAVIS_PYTHON_VERSION/g" environment.yaml
+    - sed -i -e "s/- python=.*/python=$TRAVIS_PYTHON_VERSION/g" environment.yml
     - conda env create --file environment.yml
     - conda activate lst-dev
     - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 ---
 language: python
 
+env:
+  global:
+    - PYTHONIOENCODING=UTF8
+    - MPLBACKEND=Agg
+    - PYTEST_ADDOPTS='--color=yes'
+
+
 python:
     - 3.6
     - 3.7
@@ -15,11 +22,6 @@ matrix:
 
 
 before_install:
-    # Use utf8 encoding. Should be default, but this is insurance
-    # against future changes
-    - export PYTHONIOENCODING=UTF8
-    - export MPLBACKEND=Agg
-
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     - bash miniconda.sh -b -p $HOME/miniconda
     - . $HOME/miniconda/etc/profile.d/conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,35 @@ env:
     - PYTEST_ADDOPTS='--color=yes'
 
 
-python:
-    - 3.6
-    - 3.7
-
-env:
-    - CTAPIPE_VERSION="v0.7.0" CTAPIPE_IO_LST_VERSION="v0.4.1" PROTOZFITS_VERSION=v1.4.2
-    - CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master" PROTOZFITS_VERSION="master"
-
 matrix:
+  include:
+    - name: "python=3.6, ctapipe=0.7"
+      python: 3.6
+      env:
+        - CTAPIPE_VERSION="v0.7.0"
+        - CTAPIPE_IO_LST_VERSION="v0.4.1"
+
+    - name: "python=3.7, ctapipe=0.7"
+      python: 3.7
+      env:
+        - CTAPIPE_VERSION="v0.7.0"
+        - CTAPIPE_IO_LST_VERSION="v0.4.1"
+
+    - name: "python=3.6, ctapipe=master"
+      python: 3.6
+      env:
+        - CTAPIPE_VERSION="master"
+        - CTAPIPE_IO_LST_VERSION="master"
+
+    - name: "python=3.7, ctapipe=master"
+      python: 3.7
+      env:
+        - CTAPIPE_VERSION="master"
+        - CTAPIPE_IO_LST_VERSION="master"
+
   allow_failures:
-      - env: CTAPIPE_VERSION="master" CTAPIPE_IO_LST_VERSION="master" PROTOZFITS_VERSION="master"
+    - name: "python=3.6, ctapipe=master"
+    - name: "python=3.7, ctapipe=master"
 
 
 before_install:

--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,3 @@ dependencies:
       - pytest_runner
       - pytest-ordering
       - git+git://github.com/cta-observatory/ctapipe_io_lst@v0.4.1
-

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - cta-observatory
   - conda-forge
 dependencies:
+  - python=3.7
   - pip
   - ctapipe=0.7.0
   - gammapy>=0.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ url=https://github.com/cta-observatory/cta-lstchain
 long_description = file: README.md
 long_description_content_type = text/markdown
 github_project = cta-observatory/cta-lstchain
+
+[options]
+python_requires = >=3.6


### PR DESCRIPTION
Travis was not actually testing different python versions, because we install anaconda and don't make sure which python version was installed using anaconda, so it was always what came with miniconda.

Currently 3.7.