### PR TITLE
allow to use subruns to create time calib file

### DIFF
--- a/lstchain/scripts/lstchain_data_create_time_calibration_file.py
+++ b/lstchain/scripts/lstchain_data_create_time_calibration_file.py
@@ -17,7 +17,7 @@ import argparse
 import glob
 import numpy as np
 from traitlets.config.loader import Config
-from ctapipe.io import event_source
+from ctapipe_io_lst import LSTEventSource
 from lstchain.calib.camera.r0 import LSTR0Corrections
 from lstchain.io.config import read_configuration_file
 from lstchain.calib.camera.time_correction_calculate import TimeCorrectionCalculate
@@ -78,7 +78,7 @@ def main():
     # declare the pedestal calibrator
     lst_r0 = LSTR0Corrections(pedestal_path=args.pedestal_file, config=config)
 
-    reader = event_source(input_url=path_list[0], max_events=args.max_events)
+    reader = LSTEventSource(input_url=path_list[0], max_events=args.max_events)
     # declare the time corrector
     timeCorr = TimeCorrectionCalculate(calib_file_path=args.output_file,
                                        config=config,
@@ -88,7 +88,7 @@ def main():
 
     for path in path_list:
         print("--> Processing: {}".format(path))
-        reader = event_source(input_url=path, max_events=args.max_events)
+        reader = LSTEventSource(input_url=path, max_events=args.max_events)
         print("--> Number of files", reader.multi_file.num_inputs())
         for i, event in enumerate(reader):
             if event.index.event_id % 5000 == 0:

--- a/lstchain/scripts/lstchain_data_create_time_calibration_file.py
+++ b/lstchain/scripts/lstchain_data_create_time_calibration_file.py
@@ -95,7 +95,6 @@ def main():
         log.info(f'File {i+1} out of {len(path_list)}')
         log.info(f'Processing: {path}')
         reader = LSTEventSource(input_url=path, max_events=args.max_events)
-        log.info(f'Number of files in this subrun: {reader.multi_file.num_inputs()}')
         for event in reader:
             if event.index.event_id % 5000 == 0:
                 log.info(f'event id = {event.index.event_id}')


### PR DESCRIPTION
After discuss with @moralejo I have created PR for new version of script to create time calibration file with multi subruns. 
To do it: `python lstchain_data_create_time_calibration_file.py --input-file 'LST-1.1.Run01625.000*.fits.fz' --output-file time_calib_1625_multi.h5 --max-events 60000`
