### PR TITLE
Update the calibration scaling factors based on the new estimation of the gain scaling factors due to sampling correction

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -103,7 +103,7 @@
   "gain_selector_config": {
     "threshold":  3500
   },
-  "charge_scale": [1.142,1.104],
+  "charge_scale": [1.18,1.09],
   "LocalPeakWindowSum":{
      "window_shift": 4,
      "window_width":8


### PR DESCRIPTION
The gain scaling factor (see #516) have been re-estimated with higher statistics and more constraint fit 
(see  [here](https://indico.cta-observatory.org/event/3052/contributions/25956/attachments/18098/24444/CalibrationScalingFactors_5_10_2020.pdf) for details)

The new estimated values are [HG,LG]=[1.08,1.09] (previously were [1.05,1.10]), therefore the new global scaling factors are estimated as [HG,LG]=[1.08,1.09]*[1.088,1.004] = [1.18,1.09]  (previously were [1.142,1.104])
