### PR TITLE
Fix method camera_to_sky for real events

### DIFF
--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -15,6 +15,11 @@ def test_camera_to_sky():
     np.testing.assert_allclose(sky_coords.alt, pointing_alt, rtol=1e-4)
     np.testing.assert_allclose(sky_coords.az, pointing_az, rtol=1e-4)
 
+    # Test for real event with a time
+    obs_time = Time('2018-11-01T02:00', '2018-11-01T02:00')
+    sky_coords = utils.camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az, time = obs_time)
+    np.testing.assert_allclose(sky_coords.alt, pointing_alt, rtol=1e-4)
+    np.testing.assert_allclose(sky_coords.az, pointing_az, rtol=1e-4)
 
 def test_reco_source_position_sky():
     cog_x = np.array([2, 1]) * u.m

--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -5,19 +5,19 @@ import numpy as np
 import pandas as pd
 
 
-def test_camera_to_altaz_frame():
+def test_camera_to_altaz():
     pos_x = np.array([0, 0]) * u.m
     pos_y = np.array([0, 0]) * u.m
     focal = 28*u.m
     pointing_alt = np.array([1.0, 1.0]) * u.rad
     pointing_az = np.array([0.2, 0.5]) * u.rad
-    sky_coords = utils.camera_to_altaz_frame(pos_x, pos_y, focal, pointing_alt, pointing_az)
+    sky_coords = utils.camera_to_altaz(pos_x, pos_y, focal, pointing_alt, pointing_az)
     np.testing.assert_allclose(sky_coords.alt, pointing_alt, rtol=1e-4)
     np.testing.assert_allclose(sky_coords.az, pointing_az, rtol=1e-4)
 
     # Test for real event with a time
     obs_time = Time('2018-11-01T02:00', '2018-11-01T02:00')
-    sky_coords = utils.camera_to_altaz_frame(pos_x, pos_y, focal, pointing_alt, pointing_az, time = obs_time)
+    sky_coords = utils.camera_to_altaz(pos_x, pos_y, focal, pointing_alt, pointing_az, obstime = obs_time)
     np.testing.assert_allclose(sky_coords.alt, pointing_alt, rtol=1e-4)
     np.testing.assert_allclose(sky_coords.az, pointing_az, rtol=1e-4)
 

--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -5,19 +5,19 @@ import numpy as np
 import pandas as pd
 
 
-def test_camera_to_sky():
+def test_camera_to_altaz_frame():
     pos_x = np.array([0, 0]) * u.m
     pos_y = np.array([0, 0]) * u.m
     focal = 28*u.m
     pointing_alt = np.array([1.0, 1.0]) * u.rad
     pointing_az = np.array([0.2, 0.5]) * u.rad
-    sky_coords = utils.camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az)
+    sky_coords = utils.camera_to_altaz_frame(pos_x, pos_y, focal, pointing_alt, pointing_az)
     np.testing.assert_allclose(sky_coords.alt, pointing_alt, rtol=1e-4)
     np.testing.assert_allclose(sky_coords.az, pointing_az, rtol=1e-4)
 
     # Test for real event with a time
     obs_time = Time('2018-11-01T02:00', '2018-11-01T02:00')
-    sky_coords = utils.camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az, time = obs_time)
+    sky_coords = utils.camera_to_altaz_frame(pos_x, pos_y, focal, pointing_alt, pointing_az, time = obs_time)
     np.testing.assert_allclose(sky_coords.alt, pointing_alt, rtol=1e-4)
     np.testing.assert_allclose(sky_coords.az, pointing_az, rtol=1e-4)
 

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -203,16 +203,24 @@ def reco_source_position_sky(cog_x, cog_y, disp_dx, disp_dy, focal_length, point
     return camera_to_sky(src_x, src_y, focal_length, pointing_alt, pointing_az)
 
 
-def camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az):
+def camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az, time = None):
     """
+    Compute camera to SkyCoord. For MC assume the default ObsTime.
 
     Parameters
     ----------
-    pos_x: X coordinate in camera (distance)
-    pos_y: Y coordinate in camera (distance)
-    focal: telescope focal (distance)
-    pointing_alt: pointing altitude in angle unit
-    pointing_az: pointing altitude in angle unit
+    pos_x: `~astropy.units.Quantity`
+        X coordinate in camera (distance)
+    pos_y: `~astropy.units.Quantity`
+        Y coordinate in camera (distance)
+    focal: `~astropy.units.Quantity`
+        telescope focal (distance)
+    pointing_alt: `~astropy.units.Quantity`
+        pointing altitude in angle unit
+    pointing_az: `~astropy.units.Quantity`
+        pointing altitude in angle unit
+    time: `~astropy.time.Time`
+
 
     Returns
     -------
@@ -230,6 +238,13 @@ def camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az):
     sky_coords = utils.camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az)
 
     """
+
+    if time:
+        horizon_frame = AltAz(location=location, obstime=time)
+    else:
+        horizon_frame = AltAz(location=location, obstime=obstime)
+        print("No time given, use default observation time. To be use only for MC data.")
+
     pointing_direction = SkyCoord(alt=clip_alt(pointing_alt), az=pointing_az, frame=horizon_frame)
 
     camera_frame = CameraFrame(focal_length=focal, telescope_pointing=pointing_direction)

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -236,7 +236,7 @@ def camera_to_altaz(pos_x, pos_y, focal, pointing_alt, pointing_az, obstime = No
     focal = 28*u.m
     pointing_alt = np.array([1.0, 1.0]) * u.rad
     pointing_az = np.array([0.2, 0.5]) * u.rad
-    sky_coords = utils.camera_to_altaz_frame(pos_x, pos_y, focal, pointing_alt, pointing_az)
+    sky_coords = utils.camera_to_altaz(pos_x, pos_y, focal, pointing_alt, pointing_az)
 
     """
     if not obstime:

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -240,7 +240,7 @@ def camera_to_altaz(pos_x, pos_y, focal, pointing_alt, pointing_az, obstime = No
 
     """
     if not obstime:
-        logging.warning("No time given. To be use only for MC data.")
+        logging.info("No time given. To be use only for MC data.")
     horizon_frame = AltAz(location=location, obstime=obstime)
 
     pointing_direction = SkyCoord(alt=clip_alt(pointing_alt), az=pointing_az, frame=horizon_frame)

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -26,7 +26,7 @@ __all__ = [
     'cal_cam_source_pos',
     'get_event_pos_in_camera',
     'reco_source_position_sky',
-    'camera_to_sky',
+    'camera_to_altaz_frame',
     'sky_to_camera',
     'source_side',
     'source_dx_dy',
@@ -200,12 +200,12 @@ def reco_source_position_sky(cog_x, cog_y, disp_dx, disp_dy, focal_length, point
     sky frame: `astropy.coordinates.sky_coordinate.SkyCoord`
     """
     src_x, src_y = disp.disp_to_pos(disp_dx, disp_dy, cog_x, cog_y)
-    return camera_to_sky(src_x, src_y, focal_length, pointing_alt, pointing_az)
+    return camera_to_altaz_frame(src_x, src_y, focal_length, pointing_alt, pointing_az)
 
 
-def camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az, time = None):
+def camera_to_altaz_frame(pos_x, pos_y, focal, pointing_alt, pointing_az, time = None):
     """
-    Compute camera to SkyCoord. For MC assume the default ObsTime.
+    Compute camera to Horizontal frame (Altitude-Azimuth system). For MC assume the default ObsTime.
 
     Parameters
     ----------
@@ -224,8 +224,8 @@ def camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az, time = None):
 
     Returns
     -------
-    sky frame: `astropy.coordinates.sky_coordinate.SkyCoord`
-
+    sky frame: `astropy.coordinates.AltAz`
+        horizontal frame (AltAz)
     Example:
     --------
     import astropy.units as u
@@ -235,7 +235,7 @@ def camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az, time = None):
     focal = 28*u.m
     pointing_alt = np.array([1.0, 1.0]) * u.rad
     pointing_az = np.array([0.2, 0.5]) * u.rad
-    sky_coords = utils.camera_to_sky(pos_x, pos_y, focal, pointing_alt, pointing_az)
+    sky_coords = utils.camera_to_altaz_frame(pos_x, pos_y, focal, pointing_alt, pointing_az)
 
     """
 

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -44,8 +44,8 @@ __all__ = [
 
 # position of the LST1
 location = EarthLocation.from_geodetic(-17.89139 * u.deg, 28.76139 * u.deg, 2184 * u.m)
-obstime_mc = Time('2018-11-01T02:00')
-horizon_frame = AltAz(location=location, obstime=obstime_mc)
+obstime = Time('2018-11-01T02:00')
+horizon_frame = AltAz(location=location, obstime=obstime)
 UCTS_EPOCH = Time('1970-01-01T00:00:00', scale='tai', format='isot')
 INVALID_TIME = UCTS_EPOCH
 
@@ -239,12 +239,9 @@ def camera_to_altaz(pos_x, pos_y, focal, pointing_alt, pointing_az, obstime = No
     sky_coords = utils.camera_to_altaz_frame(pos_x, pos_y, focal, pointing_alt, pointing_az)
 
     """
-
-    if obstime:
-        horizon_frame = AltAz(location=location, obstime=obstime)
-    else:
-        horizon_frame = AltAz(location=location, obstime=obstime_mc)
-        logging.warning("No time given, use default observation time. To be use only for MC data.")
+    if not obstime:
+        logging.warning("No time given. To be use only for MC data.")
+    horizon_frame = AltAz(location=location, obstime=obstime)
 
     pointing_direction = SkyCoord(alt=clip_alt(pointing_alt), az=pointing_az, frame=horizon_frame)
 

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -214,7 +214,7 @@ def test_disp_to_pos():
 
 
 def test_change_frame_camera_sky():
-    from lstchain.reco.utils import sky_to_camera, camera_to_altaz_frame
+    from lstchain.reco.utils import sky_to_camera, camera_to_altaz
     import astropy.units as u
     x = np.random.rand(1) * u.m
     y = np.random.rand(1) * u.m
@@ -222,7 +222,7 @@ def test_change_frame_camera_sky():
     pointing_alt = np.pi/3. * u.rad
     pointing_az = 0. * u.rad
 
-    sky_pos = camera_to_altaz_frame(x, y, focal_length, pointing_alt, pointing_az)
+    sky_pos = camera_to_altaz(x, y, focal_length, pointing_alt, pointing_az)
     cam_pos = sky_to_camera(sky_pos.alt, sky_pos.az, focal_length, pointing_alt, pointing_az)
     np.testing.assert_almost_equal([x, y], [cam_pos.x, cam_pos.y], decimal=4)
 

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -214,7 +214,7 @@ def test_disp_to_pos():
 
 
 def test_change_frame_camera_sky():
-    from lstchain.reco.utils import sky_to_camera, camera_to_sky
+    from lstchain.reco.utils import sky_to_camera, camera_to_altaz_frame
     import astropy.units as u
     x = np.random.rand(1) * u.m
     y = np.random.rand(1) * u.m
@@ -222,7 +222,7 @@ def test_change_frame_camera_sky():
     pointing_alt = np.pi/3. * u.rad
     pointing_az = 0. * u.rad
 
-    sky_pos = camera_to_sky(x, y, focal_length, pointing_alt, pointing_az)
+    sky_pos = camera_to_altaz_frame(x, y, focal_length, pointing_alt, pointing_az)
     cam_pos = sky_to_camera(sky_pos.alt, sky_pos.az, focal_length, pointing_alt, pointing_az)
     np.testing.assert_almost_equal([x, y], [cam_pos.x, cam_pos.y], decimal=4)
 


### PR DESCRIPTION
This PR fix the problem in the method computing camera_to_sky for event to take properly into account the time of the observation in the computation.

For the moment, just use time if provided and the default obs time in utils if not printing a warning.

I think the solution to use HA/DEC for MC event instead of RA/DEC should be done in another method when you compute ra/dec for those SkyCoords. For example, if I read correctly to compute the HA from RA, we need to extract the sideral time from the obs time and the location.
```obstime = sky_coords.obstime.value
scale_time = sky_coords.obstime.scale
longitude = sky_coords.location.longitude
latitude = sky_coords.location.latitude
time=Time(obstime, scale, location=(longitude, latitude)
HA = sky_coords.icrs.ra.to("hourangle") -time.sidereal_time("apparent")
dec = sky_coords.icrs.dec
```

Also I need to improve the test to add a check on a ra/dec value when we add the time.