### PR TITLE
Allow to filter events based on columns subset

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -308,10 +308,10 @@ def build_models(filegammas, fileprotons,
         df_gamma = pd.concat([df_gamma, pd.read_hdf(filegammas, key=dl1_params_src_dep_lstcam_key)], axis=1)
         df_proton = pd.concat([df_proton, pd.read_hdf(fileprotons, key=dl1_params_src_dep_lstcam_key)], axis=1)
 
-    df_gamma = utils.filter_events(df_gamma, filters=events_filters)
-    df_proton = utils.filter_events(df_proton, filters=events_filters)
-
     regression_features = config['regression_features']
+
+    df_gamma = utils.filter_events(df_gamma, filters=events_filters, subset=regression_features)
+    df_proton = utils.filter_events(df_proton, filters=events_filters, subset=regression_features)
 
     #Train regressors for energy and disp_norm reconstruction, only with gammas
 

--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -88,3 +88,11 @@ def test_unix_tai_to_utc():
     timestamps = np.array([timestamp_tai, np.nan])
     assert np.isclose(unix_tai_to_time(timestamps)[0].unix, timestamp_tai - leap_seconds)
     assert unix_tai_to_time(timestamps)[1] == INVALID_TIME
+
+
+def test_filter_events():
+    data = pd.DataFrame(pd.DataFrame(np.array([[np.nan, 2, 3], [4, 5, 6], [7, np.nan, 9]]),
+                                     columns=['a', 'b', 'c']))
+
+    filtered_data = utils.filter_events(data, subset=['b', 'c'])
+    np.testing.assert_array_equal(data.iloc[0:2], filtered_data)

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -426,6 +426,7 @@ def filter_events(events,
                                  leakage2_intensity=[0, 1],
                                  ),
                   dropna=True,
+                  subset=None,
                   ):
     """
     Apply data filtering to a pandas dataframe.
@@ -439,6 +440,8 @@ def filter_events(events,
     filters: dict containing events features names and their filtering range
     dropna: bool
         if True (default), `dropna()` is applied to the dataframe.
+    subset: to be used with `dropna=True`
+        see `pandas.DataFrame.dropna`
 
     Returns
     -------
@@ -453,7 +456,7 @@ def filter_events(events,
 
     if dropna:
         with pd.option_context('mode.use_inf_as_null', True):
-            return events[filter].dropna()
+            return events[filter].dropna(subset=subset)
     else:
         return events[filter]
 

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -94,7 +94,8 @@ def main():
         else:
             data.alt_tel = - np.pi/2.
             data.az_tel = - np.pi/2.
-    data = filter_events(data, filters=config["events_filters"])
+
+    data = filter_events(data, filters=config["events_filters"], subset=config['regression_features'])
 
     #Load the trained RF for reconstruction:
     fileE = args.path_models + "/reg_energy.sav"
@@ -110,7 +111,7 @@ def main():
     dl2 = dl1_to_dl2.apply_models(data, cls_gh, reg_energy, reg_disp_vector, custom_config=config)
 
     os.makedirs(args.output_dir, exist_ok=True)
-    output_file = os.path.join(args.output_dir, os.path.basename(args.input_file).replace('dl1','dl2'))
+    output_file = os.path.join(args.output_dir, os.path.basename(args.input_file).replace('dl1', 'dl2'))
 
     if os.path.exists(output_file):
         raise IOError(output_file + ' exists, exiting.')


### PR DESCRIPTION
Depending on user config, some dl1 columns can be all `nan` without impacting the analysis.
Thus, only relevant columns should be used for filtering at the dl1 to dl2 stage.