### PR TITLE
Add missing requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,15 +41,20 @@ setup(
     py_modules='version',
     install_requires=[
         'astropy',
-        'ctapipe',
+        'ctapipe~=0.7.0',
+        'distutils',
+        'eventio~=1.0',
         'gammapy>=0.17',
         'h5py',
+        'matplotlib',
         'numba',
         'numpy',
         'pandas',
         'scipy',
         'seaborn',
+        'sklearn',
         'tables',
+        'traitlets',
     ],
     package_data={
       'lstchain': ['data/lstchain_standard_config.json']

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
     install_requires=[
         'astropy',
         'ctapipe~=0.7.0',
-        'distutils',
         'eventio~=1.0',
         'gammapy>=0.17',
         'h5py',


### PR DESCRIPTION
Note: I did not add ctapipe_io_lst as this would prevent the pypi upload, as currently ctapipe_io_lst cannot be uploaded to pypi.