### PR TITLE
update astropy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     version=version,
     packages=find_packages(),
     install_requires=[
-        "astropy~=4.0",
+        "astropy~=4.0,>=4.0.2",
         'ctapipe~=0.8.0',
         'ctaplot~=0.5.3',
         "eventio>=1.1.1,<2.0.0a0",  # at least 1.1.1, but not 2


### PR DESCRIPTION
Current installation wheel (`conda env update -f env.yml` plus `pip install .`) installs 'astropy 4.0.1.post1'. And `pyirf` need astripy version 4.2.