### PR TITLE
Filter events dl1 taking into account regression features 

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -308,10 +308,11 @@ def build_models(filegammas, fileprotons,
         df_gamma = pd.concat([df_gamma, pd.read_hdf(filegammas, key=dl1_params_src_dep_lstcam_key)], axis=1)
         df_proton = pd.concat([df_proton, pd.read_hdf(fileprotons, key=dl1_params_src_dep_lstcam_key)], axis=1)
 
-    df_gamma = utils.filter_events(df_gamma, filters=events_filters)
-    df_proton = utils.filter_events(df_proton, filters=events_filters)
-
     regression_features = config['regression_features']
+
+    df_gamma = utils.filter_events(df_gamma, regression_features, filters=events_filters)
+    df_proton = utils.filter_events(df_proton, regression_features, filters=events_filters)
+
 
     #Train regressors for energy and disp_norm reconstruction, only with gammas
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -313,7 +313,6 @@ def build_models(filegammas, fileprotons,
     df_gamma = utils.filter_events(df_gamma, regression_features, filters=events_filters)
     df_proton = utils.filter_events(df_proton, regression_features, filters=events_filters)
 
-
     #Train regressors for energy and disp_norm reconstruction, only with gammas
 
     reg_energy = train_energy(df_gamma, custom_config=config)

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -46,8 +46,6 @@ __all__ = [
     'unix_tai_to_time',
 ]
 
-log = logging.getLogger(__name__)
-
 # position of the LST1
 location = EarthLocation.from_geodetic(-17.89139 * u.deg, 28.76139 * u.deg, 2184 * u.m)
 obstime = Time('2018-11-01T02:00')
@@ -457,7 +455,8 @@ def filter_events(events,
             filter = filter & (events[k] >= filters[k][0]) & (events[k] <= filters[k][1])
 
     if dropna:
-        return events[filter][reco_features].dropna()
+        with pd.option_context('mode.use_inf_as_null', True):
+            return events[filter][reco_features].dropna()
     else:
         return events[filter]
 

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -46,6 +46,8 @@ __all__ = [
     'unix_tai_to_time',
 ]
 
+log = logging.getLogger(__name__)
+
 # position of the LST1
 location = EarthLocation.from_geodetic(-17.89139 * u.deg, 28.76139 * u.deg, 2184 * u.m)
 obstime = Time('2018-11-01T02:00')
@@ -420,6 +422,7 @@ def expand_tel_list(tel_list, max_tels):
 
 
 def filter_events(events,
+                  reco_features,
                   filters=dict(intensity=[0, np.inf],
                                  width=[0, np.inf],
                                  length=[0, np.inf],
@@ -454,8 +457,7 @@ def filter_events(events,
             filter = filter & (events[k] >= filters[k][0]) & (events[k] <= filters[k][1])
 
     if dropna:
-        with pd.option_context('mode.use_inf_as_null', True):
-            return events[filter].dropna()
+        return events[filter][reco_features].dropna()
     else:
         return events[filter]
 

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -94,7 +94,7 @@ def main():
         else:
             data.alt_tel = - np.pi/2.
             data.az_tel = - np.pi/2.
-    data = filter_events(data, filters=config["events_filters"])
+    data = filter_events(data, config['regression_features'], filters=config["events_filters"])
 
     #Load the trained RF for reconstruction:
     fileE = args.path_models + "/reg_energy.sav"


### PR DESCRIPTION
Trying to solve the issue in the `filter_events` function of the `dl1_to_dl2` step (see #523) when there are columns with `NaN` and not used for regression.

This will take into account only the columns used for event reconstruction (given in the lstchain config file), but it will discard the other columns, so I guess it's not the final solution. Any suggestions or comments are welcome.

The problem is that those columns filled with `NaN` (eg. `mc_core_distance`) make the current function disregard all the rows containing `NaN`

```
         intensity  log_intensity         x         y         r       phi    length     width       psi  ...  mc_core_distance        wl  tel_id  tel_pos_x  tel_pos_y  tel_pos_z  trigger_type  ucts_trigger_type  trigger_time
0      4977.034420       3.696971 -0.162801  0.042285  0.168203  2.887475  1.125409  1.026033  1.046278  ...               NaN  0.911698       1       50.0       50.0       16.0             1                 -1  1.597728e+09
1        19.918596       1.299259  0.865152 -0.116288  0.872932 -0.133613  0.063859  0.055169 -0.345889  ...               NaN  0.863921       1       50.0       50.0       16.0             1                  1  1.597728e+09
2        97.015544       1.986841  0.091031  0.812277  0.817362  1.459193  0.096502  0.066063  1.209844  ...               NaN  0.684579       1       50.0       50.0       16.0             1                  1  1.597728e+09
```