### PR TITLE
fix time_correction method name

### DIFF
--- a/lstchain/calib/camera/time_correction_calculate.py
+++ b/lstchain/calib/camera/time_correction_calculate.py
@@ -114,19 +114,19 @@ class TimeCorrectionCalculate(Component):
                     event.r1.tel[self.tel_id].waveform[:, :, :],
                     self.tel_id,
                     no_gain_selection)
-            self.calib_pulse_time_jit(charge,
-                                      peak_time,
-                                      pixel_ids,
-                                      self.first_cap_array,
-                                      self.mean_values_per_bin,
-                                      self.entries_per_bin,
-                                      n_cap=self.n_capacitors,
-                                      n_combine=self.n_combine,
-                                      min_charge=self.minimum_charge)
+            self.calib_peak_time_jit(charge,
+                                     peak_time,
+                                     pixel_ids,
+                                     self.first_cap_array,
+                                     self.mean_values_per_bin,
+                                     self.entries_per_bin,
+                                     n_cap=self.n_capacitors,
+                                     n_combine=self.n_combine,
+                                     min_charge=self.minimum_charge)
             self.sum_events += 1
 
     @staticmethod
-    @jit(parallel=True)
+    @njit(parallel=True)
     def calib_peak_time_jit(charge,
                              peak_time,
                              pixel_ids,


### PR DESCRIPTION
I found bug in `time_correction_calculate.py`- wrong method name to call. 