### PR TITLE
Fixed initialization of charge and peak_time arrays

### DIFF
--- a/lstchain/calib/camera/calibrator.py
+++ b/lstchain/calib/camera/calibrator.py
@@ -192,8 +192,10 @@ class LSTCameraCalibrator(CameraCalibrator):
 
         no_gain_selection = np.zeros((waveforms.shape[0], waveforms.shape[1]), dtype=np.int)
 
-        charge = np.zeros(waveforms.shape[0])
-        peak_time = np.zeros(waveforms.shape[0])
+        charge = np.zeros((waveforms.shape[0], waveforms.shape[1]),
+                          dtype='float32')
+        peak_time = np.zeros((waveforms.shape[0], waveforms.shape[1]),
+                             dtype='float32')
         # image extraction for each channel:
         for i in range(waveforms.shape[0]):
             charge[i], peak_time[i] = self.image_extractor(waveforms[i], telid, no_gain_selection[i])


### PR DESCRIPTION
Current version does not work for new (r0 ro dl1 stage in real data). This seems to fix it.