### PR TITLE
Fix time message when no UCTS time info is available

### DIFF
--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -356,7 +356,7 @@ def r0_to_dl1(
         # Forcing filters for the dl1 dataset that are currently read from the pre-existing files
         # This should be fixed in ctapipe and then corrected here
         writer._h5file.filters = filters
-        print("USING FILTERS: ", writer._h5file.filters)
+        logger.info("USING FILTERS: ", writer._h5file.filters)
 
         first_valid_ucts = np.nan
         first_valid_ucts_tib = np.nan
@@ -366,12 +366,11 @@ def r0_to_dl1(
         for i, event in enumerate(chain([first_event],  event_iter)):
 
             if i % 100 == 0:
-                print(i)
+                logger.info(i)
 
             event.dl0.prefix = ''
             event.mc.prefix = 'mc'
             event.trigger.prefix = ''
-
 
             # write sub tables
             if is_simu:
@@ -413,8 +412,6 @@ def r0_to_dl1(
 
                 # update the calibration index in the dl1 event container
                 dl1_container.calibration_id = calibration_index.calibration_id
-
-
 
             # Temporal volume reducer for lstchain - dl1 level must be filled and dl0 will be overwritten.
             # When the last version of the method is implemented, vol. reduction will be done at dl0
@@ -679,7 +676,6 @@ def r0_to_dl1(
                     writer.write(table_name = f'telescope/parameters/{tel_name}',
                                  containers = [dl1_container])
 
-
                     # Muon ring analysis, for real data only (MC is done starting from DL1 files)
                     if not is_simu:
                         bad_pixels = event.mon.tel[telescope_id].calibration.unusable_pixels[0]
@@ -760,7 +756,6 @@ def r0_to_dl1(
                         writer.write(table_name=f'simulation/{tel_name}',
                                      containers=[event.mc.tel[telescope_id], extra_im]
                                      )
-
 
         if not is_simu:
             # at the end of event loop ask calculation of remaining interleaved statistics

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -356,10 +356,10 @@ def r0_to_dl1(
         # Forcing filters for the dl1 dataset that are currently read from the pre-existing files
         # This should be fixed in ctapipe and then corrected here
         writer._h5file.filters = filters
-        logger.info("USING FILTERS: ", writer._h5file.filters)
+        logger.info(f"USING FILTERS: {writer._h5file.filters}")
 
-        first_valid_ucts = np.nan
-        first_valid_ucts_tib = np.nan
+        first_valid_ucts = None
+        first_valid_ucts_tib = None
         previous_ucts_time_unix = []
         previous_ucts_trigger_type = []
 
@@ -495,14 +495,14 @@ def r0_to_dl1(
                                 # UCTS presence flag is OK
                                 ucts_time = event.lst.tel[telescope_id].evt.ucts_timestamp * 1e-9  # secs
 
-                                if math.isnan(first_valid_ucts):
+                                if first_valid_ucts is None:
                                     first_valid_ucts = ucts_time
 
                                     initial_dragon_counter = (
                                             event.lst.tel[telescope_id].evt.pps_counter[module_id] +
                                             event.lst.tel[telescope_id].evt.tenMHz_counter[module_id] * 10 ** (-7)
                                     )
-                                    logger.info(
+                                    logger.warning(
                                         f"Dragon timestamps not based on a valid absolute reference timestamp. "
                                         f"Consider using the following initial values \n"
                                         f"Event ID: {event.index.event_id}, "
@@ -511,7 +511,7 @@ def r0_to_dl1(
                                     )
 
                                 if event.lst.tel[telescope_id].evt.extdevices_presence & 1 \
-                                        and math.isnan(first_valid_ucts_tib):
+                                        and first_valid_ucts_tib is None:
                                     # Both TIB and UCTS presence flags are OK
                                     first_valid_ucts_tib = ucts_time
 
@@ -519,7 +519,7 @@ def r0_to_dl1(
                                             event.lst.tel[telescope_id].evt.tib_pps_counter +
                                             event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10 ** (-7)
                                     )
-                                    logger.info(
+                                    logger.warning(
                                         f"TIB timestamps not based on a valid absolute reference timestamp. "
                                         f"Consider using the following initial values \n"
                                         f"Event ID: {event.index.event_id}, UCTS timestamp corresponding to "
@@ -546,9 +546,9 @@ def r0_to_dl1(
                             if event.lst.tel[telescope_id].evt.extdevices_presence & 2:
                                 # UCTS presence flag is OK
                                 ucts_time = event.lst.tel[telescope_id].evt.ucts_timestamp * 1e-9  # secs
-                                if math.isnan(first_valid_ucts):
+                                if first_valid_ucts is None:
                                     first_valid_ucts = ucts_time
-                                if math.isnan(first_valid_ucts_tib) \
+                                if first_valid_ucts_tib is None \
                                         and event.lst.tel[telescope_id].evt.extdevices_presence & 1:
                                     first_valid_ucts_tib = ucts_time
                             else:
@@ -766,10 +766,10 @@ def r0_to_dl1(
                                    event.mon.tel[tel_id],
                                    new_ped=new_ped, new_ff=new_ff)
 
-    if math.isnan(first_valid_ucts):
+    if first_valid_ucts is None:
         logger.warning("Not valid UCTS timestamp found")
 
-    if math.isnan(first_valid_ucts_tib):
+    if first_valid_ucts_tib is None:
         logger.warning("Not valid TIB counter value found")
 
     if is_simu:


### PR DESCRIPTION
There was a bug in the implementation of the logging of time information when UCTS is not available. It was always showing the message "Not valid UCTS timestamp found" even though the time information was present. This fix should prevent that message from appearing always.