### PR TITLE
Fix lstcontainers call

### DIFF
--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -17,7 +17,10 @@ __all__ = [
     'DL1MonitoringEventIndexContainer',
     'DL1ParametersContainer',
     'DispContainer',
-    'LSTEventType'
+    'ExtraImageInfo',
+    'ExtraMCInfo',
+    'ExtraMCInfo',
+    'LSTEventType',
     'MetaData',
     'ThrownEventsHistogram',
 ]


### PR DESCRIPTION
After sorting the lines, the last one ('LSTEventType') did not have a comma and when sorting, it moved to the middle of the list, throwing an error. 