### PR TITLE
write array info a la ctapipe v0.8

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -15,6 +15,7 @@ from eventio.search_utils import yield_toplevel_of_type
 from .lstcontainers import ThrownEventsHistogram, ExtraMCInfo, MetaData
 from tqdm import tqdm
 from ctapipe.tools.stage1 import Stage1ProcessorTool
+from astropy.utils import deprecated
 
 
 __all__ = ['read_simu_info_hdf5',
@@ -350,6 +351,7 @@ def write_mcheader(mcheader, output_filename, obs_id=None, filters=None, metadat
         writer.write("run_config", [extramc, mcheader])
 
 
+@deprecated('09/07/2020', message='this function will disappear in lstchain v0.7')
 def write_array_info_08(subarray, output_filename):
     """
     Write the array info to a ctapipe v0.8 compatible DL1 HDF5 file
@@ -364,6 +366,7 @@ def write_array_info_08(subarray, output_filename):
     stage1._write_instrument_configuration(subarray)
 
 
+@deprecated('09/07/2020', message='this function will disappear in lstchain v0.7')
 def write_array_info(subarray, output_filename):
     """
     Write the array info to a HDF5 file

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -14,6 +14,7 @@ from eventio import Histograms
 from eventio.search_utils import yield_toplevel_of_type
 from .lstcontainers import ThrownEventsHistogram, ExtraMCInfo, MetaData
 from tqdm import tqdm
+from ctapipe.tools.stage1 import Stage1ProcessorTool
 
 
 __all__ = ['read_simu_info_hdf5',
@@ -347,6 +348,20 @@ def write_mcheader(mcheader, output_filename, obs_id=None, filters=None, metadat
     with HDF5TableWriter(filename=output_filename, group_name="simulation", mode="a", filters=filters) as writer:
         extramc.obs_id = obs_id
         writer.write("run_config", [extramc, mcheader])
+
+
+def write_array_info_08(subarray, output_filename):
+    """
+    Write the array info to a ctapipe v0.8 compatible DL1 HDF5 file
+
+    Parameters
+    ----------
+    subarray: `ctapipe.instrument.subarray.SubarrayDescription`
+    output_filename: str
+    """
+    stage1 = Stage1ProcessorTool()
+    stage1.output_path = output_filename
+    stage1._write_instrument_configuration(subarray)
 
 
 def write_array_info(subarray, output_filename):

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -38,7 +38,7 @@ from ..io import DL1ParametersContainer, standard_config, replace_config
 from ..image.muon import analyze_muon_event, tag_pix_thr
 from ..image.muon import create_muon_table, fill_muon_event
 from ..paths import parse_r0_filename, run_to_dl1_filename, r0_to_dl1_filename
-
+from ..io.io import write_array_info_08
 from ..io import (
     write_simtel_energy_histogram,
     write_mcheader,
@@ -297,6 +297,7 @@ def r0_to_dl1(
 
     # Write extra information to the DL1 file
     write_array_info(subarray, output_filename)
+    write_array_info_08(subarray, output_filename)
 
     if is_simu:
         write_mcheader(


### PR DESCRIPTION
Double the info (small overhead) for now to not change the data format.
This is temporary for lstchain v0.6