### PR TITLE
Solve matplotlib style problem that was making labels non-legible

### DIFF
--- a/lstchain/__init__.py
+++ b/lstchain/__init__.py
@@ -11,5 +11,3 @@ from .io import standard_config
 from .version import get_version
 __version__ = get_version(pep440=False)
 
-import matplotlib as mpl
-mpl.style.use('default')

--- a/lstchain/__init__.py
+++ b/lstchain/__init__.py
@@ -12,4 +12,4 @@ from .version import get_version
 __version__ = get_version(pep440=False)
 
 import matplotlib as mpl
-mpl.use.style('default')
+mpl.style.use('default')

--- a/lstchain/__init__.py
+++ b/lstchain/__init__.py
@@ -10,3 +10,6 @@ from .io import standard_config
 
 from .version import get_version
 __version__ = get_version(pep440=False)
+
+import matplotlib as mpl
+mpl.use.style('default')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ from version import get_version, update_release_version  # noqa
 update_release_version()
 version = get_version()
 
-
 def find_scripts(script_dir, prefix):
     script_list = [
         os.path.splitext(f)[0]
@@ -42,7 +41,7 @@ setup(
     install_requires=[
         'astropy',
         'ctapipe~=0.7.0',
-        'ctaplot~=0.5.0',
+        'ctaplot~=0.5.2',
         'eventio~=0.20.3',
         'gammapy>=0.17',
         'h5py',


### PR DESCRIPTION
Solution to work out the problem with the matplotlib style/backend that was described in #401. While this is worked out, these lines should force the matplotlib style to the 'default' one, that was working before for all the plotting. 
