### PR TITLE
Fix codes for adding source-dep params  when 'mc_type' of -1 is included

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -450,17 +450,20 @@ def get_source_dependent_parameters(data, config={}):
 
     src_dep_params = pd.DataFrame(index=data.index)
 
-    is_simu = 'mc_type' in data.columns
+    is_simu = ('mc_type' in data.columns) and ~(data['mc_type'] < 0).all()
     
     if is_simu:
-        if (data['mc_type'] == 0).all():
+        if (data['mc_type'][data['mc_type']>=0] == 0).all():
             data_type = 'mc_gamma'
         else:
             data_type = 'mc_proton'
     else:
         data_type = 'real_data'
     
+    print("data type: ", data_type)
+
     expected_src_pos_x_m, expected_src_pos_y_m = get_expected_source_pos(data, data_type, config)
+    print(f"expected source position: (x, y) = ({expected_src_pos_x_m[0]} m, {expected_src_pos_y_m[0]} m)")
 
     src_dep_params['expected_src_x'] = expected_src_pos_x_m
     src_dep_params['expected_src_y'] = expected_src_pos_y_m

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -450,8 +450,9 @@ def get_source_dependent_parameters(data, config={}):
 
     src_dep_params = pd.DataFrame(index=data.index)
 
-    is_simu = ('mc_type' in data.columns) and ~(data['mc_type'] < 0).all()
-    
+    is_simu = ~(data['mc_type'] < 0).all() if ('mc_type' in data.columns) else False
+
+    # -1 means real data or events that do not pass image cleaning, 0 means gamma, and >1 means hadron
     if is_simu:
         if (data['mc_type'][data['mc_type']>=0] == 0).all():
             data_type = 'mc_gamma'
@@ -460,8 +461,6 @@ def get_source_dependent_parameters(data, config={}):
     else:
         data_type = 'real_data'
     
-    print("data type: ", data_type)
-
     expected_src_pos_x_m, expected_src_pos_y_m = get_expected_source_pos(data, data_type, config)
     print(f"expected source position: (x, y) = ({expected_src_pos_x_m[0]} m, {expected_src_pos_y_m[0]} m)")
 


### PR DESCRIPTION
Current codes for adding source-dependent parameters assumed all of the events have the same `mc_type`. But `mc_type` is -1 for some events if those events don't pass image cleaning. Since `mc_type` of -1 is included in data, an unexpected source position is set with the current codes. This PR will fix that issue.