### PR TITLE
adding back event_id and obs_id in dl1 tables

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -868,7 +868,7 @@ def write_subarray_tables(writer, event, metadata=None):
     metadata: `lstchain.io.lstcontainers.MetaData`
     """
     if metadata is not None:
-        add_global_metadata(event.dl0, metadata)
+        add_global_metadata(event.index, metadata)
         add_global_metadata(event.mc, metadata)
         add_global_metadata(event.trigger, metadata)
 

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -872,8 +872,8 @@ def write_subarray_tables(writer, event, metadata=None):
         add_global_metadata(event.mc, metadata)
         add_global_metadata(event.trigger, metadata)
 
-    writer.write(table_name="subarray/mc_shower", containers=[event.dl0, event.mc])
-    writer.write(table_name="subarray/trigger", containers=[event.dl0, event.trigger])
+    writer.write(table_name="subarray/mc_shower", containers=[event.index, event.mc])
+    writer.write(table_name="subarray/trigger", containers=[event.index, event.trigger])
 
 
 def write_dataframe(dataframe, outfile, table_path, mode='a', index=False):

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -659,10 +659,10 @@ def r0_to_dl1(
 
                     event.r0.prefix = ''
 
-                    writer.write(table_name = f'telescope/image/{tel_name}',
-                                 containers = [event.r0, tel, extra_im])
-                    writer.write(table_name = f'telescope/parameters/{tel_name}',
-                                 containers = [dl1_container])
+                    writer.write(table_name=f'telescope/image/{tel_name}',
+                                 containers=[event.index, tel, extra_im])
+                    writer.write(table_name=f'telescope/parameters/{tel_name}',
+                                 containers=[event.index, dl1_container])
 
                     # Muon ring analysis, for real data only (MC is done starting from DL1 files)
                     if not is_simu:

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import os
 import pandas as pd
-from lstchain.io.io import dl1_params_lstcam_key, dl2_params_lstcam_key
+from lstchain.io.io import dl1_params_lstcam_key, dl2_params_lstcam_key, dl1_images_lstcam_key
 from lstchain.reco.utils import filter_events
 import astropy.units as u
 import tables
@@ -102,7 +102,6 @@ def test_r0_to_dl1():
 @pytest.mark.run(after='test_r0_to_dl1')
 def test_content_dl1():
     # test presence of images and parameters
-    from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key
     with tables.open_file(dl1_file) as f:
         images_table = f.root[dl1_images_lstcam_key]
         params_table = f.root[dl1_params_lstcam_key]

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -105,14 +105,14 @@ def test_content_dl1():
     with tables.open_file(dl1_file) as f:
         images_table = f.root[dl1_images_lstcam_key]
         params_table = f.root[dl1_params_lstcam_key]
-    assert 'image' in images_table.colnames
-    assert 'peak_time' in images_table.colnames
-    assert 'tel_id' in images_table.colnames
-    assert 'obs_id' in images_table.colnames
-    assert 'event_id' in images_table.colnames
-    assert 'tel_id' in params_table.colnames
-    assert 'event_id' in params_table.colnames
-    assert 'obs_id' in params_table.colnames
+        assert 'image' in images_table.colnames
+        assert 'peak_time' in images_table.colnames
+        assert 'tel_id' in images_table.colnames
+        assert 'obs_id' in images_table.colnames
+        assert 'event_id' in images_table.colnames
+        assert 'tel_id' in params_table.colnames
+        assert 'event_id' in params_table.colnames
+        assert 'obs_id' in params_table.colnames
 
 def test_get_source_dependent_parameters():
     from lstchain.reco.dl1_to_dl2 import get_source_dependent_parameters

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -2,11 +2,11 @@ from ctapipe.utils import get_dataset_path
 import numpy as np
 import pytest
 import os
-import shutil
 import pandas as pd
 from lstchain.io.io import dl1_params_lstcam_key, dl2_params_lstcam_key
 from lstchain.reco.utils import filter_events
 import astropy.units as u
+import tables
 
 test_dir = 'testfiles'
 
@@ -98,6 +98,22 @@ def test_r0_to_dl1():
     from lstchain.reco.r0_to_dl1 import r0_to_dl1
     infile = mc_gamma_testfile
     r0_to_dl1(infile, custom_config=custom_config, output_filename=dl1_file)
+
+@pytest.mark.run(after='test_r0_to_dl1')
+def test_content_dl1():
+    # test presence of images and parameters
+    from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key
+    with tables.open_file(dl1_file) as f:
+        images_table = f.root[dl1_images_lstcam_key]
+        params_table = f.root[dl1_params_lstcam_key]
+    assert 'image' in images_table.cols
+    assert 'peak_time' in images_table.cols
+    assert 'tel_id' in images_table.cols
+    assert 'obs_id' in images_table.cols
+    assert 'event_id' in images_table.cols
+    assert 'tel_id' in params_table
+    assert 'event_id' in params_table
+    assert 'obs_id' in params_table
 
 def test_get_source_dependent_parameters():
     from lstchain.reco.dl1_to_dl2 import get_source_dependent_parameters

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -105,14 +105,14 @@ def test_content_dl1():
     with tables.open_file(dl1_file) as f:
         images_table = f.root[dl1_images_lstcam_key]
         params_table = f.root[dl1_params_lstcam_key]
-    assert 'image' in images_table.cols
-    assert 'peak_time' in images_table.cols
-    assert 'tel_id' in images_table.cols
-    assert 'obs_id' in images_table.cols
-    assert 'event_id' in images_table.cols
-    assert 'tel_id' in params_table
-    assert 'event_id' in params_table
-    assert 'obs_id' in params_table
+    assert 'image' in images_table.colnames
+    assert 'peak_time' in images_table.colnames
+    assert 'tel_id' in images_table.colnames
+    assert 'obs_id' in images_table.colnames
+    assert 'event_id' in images_table.colnames
+    assert 'tel_id' in params_table.colnames
+    assert 'event_id' in params_table.colnames
+    assert 'obs_id' in params_table.colnames
 
 def test_get_source_dependent_parameters():
     from lstchain.reco.dl1_to_dl2 import get_source_dependent_parameters


### PR DESCRIPTION
`event_id` and `obs_id` disappeared from the dl1 image table with ctapipe v0.8

add simple test to check if these parameters are present in the file after r0 to dl1