### PR TITLE
Fix src dependent

### DIFF
--- a/lstchain/data/lstchain_src_dep_config.json
+++ b/lstchain/data/lstchain_src_dep_config.json
@@ -5,7 +5,7 @@
     "length": [0, Infinity],
     "wl": [0, 1],
     "r": [0, 1],
-    "leakage": [0, 1]
+    "leakage2_intensity": [0, 1]
   },
 
   "tailcut": {
@@ -62,7 +62,7 @@
     "skewness_from_source",
     "kurtosis",
     "time_gradient_from_source",
-    "leakage",
+    "leakage2_intensity",
     "n_islands",
     "dist"
   ],
@@ -75,7 +75,7 @@
     "skewness_from_source",
     "kurtosis",
     "time_gradient_from_source",
-    "leakage",
+    "leakage2_intensity",
     "n_islands",
     "log_reco_energy",
     "dist"

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -83,7 +83,6 @@ def main():
 
     if config['source_dependent']:
         data_src_dep = pd.read_hdf(args.input_file, key=dl1_params_src_dep_lstcam_key)
-        #data_src_dep = data_src_dep.set_index('index', drop=True)
         data = pd.concat([data, data_src_dep], axis=1)
 
 

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -82,8 +82,8 @@ def main():
     data = pd.read_hdf(args.input_file, key=dl1_params_lstcam_key)
 
     if config['source_dependent']:
-        data_src_dep = pd.read_hdf(args.datafile, key=dl1_params_src_dep_lstcam_key)
-        data_src_dep = data_src_dep.set_index('index', drop=True)
+        data_src_dep = pd.read_hdf(args.input_file, key=dl1_params_src_dep_lstcam_key)
+        #data_src_dep = data_src_dep.set_index('index', drop=True)
         data = pd.concat([data, data_src_dep], axis=1)
 
 


### PR DESCRIPTION
There was a small bug on the `lstchain_dl1_to_dl2.py` script that did not allow to process data using src_dependent analysis. I also got problems with `data_src_dep.set_index('index', drop=True)` why was this line there @SeiyaNozaki?

I also updated the src_dependent input card, that still had some old variables defined.