### PR TITLE
change HG factor in the standard config file

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -103,7 +103,7 @@
   "gain_selector_config": {
     "threshold":  3500
   },
-  "charge_scale": [1.142,1.104],
+  "charge_scale": [1.206, 1.104],
   "LocalPeakWindowSum":{
      "window_shift": 4,
      "window_width":8


### PR DESCRIPTION
Some discussions after the merge of #516 and due to the check shown in https://github.com/cta-observatory/cta-lstchain/pull/516#issuecomment-702119946, we realized that the HG factor was not fully accounting for the part of the signal that is not integrated after 8 ns in cosmic events. The factor difference seems to come from the difference of integrating:
- factor due to the different integration window in cosmic events (8 ns) and laser events (12 ns)
- factor due to the different integration window in cosmic events (8 ns) and cosmic events (12 ns)

that ratio is 0.947 as reported in https://github.com/cta-observatory/cta-lstchain/pull/516#issuecomment-702119946, so the new HG factor should be: 1.142 * 1 / 0.947 = 1.206