### PR TITLE
bug fix for the replacement of dl1 suffix

### DIFF
--- a/lstchain/paths.py
+++ b/lstchain/paths.py
@@ -204,4 +204,4 @@ def r0_to_dl1_filename(r0_path):
         r0_path, *exts = r0_path.rsplit(ext, 1)
 
     p = Path(r0_path)
-    return p.with_name('dl1_' + p.name).with_suffix('.h5')
+    return p.with_name('dl1_' + p.name + '.h5')

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -82,11 +82,8 @@ def main():
     data = pd.read_hdf(args.input_file, key=dl1_params_lstcam_key)
 
     if config['source_dependent']:
-        data_src_dep = pd.read_hdf(args.datafile, key=dl1_params_src_dep_lstcam_key)
-        data_src_dep = data_src_dep.set_index('index', drop=True)
+        data_src_dep = pd.read_hdf(args.input_file, key=dl1_params_src_dep_lstcam_key)
         data = pd.concat([data, data_src_dep], axis=1)
-
-
   
     # Dealing with pointing missing values. This happened when `ucts_time` was invalid.
     if 'alt_tel' in data.columns and 'az_tel' in data.columns \

--- a/lstchain/tests/test_paths.py
+++ b/lstchain/tests/test_paths.py
@@ -128,4 +128,6 @@ def test_r0_to_dl1_filename():
 
     assert str(r0_to_dl1_filename('/foo/test.simtel.gz')) == '/foo/dl1_test.h5'
     assert str(r0_to_dl1_filename('test.simtel')) == 'dl1_test.h5'
+    assert str(r0_to_dl1_filename('test.test.simtel.gz')) == 'dl1_test.test.h5'
     assert str(r0_to_dl1_filename('LST1_custom.fits.fz')) == 'dl1_LST1_custom.h5'
+    assert str(r0_to_dl1_filename('LST1_custom.test.fits.fz')) == 'dl1_LST1_custom.test.h5'


### PR DESCRIPTION
When using `r0_to_dl1_filename`, it seems another segment is removed by using `with_suffix` .

```
>>> from lstchain.paths import r0_to_dl1_filename
/fefs/aswg/workspace/seiya.nozaki/Install/anaconda3/envs/lst-dev/lib/python3.7/site-packages/corsikaio/subblocks/dtypes.py:20: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  return np.dtype(dict(**dt))
>>> r0_to_dl1_filename("/fefs/onsite/data/20200117/LST-1.1.Run01817.0000.fits.fz")
PosixPath('/fefs/onsite/data/20200117/dl1_LST-1.1.Run01817.h5')
>>> r0_to_dl1_filename("/fefs/aswg/workspace/MC_common/corsika6.9_simtelarray_2018-11-07/LST4_monotrigger/prod3/gamma/gamma_offaxis0.4deg_20190415/North_pointing/Data/gamma_20deg_0deg_run1___cta-prod3-demo-2147m-LaPalma-baseline-mono_off0.4.simtel.gz")
PosixPath('/fefs/aswg/workspace/MC_common/corsika6.9_simtelarray_2018-11-07/LST4_monotrigger/prod3/gamma/gamma_offaxis0.4deg_20190415/North_pointing/Data/dl1_gamma_20deg_0deg_run1___cta-prod3-demo-2147m-LaPalma-baseline-mono_off0.h5')
```

Here I just replaced `with_suffix` with `+`.