### PR TITLE
Fix filling of muon mc energy in the muon output

### DIFF
--- a/lstchain/image/muon/muon_analysis.py
+++ b/lstchain/image/muon/muon_analysis.py
@@ -430,17 +430,15 @@ def create_muon_table():
             }
 
 
-def fill_muon_event(parameters, output_parameters, good_ring, event_id,
+def fill_muon_event(mc_energy, output_parameters, good_ring, event_id,
                     event_time, muonintensityparam, dist_mask,
                     muonringparam, radial_distribution, size,
                     size_outside_ring, mean_pixel_charge_around_ring,
                     muonparameters, hg_peak_sample=np.nan, lg_peak_sample=np.nan):
     output_parameters['event_id'].append(event_id)
     output_parameters['event_time'].append(event_time)
-    if parameters is not None:
-        output_parameters['mc_energy'].append(parameters.mc_energy)
-    else:
-        output_parameters['mc_energy'].append(-1.)
+    output_parameters['mc_energy'].append(mc_energy)
+
     output_parameters['ring_size'].append(size)
     output_parameters['size_outside'].append(size_outside_ring)
     output_parameters['ring_center_x'].append(muonringparam.center_x.value)

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -731,7 +731,7 @@ def r0_to_dl1(
                                 lg_peak_sample = np.argmax(stacked_waveforms, axis=-1)[1]
 
                             if good_ring:
-                                fill_muon_event(None,
+                                fill_muon_event(-1,
                                                 muon_parameters,
                                                 good_ring,
                                                 event.index.event_id,

--- a/lstchain/scripts/lstchain_dl1_muon_analysis.py
+++ b/lstchain/scripts/lstchain_dl1_muon_analysis.py
@@ -136,7 +136,8 @@ def main():
             dummy_times[:] = np.nan
             parameters['dragon_time'] = dummy_times
 
-        for full_image, event_id, dragon_time in zip(images, parameters['event_id'], parameters['dragon_time']):
+        for full_image, event_id, dragon_time, mc_energy in zip(
+                images, parameters['event_id'], parameters['dragon_time'], parameters['mc_energy']):
             if args.calib_file is not None:
                 image = full_image*(~bad_pixels)
             else:
@@ -169,7 +170,7 @@ def main():
             # write ring data, including also "not-so-good" rings
             # in case we want to reconsider ring selections!:
             fill_muon_event(
-                parameters, output_parameters, good_ring, event_id,
+                mc_energy, output_parameters, good_ring, event_id,
                 dragon_time, muonintensityparam, dist_mask,
                 muonringparam, radial_distribution, size,
                 size_outside_ring, mean_pixel_charge_around_ring,


### PR DESCRIPTION
The muon mc energy that was being written per event was the full array of energies instead of the energy of the event, so no the `mc_energy` of the event is now passed to the `fill_muon_event` function whenever we have MC data, and `-1` is passed when we are analyzing real data.