### PR TITLE
Tool to produce a pedestal FITS file

### DIFF
--- a/lstchain/calib/camera/drs4.py
+++ b/lstchain/calib/camera/drs4.py
@@ -82,7 +82,7 @@ class DragonPedestal(Component):
                             meanped[gain, pixel, posads] += val
                             numped[gain, pixel, posads] += 1
 
-    def finalize_pedestal(self):
+    def complete_pedestal(self):
         if np.sum(self.numped==0) > 0:
             raise RuntimeError("Not enough events to coverage all capacitor. "
                                "Please use more events to create pedestal file.")

--- a/lstchain/scripts/lstchain_data_create_drs4_pedestal_file.py
+++ b/lstchain/scripts/lstchain_data_create_drs4_pedestal_file.py
@@ -104,7 +104,7 @@ def main():
                 print("i = {}, ev id = {}".format(i, event.index.event_id))
 
     # Finalize pedestal and write to fits file
-    pedestal.finalize_pedestal()
+    pedestal.complete_pedestal()
 
     primaryhdu = fits.PrimaryHDU(ev.lst.tel[tel_id].svc.pixel_ids)
     secondhdu = fits.ImageHDU(np.int16(pedestal.meanped))

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -34,7 +34,9 @@ class PedestalFITSWriter(Tool):
 
     aliases = {
         "input": "EventSource.input_url",
+        "i": "EventSource.input_url",
         "output": "PedestalFITSWriter.output",
+        "o": "PedestalFITSWriter.output",
     }
 
     flags = {

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -64,7 +64,24 @@ class PedestalFITSWriter(Tool):
     def start(self):
 
         try:
-            pass
+            if self.deltaT:
+                self.log.info("DeltaT correction active")
+                for i, event in enumerate(self.eventsource):
+                    for tel_id in event.r0.tels_with_data:
+                        self.lst_r0.time_lapse_corr(event, tel_id)
+                        self.pedestal.fill_pedestal_event(event)
+                        if i % 500 == 0:
+                            self.log.debug("i = {}, ev id = {}".format(i, event.index.event_id))
+            else:
+                self.log.info("DeltaT correction no active")
+                for i, event in enumerate(self.eventsource):
+                    self.pedestal.fill_pedestal_event(event)
+                    if i % 500 == 0:
+                        self.log.debug("i = {}, ev id = {}".format(i, event.index.event_id))
+
+            # Finalize pedestal and write to fits file
+            self.pedestal.finalize_pedestal()
+
         except Exception as e:
             self.log.error(e)
 

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -79,26 +79,21 @@ class PedestalFITSWriter(Tool):
 
         if self.deltaT:
             self.log.info("DeltaT correction active")
-            self.log.info(f"Progress bar {self.progress_bar}")
-            for event in tqdm(
-                self.eventsource,
-                desc=self.eventsource.__class__.__name__,
-                total=self.eventsource.max_events,
-                unit="ev",
-                disable=not self.progress_bar,
-            ):
+        else:
+            self.log.info("DeltaT correction not active")
+
+        for event in tqdm(
+            self.eventsource,
+            desc=self.eventsource.__class__.__name__,
+            total=self.eventsource.max_events,
+            unit="ev",
+            disable=not self.progress_bar,
+        ):
+            if self.deltaT:
                 for tel_id in event.r0.tels_with_data:
                     self.lst_r0.time_lapse_corr(event, tel_id)
                     self.pedestal.fill_pedestal_event(event)
-        else:
-            self.log.info("DeltaT correction no active")
-            for event in tqdm(
-                self.eventsource,
-                desc=self.eventsource.__class__.__name__,
-                total=self.eventsource.max_events,
-                unit="ev",
-                disable=not self.progress_bar,
-            ):
+            else:
                 self.pedestal.fill_pedestal_event(event)
 
         self.pedestal.complete_pedestal()

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -1,0 +1,77 @@
+"""
+Create drs4 time pedestal fits file.
+"""
+import numpy as np
+from astropy.io import fits
+
+from ctapipe.core import Provenance, traits
+from ctapipe.core import Tool
+from ctapipe.io import EventSource
+from lstchain.calib.camera.r0 import LSTR0Corrections
+from lstchain.calib.camera.drs4 import DragonPedestal
+
+
+class PedestalFITSWriter(Tool):
+
+    name = "PedestalFITSWriter"
+    description = "Generate a pedestal FITS file"
+
+    output_file = traits.Path(
+        help="Path to the generated FITS pedestal file",
+        directory_ok=False,
+        exist=False,
+    ).tag(config=True)
+
+    deltaT = traits.Bool(
+        help="Flag to use deltaT correction. Default=True", default_value=True
+    ).tag(config=True)
+
+    aliases = {
+        "input_file": "EventSource.input_url",
+        "output_file": "PedestalFITSWriter.output_file",
+    }
+
+    flags = {
+        "deltaT": ({"PedestalFITSWriter": {"deltaT": True}}, "Flag to use deltaT correction. Default is True")
+    }
+
+    classes = [EventSource, LSTR0Corrections, DragonPedestal]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        """
+        Tool that generates a pedestal FITS file for low level calibration.
+
+        For getting help run:
+        python lstchain_create_drs4_pedestal_file.py --help
+        """
+
+        self.eventsource = None
+
+    def setup(self):
+
+        self.log.debug(f"Open file")
+        self.eventsource = EventSource.from_config(parent=self)
+
+    def start(self):
+
+        try:
+            pass
+        except Exception as e:
+            self.log.error(e)
+
+    def finish(self):
+        # Provenance().add_output_file(
+        #     self.output_file,
+        #     role='mon.tel.pedestal'
+        # )
+        pass
+
+
+def main():
+    exe = PedestalFITSWriter()
+    exe.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -35,7 +35,7 @@ class PedestalFITSWriter(Tool):
 
     aliases = {
         "input": "EventSource.input_url",
-        "output": "PedestalFITSWriter.output_file",
+        "output": "PedestalFITSWriter.output",
     }
 
     flags = {
@@ -92,9 +92,7 @@ class PedestalFITSWriter(Tool):
             if self.deltaT:
                 for tel_id in event.r0.tels_with_data:
                     self.lst_r0.time_lapse_corr(event, tel_id)
-                    self.pedestal.fill_pedestal_event(event)
-            else:
-                self.pedestal.fill_pedestal_event(event)
+            self.pedestal.fill_pedestal_event(event)
 
         self.pedestal.complete_pedestal()
 

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -25,7 +25,7 @@ class PedestalFITSWriter(Tool):
     ).tag(config=True)
 
     deltaT = traits.Bool(
-        help="Flag to use deltaT correction. Default=True", default_value=True
+        help="Flag to use deltaT correction. Default=False", default_value=False
     ).tag(config=True)
 
     progress_bar = traits.Bool(
@@ -40,8 +40,8 @@ class PedestalFITSWriter(Tool):
 
     flags = {
         "deltaT": (
-            {"PedestalFITSWriter": {"deltaT": True}},
-            "Flag to use deltaT correction. Default is True",
+            {"PedestalFITSWriter": {"deltaT": False}},
+            "Flag to use deltaT correction. Default is False",
         )
     }
 

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -16,9 +16,9 @@ class PedestalFITSWriter(Tool):
     name = "PedestalFITSWriter"
     description = "Generate a pedestal FITS file"
 
-    output_file = traits.Path(
+    output = traits.Path(
         default_value="pedestal.fits",
-        help="Path to the generated FITS pedestal file",
+        help="Path to the generated fits pedestal file",
         directory_ok=False,
         exists=False,
     ).tag(config=True)
@@ -28,8 +28,8 @@ class PedestalFITSWriter(Tool):
     ).tag(config=True)
 
     aliases = {
-        "input_file": "EventSource.input_url",
-        "output_file": "PedestalFITSWriter.output_file",
+        "input": "EventSource.input_url",
+        "output": "PedestalFITSWriter.output_file"
     }
 
     flags = {
@@ -92,10 +92,10 @@ class PedestalFITSWriter(Tool):
         primaryhdu = fits.PrimaryHDU(self.pixel_ids)
         secondhdu = fits.ImageHDU(np.int16(self.pedestal.meanped))
         hdulist = fits.HDUList([primaryhdu, secondhdu])
-        hdulist.writeto(self.output_file)
+        hdulist.writeto(self.output)
 
         Provenance().add_output_file(
-            self.output_file,
+            self.output,
             role='mon.tel.pedestal'
         )
 

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -56,12 +56,12 @@ class PedestalFITSWriter(Tool):
 
         self.log.debug("Opening file")
         self.eventsource = EventSource.from_config(parent=self)
+        self.lst_r0 = self.add_component(LSTR0Corrections(parent=self))
 
         for event in self.eventsource:
             tel_id = event.r0.tels_with_data[0]
             self.pixel_ids = event.lst.tel[tel_id].svc.pixel_ids
             self.pedestal = DragonPedestal(tel_id=tel_id, n_module=event.lst.tel[tel_id].svc.num_modules)
-            self.lst_r0 = LSTR0Corrections(config=self.config)
             break
 
     def start(self):

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -44,7 +44,7 @@ class PedestalFITSWriter(Tool):
         Tool that generates a pedestal FITS file for low level calibration.
 
         For getting help run:
-        python lstchain_create_drs4_pedestal_file.py --help
+        lstchain_create_drs4_pedestal_file --help
         """
 
         self.eventsource = None
@@ -55,7 +55,7 @@ class PedestalFITSWriter(Tool):
 
     def setup(self):
 
-        self.log.debug(f"Open file")
+        self.log.debug("Opening file")
         self.eventsource = EventSource.from_config(parent=self)
 
         seeker = EventSeeker(self.eventsource)
@@ -75,13 +75,13 @@ class PedestalFITSWriter(Tool):
                         self.lst_r0.time_lapse_corr(event, tel_id)
                         self.pedestal.fill_pedestal_event(event)
                         if i % 500 == 0:
-                            self.log.debug("i = {}, ev id = {}".format(i, event.index.event_id))
+                            self.log.debug(f"i = {i}, ev id = {event.index.event_id}")
             else:
                 self.log.info("DeltaT correction no active")
                 for i, event in enumerate(self.eventsource):
                     self.pedestal.fill_pedestal_event(event)
                     if i % 500 == 0:
-                        self.log.debug("i = {}, ev id = {}".format(i, event.index.event_id))
+                        self.log.debug(f"i = {i}, ev id = {event.index.event_id}")
 
             self.pedestal.finalize_pedestal()
 

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -6,7 +6,7 @@ from astropy.io import fits
 
 from ctapipe.core import Provenance, traits
 from ctapipe.core import Tool
-from ctapipe.io import EventSource
+from ctapipe.io import EventSeeker, EventSource
 from lstchain.calib.camera.r0 import LSTR0Corrections
 from lstchain.calib.camera.drs4 import DragonPedestal
 
@@ -47,11 +47,19 @@ class PedestalFITSWriter(Tool):
         """
 
         self.eventsource = None
+        self.lst_r0 = None
+        self.pedestal = None
 
     def setup(self):
 
         self.log.debug(f"Open file")
         self.eventsource = EventSource.from_config(parent=self)
+        seeker = EventSeeker(self.eventsource)
+        ev = seeker[0]
+        tel_id = ev.r0.tels_with_data[0]
+        n_modules = ev.lst.tel[tel_id].svc.num_modules
+        self.lst_r0 = LSTR0Corrections(config=self.config)
+        self.pedestal = DragonPedestal(tel_id=tel_id, n_module=n_modules)
 
     def start(self):
 

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -84,7 +84,7 @@ class PedestalFITSWriter(Tool):
         for event in tqdm(
             self.eventsource,
             desc=self.eventsource.__class__.__name__,
-            total=self.eventsource.max_events,
+            total=len(self.eventsource.multi_file),
             unit="ev",
             disable=not self.progress_bar,
         ):

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -35,11 +35,14 @@ class PedestalFITSWriter(Tool):
 
     aliases = {
         "input": "EventSource.input_url",
-        "output": "PedestalFITSWriter.output_file"
+        "output": "PedestalFITSWriter.output_file",
     }
 
     flags = {
-        "deltaT": ({"PedestalFITSWriter": {"deltaT": True}}, "Flag to use deltaT correction. Default is True")
+        "deltaT": (
+            {"PedestalFITSWriter": {"deltaT": True}},
+            "Flag to use deltaT correction. Default is True",
+        )
     }
 
     classes = [EventSource, LSTR0Corrections, DragonPedestal]
@@ -69,18 +72,20 @@ class PedestalFITSWriter(Tool):
         for event in self.eventsource:
             tel_id = event.r0.tels_with_data[0]
             self.pixel_ids = event.lst.tel[tel_id].svc.pixel_ids
-            self.pedestal = DragonPedestal(tel_id=tel_id, n_module=event.lst.tel[tel_id].svc.num_modules)
+            self.pedestal = DragonPedestal(
+                tel_id=tel_id, n_module=event.lst.tel[tel_id].svc.num_modules
+            )
             break
 
         if self.deltaT:
             self.log.info("DeltaT correction active")
             self.log.info(f"Progress bar {self.progress_bar}")
             for event in tqdm(
-                    self.eventsource,
-                    desc=self.eventsource.__class__.__name__,
-                    total=self.eventsource.max_events,
-                    unit="ev",
-                    disable=not self.progress_bar,
+                self.eventsource,
+                desc=self.eventsource.__class__.__name__,
+                total=self.eventsource.max_events,
+                unit="ev",
+                disable=not self.progress_bar,
             ):
                 for tel_id in event.r0.tels_with_data:
                     self.lst_r0.time_lapse_corr(event, tel_id)
@@ -88,11 +93,11 @@ class PedestalFITSWriter(Tool):
         else:
             self.log.info("DeltaT correction no active")
             for event in tqdm(
-                    self.eventsource,
-                    desc=self.eventsource.__class__.__name__,
-                    total=self.eventsource.max_events,
-                    unit="ev",
-                    disable=not self.progress_bar,
+                self.eventsource,
+                desc=self.eventsource.__class__.__name__,
+                total=self.eventsource.max_events,
+                unit="ev",
+                disable=not self.progress_bar,
             ):
                 self.pedestal.fill_pedestal_event(event)
 
@@ -105,10 +110,7 @@ class PedestalFITSWriter(Tool):
         hdulist = fits.HDUList([primaryhdu, secondhdu])
         hdulist.writeto(self.output)
 
-        Provenance().add_output_file(
-            self.output,
-            role='mon.tel.pedestal'
-        )
+        Provenance().add_output_file(self.output, role="mon.tel.pedestal")
 
 
 def main():

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -21,7 +21,6 @@ class PedestalFITSWriter(Tool):
         default_value="pedestal.fits",
         help="Path to the generated fits pedestal file",
         directory_ok=False,
-        exists=False,
     ).tag(config=True)
 
     deltaT = traits.Bool(
@@ -101,7 +100,7 @@ class PedestalFITSWriter(Tool):
         primaryhdu = fits.PrimaryHDU(self.pixel_ids)
         secondhdu = fits.ImageHDU(np.int16(self.pedestal.meanped))
         hdulist = fits.HDUList([primaryhdu, secondhdu])
-        hdulist.writeto(self.output)
+        hdulist.writeto(self.output, overwrite=True)
 
         Provenance().add_output_file(self.output, role="mon.tel.pedestal")
 


### PR DESCRIPTION
This PR adds a new Tool `lstchain_create_drs4_pedestal_file`

```
$ lstchain_create_drs4_pedestal_file --help-all
Generate a pedestal FITS file

Options
-------

Arguments that take values are actually convenience aliases to full
Configurables, whose aliases are listed on the help line. For more information
on full configurables, see '--help-all'.

--deltaT
    Flag to use deltaT correction. Default is True
--input_file=<Path> (EventSource.input_url)
    Default: None
    Path to the input file containing events.
--output_file=<Path> (PedestalFITSWriter.output_file)
    Default: 'pedestal.fits'
    Path to the generated FITS pedestal file
--log-level=<Enum> (Application.log_level)
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.
--config=<Path> (Tool.config_file)
    Default: None
    name of a configuration file with parameters to load in addition to command-
    line parameters

Class parameters
----------------

Parameters are set from command-line arguments of the form:
`--Class.trait=value`. This line is evaluated in Python, so simple expressions
are allowed, e.g.:: `--C.a='range(3)'` For setting C.a=[0,1,2].

PedestalFITSWriter options
--------------------------
--PedestalFITSWriter.config_file=<Path>
    Default: None
    name of a configuration file with parameters to load in addition to command-
    line parameters
--PedestalFITSWriter.deltaT=<Bool>
    Default: True
    Flag to use deltaT correction. Default=True
--PedestalFITSWriter.log_datefmt=<Unicode>
    Default: '%Y-%m-%d %H:%M:%S'
    The date format used by logging formatters for %(asctime)s
--PedestalFITSWriter.log_format=<Unicode>
    Default: '%(levelname)s [%(name)s] (%(module)s/%(funcName)s): %(messag...
    The Logging format template
--PedestalFITSWriter.log_level=<Enum>
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.
--PedestalFITSWriter.output_file=<Path>
    Default: 'pedestal.fits'
    Path to the generated FITS pedestal file

EventSource options
-------------------
--EventSource.allowed_tels=<Set>
    Default: set()
    list of allowed tel_ids, others will be ignored. If None, all telescopes in
    the input stream will be included
--EventSource.input_url=<Path>
    Default: None
    Path to the input file containing events.
--EventSource.max_events=<Int>
    Default: None
    Maximum number of events that will be read from the file

LSTR0Corrections options
------------------------
--LSTR0Corrections.offset=<Int>
    Default: 400
    Define the offset of the baseline
--LSTR0Corrections.pedestal_path=<Unicode>
    Default: ''
    Path to the LST pedestal binary file
--LSTR0Corrections.r1_sample_end=<Int>
    Default: 39
    End sample for r1 waveform
--LSTR0Corrections.r1_sample_start=<Int>
    Default: 3
    Start sample for r1 waveform
--LSTR0Corrections.tel_id=<Int>
    Default: 1
    id of the telescope to calibrate

DragonPedestal options
----------------------
--DragonPedestal.r0_sample_start=<Int>
    Default: 11
    Start sample for waveform
```