### PR TITLE
Correct LSTR0Corrections cards for calibration script

### DIFF
--- a/lstchain/data/onsite_camera_calibration_param.json
+++ b/lstchain/data/onsite_camera_calibration_param.json
@@ -31,9 +31,7 @@
      "time_cut_outliers": [2,38]
    },
    "LSTR0Corrections": {
-      "r1_sample_start": 2,
-      "tel_id":1,
-      "r1_sample_end": 38
+      "tel_id":1
    },
    "TimeCorrectionCalculate": {
        "tel_id":1,

--- a/lstchain/visualization/plot_drs4.py
+++ b/lstchain/visualization/plot_drs4.py
@@ -44,7 +44,7 @@ def plot_pedestals(data_file, pedestal_file, run=0 , plot_file="none", tel_id=1,
 
     # r0 calibrator
     r0_calib = LSTR0Corrections(pedestal_path=pedestal_file, offset=offset_value,
-                                r1_sample_start=2, r1_sample_end=38, tel_id=tel_id )
+                                tel_id=tel_id )
 
     # event_reader
     reader = event_source(data_file, max_events=1000)


### PR DESCRIPTION
Keep default trailets values for the selection of the R0 waveform samples to be used for the R1 waveform. Before the firmware upgrade of November, values were
 "r1_sample_start": 2,
 "r1_sample_end": 38

After, they should be: 
"r1_sample_start": 3,
 "r1_sample_end": 39

A test did not show major changes in the calibration results