### PR TITLE
Raise an error when keys for the filtering don't exist

### DIFF
--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -92,14 +92,15 @@ def test_unix_tai_to_utc():
 
 def test_filter_events():
     from lstchain.reco.utils import filter_events
-    df = pd.DataFrame({'a': [1, 2, 3, ],
+    df = pd.DataFrame({'a': [1, 2, 3],
                        'b': [np.nan, 2.2, 3.2],
                        'c': [1, 2, np.inf]}
                       )
-    np.testing.assert_array_equal(filter_events(df, finite_params=['b']),
+    np.testing.assert_array_equal(filter_events(df, filters=dict(a=[0, np.inf], b=[0, np.inf], c=[0, np.inf]), finite_params=['b']),
                                   pd.DataFrame({'a': [2, 3], 'b': [2.2, 3.2], 'c': [2, np.inf]}))
-    np.testing.assert_array_equal(filter_events(df, finite_params=['b', 'c']),
+    np.testing.assert_array_equal(filter_events(df, filters=dict(a=[0, np.inf], b=[0, np.inf], c=[0, np.inf]), finite_params=['b', 'c']),
                                   pd.DataFrame({'a': [2], 'b': [2.2], 'c': [2]}))
-    np.testing.assert_array_equal(filter_events(df, finite_params=['e']), df)
-    np.testing.assert_array_equal(filter_events(df, filters={'a': [0, 1]}),
+    np.testing.assert_array_equal(filter_events(df, filters=dict(a=[0, 1])),
                                   pd.DataFrame({'a': [1], 'b': [np.nan], 'c': 1}))
+    with np.testing.assert_raises(KeyError):
+        filter_events(df, filters=dict(e=[0, np.inf]))

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -452,11 +452,8 @@ def filter_events(events,
     filter = np.ones(len(events), dtype=bool)
 
     for k in filters.keys():
-        if k in events.columns:
-            filter &= (events[k] >= filters[k][0]) & (events[k] <= filters[k][1])
-        else:
-            raise KeyError(f'{k} does not exist in the list of keys')
-
+        filter &= (events[k] >= filters[k][0]) & (events[k] <= filters[k][1])
+        
     if finite_params is not None:
         _finite_params = list(set(finite_params).intersection(list(events.columns)))
         with pd.option_context('mode.use_inf_as_null', True):

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -455,7 +455,7 @@ def filter_events(events,
         if k in events.columns:
             filter &= (events[k] >= filters[k][0]) & (events[k] <= filters[k][1])
         else:
-            raise TypeError(f'{k} does not exist in the list of keys')
+            raise KeyError(f'{k} does not exist in the list of keys')
 
     if finite_params is not None:
         _finite_params = list(set(finite_params).intersection(list(events.columns)))

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -436,7 +436,6 @@ def filter_events(events,
     Apply data filtering to a pandas dataframe.
     Each filtering range is applied if the column name exists in the DataFrame so that
     `(events >= range[0]) & (events <= range[1])`
-    If the column name does not exist, the filtering is simply not applied
 
     Parameters
     ----------
@@ -455,6 +454,8 @@ def filter_events(events,
     for k in filters.keys():
         if k in events.columns:
             filter &= (events[k] >= filters[k][0]) & (events[k] <= filters[k][1])
+        else:
+            raise TypeError(f'{k} does not exist in the list of keys')
 
     if finite_params is not None:
         _finite_params = list(set(finite_params).intersection(list(events.columns)))


### PR DESCRIPTION
If the column name for the filtering does not exist, the filtering is simply not applied without warning.
I myself sometimes wasted time as I didn't notice the filtering didn't work due to the change of hillas parameters' names.
This PR is to raise an error when keys for the filtering don't exist. 