### PR TITLE
Update to astropy v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     version=version,
     packages=find_packages(),
     install_requires=[
-        "astropy>=3,<5",
+        "astropy>3,<5",
         'ctapipe~=0.8.0',
         'ctaplot~=0.5.3',
         "eventio>=1.1.1,<2.0.0a0",  # at least 1.1.1, but not 2

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "eventio>=1.1.1,<2.0.0a0",  # at least 1.1.1, but not 2
         'gammapy>=0.17',
         'h5py',
+        'joblib',
         'matplotlib',
         'numba',
         'numpy',
@@ -56,9 +57,7 @@ setup(
         'seaborn',
         'scikit-learn',
         'tables',
-        'joblib',
         'traitlets',
-        'joblib',
     ],
     package_data={
         'lstchain': ['data/lstchain_standard_config.json',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     version=version,
     packages=find_packages(),
     install_requires=[
-        "astropy>3,<5",
+        "astropy~=4.0",
         'ctapipe~=0.8.0',
         'ctaplot~=0.5.3',
         "eventio>=1.1.1,<2.0.0a0",  # at least 1.1.1, but not 2


### PR DESCRIPTION
Following the discussion on slack:
https://ctapipe.slack.com/archives/C0160M3K362/p1596115158284400

```py3
astropy>=3,<5
```
may install astropy v3.2.3, which is not compatible with lstchain >= v0.6, so this should solve the problem