### PR TITLE
Solve dl2 and dl1_src_dependent writing

### DIFF
--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -144,7 +144,7 @@ def main():
 
                 h5in.copy_node(k, g, overwrite=True)
 
-    write_dl2_dataframe(dl2.astype(float), output_file)
+    write_dl2_dataframe(dl2, output_file)
 
 if __name__ == '__main__':
     main()

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -34,7 +34,8 @@ from lstchain.io import (
 from lstchain.io.io import (
     dl1_params_lstcam_key,
     dl1_params_src_dep_lstcam_key,
-    dl1_images_lstcam_key
+    dl1_images_lstcam_key,
+    dl2_params_lstcam_key,
 )
 
 
@@ -121,12 +122,13 @@ def main():
     dl1_keys.remove(dl1_images_lstcam_key)
     dl1_keys.remove(dl1_params_lstcam_key)
 
-    if config['source_dependent']:
+    if dl1_params_src_dep_lstcam_key in dl1_keys:
         dl1_keys.remove(dl1_params_src_dep_lstcam_key)
 
     with open_file(args.input_file, 'r') as h5in:
         with open_file(output_file, 'a') as h5out:
 
+            # Write the selected DL1 info
             for k in dl1_keys:
                 if not k.startswith('/'):
                     k = '/' + k
@@ -142,6 +144,7 @@ def main():
 
                 h5in.copy_node(k, g, overwrite=True)
 
+    write_dl2_dataframe(dl2.astype(float), output_file)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
With #384, and discussing what was the best way to write the DL1 info and which one to write in the DL2 file, we actually forgot to write the DL2 information (!)
Also now, if src_dependent parameters are present in the DL1 file, they are removed in the DL2 one (regardless of whether they are used or not in the dl1_to_dl2 passage) 