### PR TITLE
Fix lstchain_rfperformance tests

### DIFF
--- a/lstchain/scripts/lstchain_mc_rfperformance.py
+++ b/lstchain/scripts/lstchain_mc_rfperformance.py
@@ -14,20 +14,18 @@ $>python lstchain_mc_rfperformance.py
 
 """
 
+import argparse
 import logging
 import sys
-import numpy as np
-import pandas as pd
-import argparse
+
 import matplotlib.pyplot as plt
-from distutils.util import strtobool
+import pandas as pd
+
+from lstchain.io import standard_config, replace_config, read_configuration_file
+from lstchain.io.io import dl1_params_lstcam_key
 from lstchain.reco import dl1_to_dl2
 from lstchain.reco.utils import filter_events
 from lstchain.visualization import plot_dl2
-from lstchain.reco import utils
-import astropy.units as u
-from lstchain.io import standard_config, replace_config, read_configuration_file
-from lstchain.io.io import dl1_params_lstcam_key
 
 try:
     import ctaplot

--- a/lstchain/scripts/lstchain_mc_rfperformance.py
+++ b/lstchain/scripts/lstchain_mc_rfperformance.py
@@ -14,6 +14,8 @@ $>python lstchain_mc_rfperformance.py
 
 """
 
+import logging
+import sys
 import numpy as np
 import pandas as pd
 import argparse
@@ -31,6 +33,8 @@ try:
     import ctaplot
 except ImportError as e:
     print("ctaplot not installed, some plotting function will be missing")
+
+log = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser(description="Train and Apply Random Forests.")
 
@@ -110,6 +114,10 @@ def main():
     ####PLOT SOME RESULTS#####
 
     selected_gammas = dl2.query('reco_type==0 & mc_type==0')
+
+    if(len(selected_gammas) == 0):
+        log.warning('No gammas selected, I will not plot any output') 
+        sys.exit()
 
     plot_dl2.plot_features(dl2)
     if not args.batch:

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -88,8 +88,12 @@ def test_lstchain_mc_trainpipe():
 @pytest.mark.run(after='test_lstchain_mc_r0_to_dl1')
 def test_lstchain_mc_rfperformance():
     gamma_file = dl1_file
-    produce_fake_dl1_proton_file()
+    produce_fake_dl1_proton_file(dl1_file)
+    #produce_fake_dl1_proton_file()
     proton_file = fake_dl1_proton_file
+
+    print('proton_file', proton_file)
+    print('gamma_file', gamma_file)
 
     run_program(
         'lstchain_mc_rfperformance',

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -90,11 +90,7 @@ def test_lstchain_mc_trainpipe():
 def test_lstchain_mc_rfperformance():
     gamma_file = dl1_file
     produce_fake_dl1_proton_file(dl1_file)
-    #produce_fake_dl1_proton_file()
     proton_file = fake_dl1_proton_file
-
-    print('proton_file', proton_file)
-    print('gamma_file', gamma_file)
 
     run_program(
         'lstchain_mc_rfperformance',

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -1,14 +1,15 @@
-import pytest
-import pandas as pd
 import os
-from lstchain.tests.test_lstchain import test_dir, mc_gamma_testfile, produce_fake_dl1_proton_file, fake_dl1_proton_file
-from lstchain.io.io import dl1_params_lstcam_key
-import numpy as np
-from lstchain.io.io import dl1_params_src_dep_lstcam_key
-import subprocess as sp
-import pkg_resources
 import shutil
+import subprocess as sp
 
+import numpy as np
+import pandas as pd
+import pkg_resources
+import pytest
+
+from lstchain.io.io import dl1_params_lstcam_key
+from lstchain.io.io import dl1_params_src_dep_lstcam_key
+from lstchain.tests.test_lstchain import test_dir, mc_gamma_testfile, produce_fake_dl1_proton_file, fake_dl1_proton_file
 
 output_dir = os.path.join(test_dir, 'scripts')
 dl1_file = os.path.join(output_dir, 'dl1_gamma_test_large.h5')

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -132,16 +132,16 @@ def test_apply_models():
     dl2 = apply_models(dl1, reg_cls_gh, reg_energy, reg_disp, custom_config=custom_config)
     dl2.to_hdf(dl2_file, key=dl2_params_lstcam_key)
 
-def produce_fake_dl1_proton_file():
+def produce_fake_dl1_proton_file(dl1_file):
     """
-    Produce a fake dl2 proton file by copying the dl2 gamma test file
+    Produce a fake dl1 proton file by copying the dl2 gamma test file
     and changing mc_type
     """
     events = pd.read_hdf(dl1_file, key=dl1_params_lstcam_key)
     events.mc_type = 101
     events.to_hdf(fake_dl1_proton_file, key=dl1_params_lstcam_key)
 
-def produce_fake_dl2_proton_file():
+def produce_fake_dl2_proton_file(dl2_file):
     """
     Produce a fake dl2 proton file by copying the dl2 gamma test file
     and changing mc_type
@@ -154,7 +154,7 @@ def produce_fake_dl2_proton_file():
 def test_sensitivity():
     from lstchain.mc.sensitivity import find_best_cuts_sensitivity, sensitivity 
 
-    produce_fake_dl2_proton_file()
+    produce_fake_dl2_proton_file(dl2_file)
 
     nfiles_gammas = 1
     nfiles_protons = 1

--- a/lstchain/visualization/plot_dl2.py
+++ b/lstchain/visualization/plot_dl2.py
@@ -4,27 +4,29 @@ Usage:
 "import plot_dl2"
 """
 import os
-import numpy as np
-import joblib
-import matplotlib.pyplot as plt
-from scipy.stats import norm
-from ..io.config import get_standard_config, read_configuration_file
-import ctaplot
+
 import astropy.units as u
-from astropy.table import Table
-from astropy.io.misc.hdf5 import write_table_hdf5, read_table_hdf5
+import ctaplot
+import joblib
 import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy.io.misc.hdf5 import write_table_hdf5, read_table_hdf5
+from astropy.table import Table
+from scipy.stats import norm
+
+from ..io.config import get_standard_config, read_configuration_file
 
 __all__ = [
-    'plot_features',
+    'direction_results',
+    'energy_results',
     'plot_disp',
     'plot_disp_vector',
+    'plot_energy_resolution',
+    'plot_features',
+    'plot_importances',
     'plot_pos',
     'plot_roc_gamma',
-    'plot_importances',
-    'plot_energy_resolution',
-    'energy_results',
-    'direction_results'
 ]
 
 


### PR DESCRIPTION
There were two problems that were making the tests from the `scripts` folder not to pass:
- If the `fake_proton_file` was created from that folder, since we relied on absolute paths wrt the `lstchain/tests` folder.
- If the number of `selected_gammas` in `lstchain_mc_rfperformance` was 0, the code was breaking.

Now tests pass also from inside the `scripts` folder and regardless of the input files used.