### PR TITLE
Fix travis errors related to test_overlay_source

### DIFF
--- a/lstchain/visualization/tests/test_camera.py
+++ b/lstchain/visualization/tests/test_camera.py
@@ -19,7 +19,7 @@ def test_overlay_source():
     geom = CameraGeometry.from_name('LSTCam')
     image = np.random.rand(geom.n_pixels)
     display = CameraDisplay(geom, image)
-    overlay_source(display, 0.1 * u.m, 0.3 * u.m)
+    #overlay_source(display, 0.1 * u.m, 0.3 * u.m)
 
 
 def test_display_dl1_event():

--- a/lstchain/visualization/tests/test_camera.py
+++ b/lstchain/visualization/tests/test_camera.py
@@ -1,15 +1,17 @@
-import numpy as np
-from lstchain.visualization.camera import overlay_source, overlay_disp_vector, display_dl1_event
-from lstchain.reco.disp import disp_parameters_event
-from ctapipe.visualization import CameraDisplay
-from ctapipe.instrument import CameraGeometry
 import astropy.units as u
+import numpy as np
+from ctapipe.instrument import CameraGeometry
+from ctapipe.visualization import CameraDisplay
+
+from lstchain.reco.disp import disp_parameters_event
+from lstchain.visualization.camera import overlay_source, overlay_disp_vector, display_dl1_event
+
 
 def test_overlay_source():
     geom = CameraGeometry.from_name('LSTCam')
     image = np.random.rand(geom.n_pixels)
     display = CameraDisplay(geom, image)
-    #overlay_source(display, 0.1 * u.m, 0.3 * u.m)
+    overlay_source(display, 0.1 * u.m, 0.3 * u.m)
 
 
 def test_overlay_disp_vector():

--- a/lstchain/visualization/tests/test_camera.py
+++ b/lstchain/visualization/tests/test_camera.py
@@ -6,28 +6,27 @@ from ctapipe.instrument import CameraGeometry
 import astropy.units as u
 
 def test_overlay_disp_vector():
-
     from ctapipe.image import hillas_parameters
 
     geom = CameraGeometry.from_name('LSTCam')
     image = np.random.rand(geom.n_pixels)
     display = CameraDisplay(geom, image)
     hillas = hillas_parameters(geom, image)
-    disp = disp_parameters_event(hillas, 0.1*u.m, 0.3*u.m)
+    disp = disp_parameters_event(hillas, 0.1 * u.m, 0.3 * u.m)
     overlay_disp_vector(display, disp, hillas)
-
 
 def test_overlay_source():
     geom = CameraGeometry.from_name('LSTCam')
     image = np.random.rand(geom.n_pixels)
     display = CameraDisplay(geom, image)
-    overlay_source(display, 0.1, 0.3)
+    overlay_source(display, 0.1 * u.m, 0.3 * u.m)
 
 
 def test_display_dl1_event():
     from ctapipe.io import event_source, EventSeeker
     from lstchain.tests.test_lstchain import mc_gamma_testfile
     from ctapipe.calib import CameraCalibrator
+
     source = event_source(mc_gamma_testfile, back_seekable=True)
     seeker = EventSeeker(source)
     event = seeker[11]  # event 11 has telescopes 1 and 4 with data

--- a/lstchain/visualization/tests/test_camera.py
+++ b/lstchain/visualization/tests/test_camera.py
@@ -5,6 +5,13 @@ from ctapipe.visualization import CameraDisplay
 from ctapipe.instrument import CameraGeometry
 import astropy.units as u
 
+def test_overlay_source():
+    geom = CameraGeometry.from_name('LSTCam')
+    image = np.random.rand(geom.n_pixels)
+    display = CameraDisplay(geom, image)
+    #overlay_source(display, 0.1 * u.m, 0.3 * u.m)
+
+
 def test_overlay_disp_vector():
     from ctapipe.image import hillas_parameters
 
@@ -15,11 +22,6 @@ def test_overlay_disp_vector():
     disp = disp_parameters_event(hillas, 0.1 * u.m, 0.3 * u.m)
     overlay_disp_vector(display, disp, hillas)
 
-def test_overlay_source():
-    geom = CameraGeometry.from_name('LSTCam')
-    image = np.random.rand(geom.n_pixels)
-    display = CameraDisplay(geom, image)
-    #overlay_source(display, 0.1 * u.m, 0.3 * u.m)
 
 
 def test_display_dl1_event():


### PR DESCRIPTION
we've been experiencing some travis error related to the camera display, that could not be reproduced locally. I'll copy it down for bookkeeping. I've been doing some tests and apparently the order of the tests matter. For some reason, if we run the `test_overlay_source` after the `test_overlay_disp_vector`, the error appears. It is not clear to me yet what is the origin, but this PR fixes it.

```
_____________________________ test_overlay_source ______________________________
    def test_overlay_source():
        geom = CameraGeometry.from_name('LSTCam')
        image = np.random.rand(geom.n_pixels)
>       display = CameraDisplay(geom, image)
lstchain/visualization/tests/test_camera.py:23: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/ctapipe/visualization/mpl_camera.py:191: in __init__
    self.image = image
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/ctapipe/visualization/mpl_camera.py:322: in image
    self._update()
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/ctapipe/visualization/mpl_camera.py:327: in _update
    self.update(force)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/ctapipe/visualization/mpl_camera.py:331: in update
    self.axes.figure.canvas.draw()
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/backends/backend_agg.py:393: in draw
    self.figure.draw(self.renderer)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/artist.py:38: in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/figure.py:1736: in draw
    renderer, self, artists, self.suppressComposite)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/image.py:137: in _draw_list_compositing_images
    a.draw(renderer)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/artist.py:38: in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/axes/_base.py:2630: in draw
    mimage._draw_list_compositing_images(renderer, self, artists)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/image.py:137: in _draw_list_compositing_images
    a.draw(renderer)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/artist.py:38: in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/quiver.py:589: in draw
    verts = self._make_verts(self.U, self.V, self.angles)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/quiver.py:689: in _make_verts
    angles, lengths = self._angles_lengths(U, V, eps=eps)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/matplotlib/quiver.py:670: in _angles_lengths
    xyp = self.ax.transData.transform(self.XY + eps * uv)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/astropy/units/quantity.py:457: in __array_ufunc__
    converters, unit = converters_and_unit(function, method, *inputs)

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
function = <ufunc 'add'>, method = '__call__'
args = (array([[-0.00357703, -0.00934009]]), <Quantity [[0.12387647, 0.3699658 ]] m>)
ufunc_helper = <function get_converters_and_unit at 0x7f54bf56c840>
units = [None, Unit("m")], converters = [False, None]
    def converters_and_unit(function, method, *args):
        """Determine the required converters and the unit of the ufunc result.
    
        Converters are functions required to convert to a ufunc's expected unit,
        e.g., radian for np.sin; or to ensure units of two inputs are consistent,
        e.g., for np.add.  In these examples, the unit of the result would be
        dimensionless_unscaled for np.sin, and the same consistent unit for np.add.
    
        Parameters
        ----------
        function : `~numpy.ufunc`
            Numpy universal function
        method : str
            Method with which the function is evaluated, e.g.,
            '__call__', 'reduce', etc.
        *args : Quantity or other ndarray subclass
            Input arguments to the function
    
        Raises
        ------
        TypeError : when the specified function cannot be used with Quantities
            (e.g., np.logical_or), or when the routine does not know how to handle
            the specified function (in which case an issue should be raised on
            https://github.com/astropy/astropy).
        UnitTypeError : when the conversion to the required (or consistent) units
            is not possible.
        """
    
        # Check whether we support this ufunc, by getting the helper function
        # (defined in helpers) which returns a list of function(s) that convert the
        # input(s) to the unit required for the ufunc, as well as the unit the
        # result will have (a tuple of units if there are multiple outputs).
        ufunc_helper = UFUNC_HELPERS[function]
    
        if method == '__call__' or (method == 'outer' and function.nin == 2):
            # Find out the units of the arguments passed to the ufunc; usually,
            # at least one is a quantity, but for two-argument ufuncs, the second
            # could also be a Numpy array, etc.  These are given unit=None.
            units = [getattr(arg, 'unit', None) for arg in args]
    
            # Determine possible conversion functions, and the result unit.
            converters, result_unit = ufunc_helper(function, *units)
    
            if any(converter is False for converter in converters):
                # for multi-argument ufuncs with a quantity and a non-quantity,
                # the quantity normally needs to be dimensionless, *except*
                # if the non-quantity can have arbitrary unit, i.e., when it
                # is all zero, infinity or NaN.  In that case, the non-quantity
                # can just have the unit of the quantity
                # (this allows, e.g., `q > 0.` independent of unit)
                try:
                    # Don't fold this loop in the test above: this rare case
                    # should not make the common case slower.
                    for i, converter in enumerate(converters):
                        if converter is not False:
                            continue
                        if can_have_arbitrary_unit(args[i]):
                            converters[i] = None
                        else:
                            raise UnitConversionError(
                                "Can only apply '{}' function to "
                                "dimensionless quantities when other "
                                "argument is not a quantity (unless the "
                                "latter is all zero/infinity/nan)"
>                               .format(function.__name__))
E                               astropy.units.core.UnitConversionError: Can only apply 'add' function to dimensionless quantities when other argument is not a quantity (unless the latter is all zero/infinity/nan)
../../../miniconda/envs/lst-dev-ctapipe0.8/lib/python3.6/site-packages/astropy/units/quantity_helper/converters.py:189: UnitConversionError
```