### PR TITLE
Try to find out why codecov not working for scripts on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,14 @@ install:
       pip install \
       https://github.com/cta-observatory/ctapipe/archive/$CTAPIPE_VERSION.tar.gz \
       https://github.com/cta-observatory/ctapipe_io_lst/archive/$CTAPIPE_IO_LST_VERSION.tar.gz \
-      pytest-cov codecov
+      pytest pytest-cov codecov
     - pip install .
+    - hash -r
+    - which pytest
 
 
 script:
+    - which pytest
     - pytest --cov lstchain --cov-report=xml lstchain
 
 after_success:


### PR DESCRIPTION
Codecov does not report any diff coverage for #397, but locally it works. I try to find out why.