### PR TITLE
Set up environment of the lstchain_ctapipe0.8 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,16 @@ env:
 
 matrix:
   include:
-    - name: "python=3.6, ctapipe=0.7"
+    - name: "python=3.6, ctapipe=0.8"
       python: 3.6
       env:
-        - CTAPIPE_VERSION="v0.7.0"
+        - CTAPIPE_VERSION="v0.8.0"
         - CTAPIPE_IO_LST_VERSION="v0.4.1"
 
-    - name: "python=3.7, ctapipe=0.7"
+    - name: "python=3.7, ctapipe=0.8"
       python: 3.7
       env:
-        - CTAPIPE_VERSION="v0.7.0"
+        - CTAPIPE_VERSION="v0.8.0"
         - CTAPIPE_IO_LST_VERSION="v0.4.1"
 
     - name: "python=3.6, ctapipe=master"

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.7
   - pip
-  - ctapipe=0.7.0
+  - ctapipe=0.8.0
   - gammapy>=0.17
   - h5py
   - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: lst-dev
+name: lst-dev-ctapipe0.8
 channels:
   - default
   - cta-observatory

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'astropy',
-        'ctapipe~=0.7.0',
+        'ctapipe~=0.8.0',
         'ctaplot~=0.5.3',
         'eventio~=0.20.3',
         'gammapy>=0.17',

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,10 @@ setup(
     version=version,
     packages=find_packages(),
     install_requires=[
-        'astropy',
+        "astropy>=3,<5",
         'ctapipe~=0.8.0',
         'ctaplot~=0.5.3',
-        'eventio~=0.20.3',
+        "eventio>=1.1.1,<2.0.0a0",  # at least 1.1.1, but not 2
         'gammapy>=0.17',
         'h5py',
         'matplotlib',


### PR DESCRIPTION
Setting up new environment and updating travis and environment variables with the new software versions.
Notice that this PR has as a target the branch `lstchain_ctapipe0.8`, the development branch that will contain the changes to update to ctapipe v0.8