### PR TITLE
Tool to produce a time calibration HDF5 file

### DIFF
--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -1,0 +1,68 @@
+"""
+Create drs4 time correction coefficients.
+"""
+from ctapipe.core import Provenance, traits
+from ctapipe.io import HDF5TableWriter
+from ctapipe.core import Tool
+from ctapipe.io import EventSource
+from lstchain.calib.camera.r0 import LSTR0Corrections
+
+
+class TimeCalibrationHDF5Writer(Tool):
+
+    name = "TimeCalibrationHDF5Writer"
+    description = "Generate a HDF5 file with time calibration coefficients"
+
+    output_file = traits.Path(
+        help="Path to the generated the generated HDF5 time calibration file",
+        directory_ok=False,
+        exists=False,
+    ).tag(config=True)
+
+    aliases = {
+        "input_file": "EventSource.input_url",
+        "output_file": "TimeCalibrationHDF5Writer.output_file",
+        "pedestal_file": "LSTR0Corrections.pedestal_path",
+    }
+
+    classes = [EventSource, LSTR0Corrections]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        """
+        Tool that generates a HDF5 file with time calibration coefficients.
+
+        For getting help run:
+        python lstchain_create_time_calibration_file.py --help
+        """
+
+        self.eventsource = None
+        self.writer = None
+
+    def setup(self):
+
+        self.log.debug(f"Open file")
+
+    def start(self):
+
+        try:
+            self.log.debug(f"Start loop")
+        except Exception as e:
+            self.log.error(e)
+
+    def finish(self):
+        # Provenance().add_output_file(
+        #     self.output_file,
+        #     role='mon.tel.calibration'
+        # )
+        # self.writer.close()
+        pass
+
+
+def main():
+    exe = TimeCalibrationHDF5Writer()
+    exe.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -55,7 +55,17 @@ class TimeCalibrationHDF5Writer(Tool):
     def start(self):
 
         try:
-            self.log.debug(f"Start loop")
+            for i, event in enumerate(self.eventsource):
+                if i % 5000 == 0:
+                    self.log.debug(f"i = {i}, ev id = {event.index.event_id}")
+                self.lst_r0.calibrate(event)
+
+                # cut in signal to avoid cosmic events
+                if event.r1.tel[self.timeCorr.tel_id].trigger_type == 4 or (
+                        np.median(np.sum(event.r1.tel[self.timeCorr.tel_id].waveform[0], axis=1)) > 300
+                ):
+                    self.timeCorr.calibrate_peak_time(event)
+
         except Exception as e:
             self.log.error(e)
 

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -30,7 +30,7 @@ class TimeCalibrationHDF5Writer(Tool):
 
     max_events = traits.Int(
         help="Maximum numbers of events to read. Default = 20000",
-        default_value=2000
+        default_value=20000
     ).tag(config=True)
 
     aliases = {

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -2,10 +2,9 @@
 Create drs4 time correction coefficients.
 """
 import glob
-import numpy as np
 
-from ctapipe.core import Provenance, traits
-from ctapipe.core import Tool
+import numpy as np
+from ctapipe.core import Provenance, Tool, traits
 from ctapipe_io_lst import LSTEventSource
 from lstchain.calib.camera.r0 import LSTR0Corrections
 from lstchain.calib.camera.time_correction_calculate import TimeCorrectionCalculate
@@ -16,15 +15,15 @@ class TimeCalibrationHDF5Writer(Tool):
     name = "TimeCalibrationHDF5Writer"
     description = "Generate a HDF5 file with time calibration coefficients"
 
-    input_file = traits.Unicode(
+    input = traits.Unicode(
         help="Path to the fits.fz input file containing events (wildcards allowed)",
     ).tag(config=True)
 
-    output_file = traits.Unicode(
+    output = traits.Unicode(
         help="Path to the hdf5 time calibration file",
     ).tag(config=True)
 
-    pedestal_file = traits.Unicode(
+    pedestal = traits.Unicode(
         help="Path to drs4 fits pedestal file",
     ).tag(config=True)
 
@@ -33,9 +32,9 @@ class TimeCalibrationHDF5Writer(Tool):
     ).tag(config=True)
 
     aliases = {
-        "input_file": "TimeCalibrationHDF5Writer.input_file",
-        "output_file": "TimeCalibrationHDF5Writer.output_file",
-        "pedestal_file": "LSTR0Corrections.pedestal_path",
+        "input": "TimeCalibrationHDF5Writer.input",
+        "output": "TimeCalibrationHDF5Writer.output",
+        "pedestal": "LSTR0Corrections.pedestal_path",
         "max_events": "TimeCalibrationHDF5Writer.max_events",
     }
 
@@ -56,7 +55,7 @@ class TimeCalibrationHDF5Writer(Tool):
 
     def setup(self):
 
-        self.path_list = sorted(glob.glob(self.input_file))
+        self.path_list = sorted(glob.glob(self.input))
         self.reader = self.add_component(
             LSTEventSource(
                 input_url=self.path_list[0],
@@ -65,10 +64,10 @@ class TimeCalibrationHDF5Writer(Tool):
             )
         )
         self.lst_r0 = self.add_component(
-            LSTR0Corrections(pedestal_path=self.pedestal_file, parent=self)
+            LSTR0Corrections(pedestal_path=self.pedestal, parent=self)
         )
         self.timeCorr = TimeCorrectionCalculate(
-            calib_file_path=self.output_file,
+            calib_file_path=self.output,
             subarray=self.reader.subarray,
             config=self.config,
         )
@@ -98,7 +97,7 @@ class TimeCalibrationHDF5Writer(Tool):
 
         self.timeCorr.finalize()
         Provenance().add_output_file(
-            self.output_file,
+            self.output,
             role='mon.tel.calibration'
         )
 

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -17,20 +17,19 @@ class TimeCalibrationHDF5Writer(Tool):
     description = "Generate a HDF5 file with time calibration coefficients"
 
     input_file = traits.Unicode(
-        help="Path to the input file containing events (wildcards allowed)",
+        help="Path to the fits.fz input file containing events (wildcards allowed)",
     ).tag(config=True)
 
     output_file = traits.Unicode(
-        help="Path to the time calibration file",
+        help="Path to the hdf5 time calibration file",
     ).tag(config=True)
 
     pedestal_file = traits.Unicode(
-        help="Path to drs4 pedestal file",
+        help="Path to drs4 fits pedestal file",
     ).tag(config=True)
 
     max_events = traits.Int(
-        help="Maximum numbers of events to read. Default = 20000",
-        default_value=20000
+        help="Maximum numbers of events to read. Default = 20000", default_value=20000
     ).tag(config=True)
 
     aliases = {
@@ -50,7 +49,7 @@ class TimeCalibrationHDF5Writer(Tool):
         For getting help run:
         lstchain_create_time_calibration_file --help
         """
-
+        self.reader = None
         self.timeCorr = None
         self.path_list = None
         self.lst_r0 = None
@@ -58,14 +57,19 @@ class TimeCalibrationHDF5Writer(Tool):
     def setup(self):
 
         self.path_list = sorted(glob.glob(self.input_file))
-        reader = LSTEventSource(input_url=self.path_list[0], max_events=self.max_events)
-        self.lst_r0 = LSTR0Corrections(
-            pedestal_path=self.pedestal_file,
-            config=self.config,
+        self.reader = self.add_component(
+            LSTEventSource(
+                input_url=self.path_list[0],
+                max_events=self.max_events,
+                config=self.config,
+            )
+        )
+        self.lst_r0 = self.add_component(
+            LSTR0Corrections(pedestal_path=self.pedestal_file, parent=self)
         )
         self.timeCorr = TimeCorrectionCalculate(
             calib_file_path=self.output_file,
-            subarray=reader.subarray,
+            subarray=self.reader.subarray,
             config=self.config,
         )
 
@@ -73,10 +77,10 @@ class TimeCalibrationHDF5Writer(Tool):
 
         try:
             for j, path in enumerate(self.path_list):
-                reader = LSTEventSource(input_url=self.path_list[0], max_events=self.max_events)
+                self.reader.input_url = path
                 self.log.info(f"File {j + 1} out of {len(self.path_list)}")
                 self.log.info(f"Processing: {path}")
-                for i, event in enumerate(reader):
+                for i, event in enumerate(self.reader):
                     if i % 5000 == 0:
                         self.log.debug(f"i = {i}, ev id = {event.index.event_id}")
                     self.lst_r0.calibrate(event)

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -15,8 +15,13 @@ class TimeCalibrationHDF5Writer(Tool):
     name = "TimeCalibrationHDF5Writer"
     description = "Generate a HDF5 file with time calibration coefficients"
 
-    input = traits.Unicode(
-        help="Path to the fits.fz input file containing events (wildcards allowed)",
+    input = traits.Path(
+        help="Path to the fits.fz events file or directory to glob"
+    ).tag(config=True)
+
+    glob = traits.Unicode(
+        help="Filename pattern to glob files in the directory",
+        default_value="*"
     ).tag(config=True)
 
     output = traits.Unicode(
@@ -33,6 +38,7 @@ class TimeCalibrationHDF5Writer(Tool):
 
     aliases = {
         "input": "TimeCalibrationHDF5Writer.input",
+        "glob": "TimeCalibrationHDF5Writer.glob",
         "output": "TimeCalibrationHDF5Writer.output",
         "pedestal": "LSTR0Corrections.pedestal_path",
         "max_events": "TimeCalibrationHDF5Writer.max_events",
@@ -55,7 +61,10 @@ class TimeCalibrationHDF5Writer(Tool):
 
     def setup(self):
 
-        self.path_list = sorted(glob.glob(self.input))
+        self.path_list = [str(self.input)]
+        if self.input.is_dir():
+            self.path_list = sorted(glob.glob(str(self.input/self.glob)))
+
         self.reader = self.add_component(
             LSTEventSource(
                 input_url=self.path_list[0],

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -36,8 +36,10 @@ class TimeCalibrationHDF5Writer(Tool):
 
     aliases = {
         "input": "TimeCalibrationHDF5Writer.input",
+        "i": "TimeCalibrationHDF5Writer.input",
         "glob": "TimeCalibrationHDF5Writer.glob",
         "output": "TimeCorrectionCalculate.calib_file_path",
+        "o": "TimeCorrectionCalculate.calib_file_path",
         "pedestal": "LSTR0Corrections.pedestal_path",
         "max_events": "TimeCalibrationHDF5Writer.max_events",
     }

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -70,12 +70,12 @@ class TimeCalibrationHDF5Writer(Tool):
             self.log.error(e)
 
     def finish(self):
-        # Provenance().add_output_file(
-        #     self.output_file,
-        #     role='mon.tel.calibration'
-        # )
-        # self.writer.close()
-        pass
+
+        self.timeCorr.finalize()
+        Provenance().add_output_file(
+            self.output_file,
+            role='mon.tel.calibration'
+        )
 
 
 def main():

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -25,14 +25,6 @@ class TimeCalibrationHDF5Writer(Tool):
         default_value="*"
     ).tag(config=True)
 
-    output = traits.Unicode(
-        help="Path to the hdf5 time calibration file",
-    ).tag(config=True)
-
-    pedestal = traits.Unicode(
-        help="Path to drs4 fits pedestal file",
-    ).tag(config=True)
-
     max_events = traits.Int(
         help="Maximum numbers of events to read. Default = 20000", default_value=20000
     ).tag(config=True)
@@ -45,7 +37,7 @@ class TimeCalibrationHDF5Writer(Tool):
     aliases = {
         "input": "TimeCalibrationHDF5Writer.input",
         "glob": "TimeCalibrationHDF5Writer.glob",
-        "output": "TimeCalibrationHDF5Writer.output",
+        "output": "TimeCorrectionCalculate.calib_file_path",
         "pedestal": "LSTR0Corrections.pedestal_path",
         "max_events": "TimeCalibrationHDF5Writer.max_events",
     }
@@ -79,10 +71,9 @@ class TimeCalibrationHDF5Writer(Tool):
             )
         )
         self.lst_r0 = self.add_component(
-            LSTR0Corrections(pedestal_path=self.pedestal, parent=self)
+            LSTR0Corrections(parent=self)
         )
         self.timeCorr = TimeCorrectionCalculate(
-            calib_file_path=self.output,
             subarray=self.eventsource.subarray,
             config=self.config,
         )
@@ -111,7 +102,7 @@ class TimeCalibrationHDF5Writer(Tool):
 
         self.timeCorr.finalize()
         Provenance().add_output_file(
-            self.output,
+            self.timeCorr.calib_file_path,
             role='mon.tel.calibration'
         )
 

--- a/lstchain/tools/lstchain_create_time_calibration_file.py
+++ b/lstchain/tools/lstchain_create_time_calibration_file.py
@@ -4,7 +4,6 @@ Create drs4 time correction coefficients.
 import numpy as np
 
 from ctapipe.core import Provenance, traits
-from ctapipe.io import HDF5TableWriter
 from ctapipe.core import Tool
 from ctapipe.io import EventSource
 from lstchain.calib.camera.r0 import LSTR0Corrections
@@ -17,8 +16,7 @@ class TimeCalibrationHDF5Writer(Tool):
     description = "Generate a HDF5 file with time calibration coefficients"
 
     output_file = traits.Unicode(
-        default_value="time_calibration.hdf5",
-        help="Path to the generated the generated HDF5 time calibration file",
+        help="Path to the time calibration file",
     ).tag(config=True)
 
     aliases = {
@@ -27,7 +25,7 @@ class TimeCalibrationHDF5Writer(Tool):
         "pedestal_file": "LSTR0Corrections.pedestal_path",
     }
 
-    classes = [EventSource, LSTR0Corrections]
+    classes = [EventSource, LSTR0Corrections, TimeCorrectionCalculate]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -35,7 +33,7 @@ class TimeCalibrationHDF5Writer(Tool):
         Tool that generates a HDF5 file with time calibration coefficients.
 
         For getting help run:
-        python lstchain_create_time_calibration_file.py --help
+        lstchain_create_time_calibration_file --help
         """
 
         self.eventsource = None
@@ -44,7 +42,7 @@ class TimeCalibrationHDF5Writer(Tool):
 
     def setup(self):
 
-        self.log.debug(f"Opening file")
+        self.log.debug("Opening file")
         self.eventsource = EventSource.from_config(parent=self)
         self.lst_r0 = LSTR0Corrections(config=self.config)
         self.timeCorr = TimeCorrectionCalculate(


### PR DESCRIPTION
This PR adds a new Tool  `lstchain_create_time_calibration_file`

```
lstchain_create_time_calibration_file --help-all
Generate a HDF5 file with time calibration coefficients

Options
-------

Arguments that take values are actually convenience aliases to full
Configurables, whose aliases are listed on the help line. For more information
on full configurables, see '--help-all'.

--input=<Path> (TimeCalibrationHDF5Writer.input)
    Default: None
    Path to the fits.fz events file or directory to glob
--glob=<Unicode> (TimeCalibrationHDF5Writer.glob)
    Default: '*'
    Filename pattern to glob files in the directory
--output=<Unicode> (TimeCalibrationHDF5Writer.output)
    Default: ''
    Path to the hdf5 time calibration file
--pedestal=<Unicode> (LSTR0Corrections.pedestal_path)
    Default: ''
    Path to the LST pedestal binary file
--max_events=<Int> (TimeCalibrationHDF5Writer.max_events)
    Default: 20000
    Maximum numbers of events to read. Default = 20000
--log-level=<Enum> (Application.log_level)
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.
--config=<Path> (Tool.config_file)
    Default: None
    name of a configuration file with parameters to load in addition to command-
    line parameters

Class parameters
----------------

Parameters are set from command-line arguments of the form:
`--Class.trait=value`. This line is evaluated in Python, so simple expressions
are allowed, e.g.:: `--C.a='range(3)'` For setting C.a=[0,1,2].

TimeCalibrationHDF5Writer options
---------------------------------
--TimeCalibrationHDF5Writer.config_file=<Path>
    Default: None
    name of a configuration file with parameters to load in addition to command-
    line parameters
--TimeCalibrationHDF5Writer.glob=<Unicode>
    Default: '*'
    Filename pattern to glob files in the directory
--TimeCalibrationHDF5Writer.input=<Path>
    Default: None
    Path to the fits.fz events file or directory to glob
--TimeCalibrationHDF5Writer.log_datefmt=<Unicode>
    Default: '%Y-%m-%d %H:%M:%S'
    The date format used by logging formatters for %(asctime)s
--TimeCalibrationHDF5Writer.log_format=<Unicode>
    Default: '%(levelname)s [%(name)s] (%(module)s/%(funcName)s): %(messag...
    The Logging format template
--TimeCalibrationHDF5Writer.log_level=<Enum>
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.
--TimeCalibrationHDF5Writer.max_events=<Int>
    Default: 20000
    Maximum numbers of events to read. Default = 20000
--TimeCalibrationHDF5Writer.output=<Unicode>
    Default: ''
    Path to the hdf5 time calibration file
--TimeCalibrationHDF5Writer.pedestal=<Unicode>
    Default: ''
    Path to drs4 fits pedestal file
--TimeCalibrationHDF5Writer.progress_bar=<Bool>
    Default: True
    show progress bar during processing

LSTEventSource options
----------------------
--LSTEventSource.allowed_tels=<Set>
    Default: set()
    list of allowed tel_ids, others will be ignored. If None, all telescopes in
    the input stream will be included
--LSTEventSource.baseline=<Int>
    Default: 400
    r0 waveform baseline (default from EvB v3)
--LSTEventSource.input_url=<Path>
    Default: None
    Path to the input file containing events.
--LSTEventSource.max_events=<Int>
    Default: None
    Maximum number of events that will be read from the file
--LSTEventSource.multi_streams=<Bool>
    Default: True
    Read in parallel all streams
--LSTEventSource.n_gains=<Int>
    Default: 2
    Number of gains at r0/r1 level

LSTR0Corrections options
------------------------
--LSTR0Corrections.offset=<Int>
    Default: 400
    Define the offset of the baseline
--LSTR0Corrections.pedestal_path=<Unicode>
    Default: ''
    Path to the LST pedestal binary file
--LSTR0Corrections.r1_sample_end=<Int>
    Default: 39
    End sample for r1 waveform
--LSTR0Corrections.r1_sample_start=<Int>
    Default: 3
    Start sample for r1 waveform
--LSTR0Corrections.tel_id=<Int>
    Default: 1
    id of the telescope to calibrate

TimeCorrectionCalculate options
-------------------------------
--TimeCorrectionCalculate.calib_file_path=<Unicode>
    Default: ''
    Path to the time calibration file
--TimeCorrectionCalculate.charge_product=<Unicode>
    Default: 'LocalPeakWindowSum'
    Name of the charge extractor to be used
--TimeCorrectionCalculate.minimum_charge=<Float>
    Default: 200
    Cut on charge. Default 200 ADC
--TimeCorrectionCalculate.n_capacitors=<Int>
    Default: 1024
    Number of capacitors (1024 or 4096). Default 1024.
--TimeCorrectionCalculate.n_combine=<Int>
    Default: 8
    How many capacitors are combines in a single bin. Default 8
--TimeCorrectionCalculate.n_harmonics=<Int>
    Default: 16
    Number of harmonic for Fourier series expansion. Default 16
--TimeCorrectionCalculate.tel_id=<Int>
    Default: 1
    Id of the telescope to calibrate
```