### PR TITLE
Change default calibration scaling factor tp account for different integration windows and the effect of sampling inhomogeneities

### DIFF
--- a/lstchain/calib/camera/calibration_calculator.py
+++ b/lstchain/calib/camera/calibration_calculator.py
@@ -36,7 +36,7 @@ class CalibrationCalculator(Component):
 
     """
     squared_excess_noise_factor = Float(
-        1.2,
+        1.222,
         help='Excess noise factor squared: 1+ Var(gain)/Mean(Gain)**2'
     ).tag(config=True)
 

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -103,7 +103,7 @@
   "gain_selector_config": {
     "threshold":  3500
   },
-  "charge_scale": [1.0,1.0],
+  "charge_scale": [1.142,1.104],
   "LocalPeakWindowSum":{
      "window_shift": 4,
      "window_width":8
@@ -129,6 +129,7 @@
   "LSTCalibrationCalculator":{
      "minimum_hg_charge_median": 5000,
      "maximum_lg_charge_std": 300,
+    "squared_excess_noise_factor": 1.222,
      "flatfield_product": "FlasherFlatFieldCalculator",
      "pedestal_product": "PedestalIntegrator",
      "PedestalIntegrator":{

--- a/lstchain/data/onsite_camera_calibration_param.json
+++ b/lstchain/data/onsite_camera_calibration_param.json
@@ -10,6 +10,7 @@
    "LSTCalibrationCalculator": {
      "minimum_hg_charge_median": 5000,
      "maximum_lg_charge_std": 300,
+     "squared_excess_noise_factor": 1.222,
      "flatfield_product": "FlasherFlatFieldCalculator",
      "pedestal_product": "PedestalIntegrator"
    },


### PR DESCRIPTION
- Modify the global calibration scaling factor including:
      1. The factor due to the different integration window in cosmics (8 ns) and laser events (12 ns). We use the values estimated on data by Yukiho (see [slide 12](https://indico.cta-observatory.org/event/2853/contributions/24597/attachments/17750/23853/ChargeRecoYukiho20200629.pdf)) :  [HG,LG]=[1.088,1.004]
      2. The average estimated effect on the gain due to the DRS4 time sampling inhomogeneities and laser variation:  [HG,LG]=[1.05,1.10]  
    
- Update the excess noise factor to the most recent estimated value (Fˆ2=1.222)

It will remain a small underestimation of the light with respect to MC due to the 12 ns window, taken here as reference
