### PR TITLE
fill event info even if Hillas parameters could not be computed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ are unit tested and should be working as long as the build status is passing.
 
 - You will need to install [anaconda](https://www.anaconda.com/distribution/#download-section) first. 
 
+### As user
+
+```
+LSTCHAIN_VER=0.6.3
+wget https://raw.githubusercontent.com/cta-observatory/cta-lstchain/v$LSTCHAIN_VER/environment.yml
+conda env create -n lst -f environment.yml
+conda activate lst
+pip install https://github.com/cta-observatory/cta-lstchain/archive/v$LSTCHAIN_VER.tar.gz
+rm environment.yml
+```
+
+### As developer
+
 - Create and activate the conda environment:
 ```
 git clone https://github.com/cta-observatory/cta-lstchain.git
@@ -27,7 +40,7 @@ To update the environment (e.g. when depenencies got updated), use:
 conda env update -n lst-dev -f environment.yml
 ```
 
-- Install lstchain:
+- Install lstchain in developer mode:
 
 ```
 pip install -e .

--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -99,9 +99,7 @@ class DL1ParametersContainer(Container):
     mc_az_tel = Field(None, 'Telescope MC azimuth pointing', unit=u.rad)
     mc_alt_tel = Field(None, 'Telescope MC altitude pointing', unit=u.rad)
     mc_x_max = Field(None, "MC Xmax value", unit=u.g / u.cm**2)
-    mc_core_distance = Field(
-            u.Quantity(np.nan, u.m), "Distance from the impact point to the "
-                                     "telescope", unit=u.m)
+    mc_core_distance = Field(None, "Distance from the impact point to the telescope", unit=u.m)
     mc_shower_primary_id = Field(None, "MC shower primary ID 0 (gamma), 1(e-),"
                                     "2(mu-), 100*A+Z for nucleons and nuclei,"
                                     "negative for antimatter.")

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -60,6 +60,7 @@ from ..io.io import write_array_info_08
 from ..io.lstcontainers import ExtraImageInfo, DL1MonitoringEventIndexContainer
 from ..paths import parse_r0_filename, run_to_dl1_filename, r0_to_dl1_filename
 from ..pointing import PointingPosition
+from ..io.io import dl1_params_lstcam_key
 
 logger = logging.getLogger(__name__)
 
@@ -758,8 +759,7 @@ def r0_to_dl1(
         # Reconstruct source position from disp for all events and write the result in the output file
         for tel_name in ['LST_LSTCam']:
             focal = OpticsDescription.from_name(tel_name.split('_')[0]).equivalent_focal_length
-            dl1_params_key = f'dl1/event/telescope/parameters/{tel_name}'
-            add_disp_to_parameters_table(output_filename, dl1_params_key, focal)
+            add_disp_to_parameters_table(output_filename, dl1_params_lstcam_key, focal)
 
         # Write energy histogram from simtel file and extra metadata
         # ONLY of the simtel file has been read until the end, otherwise it seems to hang here forever

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -430,12 +430,12 @@ def r0_to_dl1(
                 # DL1 output or not.
 
                 try:
-                    dl1_filled = get_dl1(event,
-                                         subarray,
-                                         telescope_id,
-                                         dl1_container=dl1_container,
-                                         custom_config=config,
-                                         use_main_island=True)
+                    get_dl1(event,
+                            subarray,
+                            telescope_id,
+                            dl1_container=dl1_container,
+                            custom_config=config,
+                            use_main_island=True)
 
                 except HillasParameterizationError:
                     logging.exception(

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -142,7 +142,7 @@ def get_dl1(
         # Fill container
         dl1_container.fill_hillas(hillas)
 
-        if np.isfinite(dl1_container.intensity):
+        if dl1_container.intensity > 0:
             dl1_container.log_intensity = np.log10(dl1_container.intensity)
 
         # convert ctapipe's width and length (in m) to deg:

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -405,8 +405,6 @@ def r0_to_dl1(
                 # calibrate and extract image from event
                 r1_dl1_calibrator(event)
 
-                # update the calibration index in the dl1 event container
-                dl1_container.calibration_id = calibration_index.calibration_id
 
             # Temporal volume reducer for lstchain - dl1 level must be filled and dl0 will be overwritten.
             # When the last version of the method is implemented, vol. reduction will be done at dl0
@@ -419,6 +417,9 @@ def r0_to_dl1(
             for ii, telescope_id in enumerate(event.r0.tels_with_data):
 
                 dl1_container.reset()
+
+                # update the calibration index in the dl1 event container
+                dl1_container.calibration_id = calibration_index.calibration_id
 
                 dl1_container.fill_event_info(event)
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -142,12 +142,16 @@ def get_dl1(
         # Fill container
         dl1_container.fill_hillas(hillas)
 
+        if np.isfinite(dl1_container.intensity):
+            dl1_container.log_intensity = np.log10(dl1_container.intensity)
+
         # convert ctapipe's width and length (in m) to deg:
         foclen = subarray.tel[telescope_id].optics.equivalent_focal_length
         width = np.rad2deg(np.arctan2(dl1_container.width, foclen))
         length = np.rad2deg(np.arctan2(dl1_container.length, foclen))
         dl1_container.width = width
         dl1_container.length = length
+        dl1_container.wl = dl1_container.width / dl1_container.length
 
         dl1_container.set_timing_features(camera_geometry[signal_pixels],
                                           image[signal_pixels],
@@ -362,8 +366,6 @@ def r0_to_dl1(
             event.mc.prefix = 'mc'
             event.trigger.prefix = ''
 
-            dl1_container.reset()
-
             # write sub tables
             if is_simu:
                 write_subarray_tables(writer, event, metadata)
@@ -402,9 +404,6 @@ def r0_to_dl1(
                 # calibrate and extract image from event
                 r1_dl1_calibrator(event)
 
-                # update the calibration index in the dl1 event container
-                dl1_container.calibration_id = calibration_index.calibration_id
-
             # Temporal volume reducer for lstchain - dl1 level must be filled and dl0 will be overwritten.
             # When the last version of the method is implemented, vol. reduction will be done at dl0
             apply_volume_reduction(event, subarray, config)
@@ -414,6 +413,9 @@ def r0_to_dl1(
             # only after the ring analysis is complete.
 
             for ii, telescope_id in enumerate(event.r0.tels_with_data):
+                dl1_container.reset()
+                # update the calibration index in the dl1 event container
+                dl1_container.calibration_id = calibration_index.calibration_id
 
                 tel = event.dl1.tel[telescope_id]
                 tel.prefix = ''  # don't really need one
@@ -440,207 +442,198 @@ def r0_to_dl1(
                         'HillasParameterizationError in get_dl1()'
                     )
 
-                # The condition below should now be true for all events, this
-                # is a relic of previous approach in which only survivors of
-                # cleaning and parametrization were further processed.
-                if dl1_filled is not None:
+                dl1_container.fill_event_info(event)
 
-                    dl1_container.fill_event_info(event)
+                # Log10(Energy) in TeV
+                if is_simu:
+                    dl1_container.mc_energy = event.mc.energy.to_value(u.TeV)
+                    dl1_container.log_mc_energy = np.log10(event.mc.energy.to_value(u.TeV))
+                    dl1_container.fill_mc(event, subarray.positions[telescope_id])
 
-                    # Some custom def
-                    dl1_container.wl = dl1_container.width / dl1_container.length
-                    # Log10(Energy) in TeV
-                    if is_simu:
-                        dl1_container.mc_energy = event.mc.energy.to_value(u.TeV)
-                        dl1_container.log_mc_energy = np.log10(event.mc.energy.to_value(u.TeV))
-                        dl1_container.fill_mc(event, subarray.positions[telescope_id])
+                if not is_simu:
+                    # GPS + WRS + UCTS is now working in its nominal configuration.
+                    # These TS are stored into ucts_time container.
+                    # TS can be alternatively calculated from the TIB and
+                    # Dragon modules counters based on the first valid UCTS TS
+                    # as the reference point. For the time being, the three TS
+                    # are stored in the DL1 files for checking purposes.
 
-                    dl1_container.log_intensity = np.log10(dl1_container.intensity)
+                    module_id = 82  # Get counters from the central Dragon module
 
-                    if not is_simu:
-                        # GPS + WRS + UCTS is now working in its nominal configuration.
-                        # These TS are stored into ucts_time container.
-                        # TS can be alternatively calculated from the TIB and
-                        # Dragon modules counters based on the first valid UCTS TS
-                        # as the reference point. For the time being, the three TS
-                        # are stored in the DL1 files for checking purposes.
+                    if math.isnan(ucts_t0_dragon) and math.isnan(dragon_counter0) \
+                            and math.isnan(ucts_t0_tib) and math.isnan(tib_counter0):
+                        # Dragon/TIB timestamps not based on a valid absolute reference timestamp
 
-                        module_id = 82  # Get counters from the central Dragon module
+                        dragon_time = (
+                                event.lst.tel[telescope_id].svc.date +
+                                event.lst.tel[telescope_id].evt.pps_counter[module_id] +
+                                event.lst.tel[telescope_id].evt.tenMHz_counter[module_id] * 10 ** (-7)
+                        )
 
-                        if math.isnan(ucts_t0_dragon) and math.isnan(dragon_counter0) \
-                                and math.isnan(ucts_t0_tib) and math.isnan(tib_counter0):
-                            # Dragon/TIB timestamps not based on a valid absolute reference timestamp
+                        tib_time = (
+                                event.lst.tel[telescope_id].svc.date +
+                                event.lst.tel[telescope_id].evt.tib_pps_counter +
+                                event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10 ** (-7)
+                        )
 
-                            dragon_time = (
-                                    event.lst.tel[telescope_id].svc.date +
-                                    event.lst.tel[telescope_id].evt.pps_counter[module_id] +
-                                    event.lst.tel[telescope_id].evt.tenMHz_counter[module_id] * 10 ** (-7)
-                            )
+                        if event.lst.tel[telescope_id].evt.extdevices_presence & 2:
+                            # UCTS presence flag is OK
+                            ucts_time = event.lst.tel[telescope_id].evt.ucts_timestamp * 1e-9  # secs
 
-                            tib_time = (
-                                    event.lst.tel[telescope_id].svc.date +
-                                    event.lst.tel[telescope_id].evt.tib_pps_counter +
-                                    event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10 ** (-7)
-                            )
+                            if first_valid_ucts is None:
+                                first_valid_ucts = ucts_time
 
-                            if event.lst.tel[telescope_id].evt.extdevices_presence & 2:
-                                # UCTS presence flag is OK
-                                ucts_time = event.lst.tel[telescope_id].evt.ucts_timestamp * 1e-9  # secs
+                                initial_dragon_counter = (
+                                        event.lst.tel[telescope_id].evt.pps_counter[module_id] +
+                                        event.lst.tel[telescope_id].evt.tenMHz_counter[module_id] * 10 ** (-7)
+                                )
+                                logger.warning(
+                                    f"Dragon timestamps not based on a valid absolute reference timestamp. "
+                                    f"Consider using the following initial values \n"
+                                    f"Event ID: {event.index.event_id}, "
+                                    f"First valid UCTS timestamp: {first_valid_ucts:.9f} s, "
+                                    f"corresponding Dragon counter {initial_dragon_counter:.9f} s"
+                                )
 
-                                if first_valid_ucts is None:
-                                    first_valid_ucts = ucts_time
+                            if event.lst.tel[telescope_id].evt.extdevices_presence & 1 \
+                                    and first_valid_ucts_tib is None:
+                                # Both TIB and UCTS presence flags are OK
+                                first_valid_ucts_tib = ucts_time
 
-                                    initial_dragon_counter = (
-                                            event.lst.tel[telescope_id].evt.pps_counter[module_id] +
-                                            event.lst.tel[telescope_id].evt.tenMHz_counter[module_id] * 10 ** (-7)
-                                    )
-                                    logger.warning(
-                                        f"Dragon timestamps not based on a valid absolute reference timestamp. "
-                                        f"Consider using the following initial values \n"
-                                        f"Event ID: {event.index.event_id}, "
-                                        f"First valid UCTS timestamp: {first_valid_ucts:.9f} s, "
-                                        f"corresponding Dragon counter {initial_dragon_counter:.9f} s"
-                                    )
-
-                                if event.lst.tel[telescope_id].evt.extdevices_presence & 1 \
-                                        and first_valid_ucts_tib is None:
-                                    # Both TIB and UCTS presence flags are OK
-                                    first_valid_ucts_tib = ucts_time
-
-                                    initial_tib_counter = (
-                                            event.lst.tel[telescope_id].evt.tib_pps_counter +
-                                            event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10 ** (-7)
-                                    )
-                                    logger.warning(
-                                        f"TIB timestamps not based on a valid absolute reference timestamp. "
-                                        f"Consider using the following initial values \n"
-                                        f"Event ID: {event.index.event_id}, UCTS timestamp corresponding to "
-                                        f"the first valid TIB counter: {first_valid_ucts_tib:.9f} s, "
-                                        f"corresponding TIB counter {initial_tib_counter:.9f} s"
-                                    )
-                            else:
-                                ucts_time = math.nan
-
+                                initial_tib_counter = (
+                                        event.lst.tel[telescope_id].evt.tib_pps_counter +
+                                        event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10 ** (-7)
+                                )
+                                logger.warning(
+                                    f"TIB timestamps not based on a valid absolute reference timestamp. "
+                                    f"Consider using the following initial values \n"
+                                    f"Event ID: {event.index.event_id}, UCTS timestamp corresponding to "
+                                    f"the first valid TIB counter: {first_valid_ucts_tib:.9f} s, "
+                                    f"corresponding TIB counter {initial_tib_counter:.9f} s"
+                                )
                         else:
-                            # Dragon/TIB timestamps based on a valid absolute reference UCTS timestamp
-                            dragon_time = (
-                                    (ucts_t0_dragon - dragon_counter0) * 1e-9 +  # secs
-                                    event.lst.tel[telescope_id].evt.pps_counter[module_id] +
-                                    event.lst.tel[telescope_id].evt.tenMHz_counter[module_id] * 10 ** (-7)
-                            )
+                            ucts_time = math.nan
 
-                            tib_time = (
-                                    (ucts_t0_tib - tib_counter0) * 1e-9 +  # secs
-                                    event.lst.tel[telescope_id].evt.tib_pps_counter +
-                                    event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10 ** (-7)
-                            )
+                    else:
+                        # Dragon/TIB timestamps based on a valid absolute reference UCTS timestamp
+                        dragon_time = (
+                                (ucts_t0_dragon - dragon_counter0) * 1e-9 +  # secs
+                                event.lst.tel[telescope_id].evt.pps_counter[module_id] +
+                                event.lst.tel[telescope_id].evt.tenMHz_counter[module_id] * 10 ** (-7)
+                        )
 
-                            if event.lst.tel[telescope_id].evt.extdevices_presence & 2:
-                                # UCTS presence flag is OK
-                                ucts_time = event.lst.tel[telescope_id].evt.ucts_timestamp * 1e-9  # secs
-                                if first_valid_ucts is None:
-                                    first_valid_ucts = ucts_time
-                                if first_valid_ucts_tib is None \
-                                        and event.lst.tel[telescope_id].evt.extdevices_presence & 1:
-                                    first_valid_ucts_tib = ucts_time
-                            else:
-                                ucts_time = math.nan
+                        tib_time = (
+                                (ucts_t0_tib - tib_counter0) * 1e-9 +  # secs
+                                event.lst.tel[telescope_id].evt.tib_pps_counter +
+                                event.lst.tel[telescope_id].evt.tib_tenMHz_counter * 10 ** (-7)
+                        )
 
-                        # FIXME: directly use unix_tai format whenever astropy v4.1 is out
-                        ucts_time_utc = unix_tai_to_time(ucts_time)
-                        dragon_time_utc = unix_tai_to_time(dragon_time)
-                        tib_time_utc = unix_tai_to_time(tib_time)
-
-                        dl1_container.ucts_time = ucts_time_utc.unix
-                        dl1_container.dragon_time = dragon_time_utc.unix
-                        dl1_container.tib_time = tib_time_utc.unix
-
-                        # Until the TIB trigger_type is fully reliable, we also add
-                        # the ucts_trigger_type to the data
-                        dl1_container.ucts_trigger_type = event.lst.tel[telescope_id].evt.ucts_trigger_type
-
-                        # Due to a DAQ bug, sometimes there are 'jumps' in the
-                        # UCTS info in the raw files. After one such jump,
-                        # all the UCTS info attached to an event actually
-                        # corresponds to the next event. This one-event
-                        # shift stays like that until there is another jump
-                        # (then it becomes a 2-event shift and so on). We will
-                        # keep track of those jumps, by storing the UCTS info
-                        # of the previously read events in the list
-                        # previous_ucts_time_unix. The list has one element
-                        # for each of the jumps, so if there has been just
-                        # one jump we have the UCTS info of the previous
-                        # event only (which truly corresponds to the
-                        # current event). If there have been n jumps, we keep
-                        # the past n events. The info to be used for
-                        # the current event is always the first element of
-                        # the array, previous_ucts_time_unix[0], whereas the
-                        # current event's (wrong) ucts info is placed last in
-                        # the array. Each time the first array element is
-                        # used, it is removed and the rest move up in the
-                        # list. We have another similar array for the trigger
-                        # types, previous_ucts_trigger_type
-                        #
-                        if len(previous_ucts_time_unix) > 0:
-                            # keep the time & trigger type read for this
-                            # event (which really correspond to a later event):
-                            current_ucts_time = dl1_container.ucts_time
-                            current_ucts_trigger_type = dl1_container.ucts_trigger_type
-                            # put in dl1_container the proper time for this
-                            # event:
-                            dl1_container.ucts_time = \
-                                previous_ucts_time_unix.pop(0)
-                            dl1_container.ucts_trigger_type = \
-                                previous_ucts_trigger_type.pop(0)
-
-                            # now put the current values last in the list,
-                            # for later use:
-                            previous_ucts_time_unix.append(current_ucts_time)
-                            previous_ucts_trigger_type.\
-                                append(current_ucts_trigger_type)
-
-                        # Now check consistency of UCTS and Dragon times. If
-                        # UCTS time is ahead of Dragon time by more than
-                        # 1.e-6 s, most likely the UCTS info has been
-                        # lost for this event (i.e. there has been another
-                        # 'jump' of those described above), and the one we have
-                        # actually corresponds to the next event. So we put it
-                        # back first in the list, to assign it to the next
-                        # event. We also move the other elements down in the
-                        # list,  which will now be one element longer.
-                        # We leave the current event with the same time,
-                        # which will be approximately correct (depending on
-                        # event rate), and set its ucts_trigger_type to -1,
-                        # which will tell us a jump happened and hence this
-                        # event does not have proper UCTS info.
-
-                        if dl1_container.ucts_time - dl1_container.dragon_time > 1.e-6:
-                            previous_ucts_time_unix.\
-                                insert( 0, dl1_container.ucts_time)
-                            previous_ucts_trigger_type.\
-                                insert(0, dl1_container.ucts_trigger_type)
-                            dl1_container.ucts_trigger_type = -1
-
-                        # Select the timestamps to be used for pointing interpolation
-                        if config['timestamps_pointing'] == "ucts":
-                            event_timestamps = dl1_container.ucts_time
-                        elif config['timestamps_pointing'] == "dragon":
-                            event_timestamps = dragon_time_utc.unix
-                        elif config['timestamps_pointing'] == "tib":
-                            event_timestamps = tib_time_utc.unix
+                        if event.lst.tel[telescope_id].evt.extdevices_presence & 2:
+                            # UCTS presence flag is OK
+                            ucts_time = event.lst.tel[telescope_id].evt.ucts_timestamp * 1e-9  # secs
+                            if first_valid_ucts is None:
+                                first_valid_ucts = ucts_time
+                            if first_valid_ucts_tib is None \
+                                    and event.lst.tel[telescope_id].evt.extdevices_presence & 1:
+                                first_valid_ucts_tib = ucts_time
                         else:
-                            raise ValueError("The timestamps_pointing option is not a valid one. \
-                                             Try ucts (default), dragon or tib.")
+                            ucts_time = math.nan
 
-                        if pointing_file_path and event_timestamps > 0:
-                            azimuth, altitude = pointings.cal_pointingposition(event_timestamps, drive_data)
-                            event.pointing.tel[telescope_id].azimuth = azimuth
-                            event.pointing.tel[telescope_id].altitude = altitude
-                            dl1_container.az_tel = azimuth
-                            dl1_container.alt_tel = altitude
-                        else:
-                            dl1_container.az_tel = u.Quantity(np.nan, u.rad)
-                            dl1_container.alt_tel = u.Quantity(np.nan, u.rad)
+                    # FIXME: directly use unix_tai format whenever astropy v4.1 is out
+                    ucts_time_utc = unix_tai_to_time(ucts_time)
+                    dragon_time_utc = unix_tai_to_time(dragon_time)
+                    tib_time_utc = unix_tai_to_time(tib_time)
+
+                    dl1_container.ucts_time = ucts_time_utc.unix
+                    dl1_container.dragon_time = dragon_time_utc.unix
+                    dl1_container.tib_time = tib_time_utc.unix
+
+                    # Until the TIB trigger_type is fully reliable, we also add
+                    # the ucts_trigger_type to the data
+                    dl1_container.ucts_trigger_type = event.lst.tel[telescope_id].evt.ucts_trigger_type
+
+                    # Due to a DAQ bug, sometimes there are 'jumps' in the
+                    # UCTS info in the raw files. After one such jump,
+                    # all the UCTS info attached to an event actually
+                    # corresponds to the next event. This one-event
+                    # shift stays like that until there is another jump
+                    # (then it becomes a 2-event shift and so on). We will
+                    # keep track of those jumps, by storing the UCTS info
+                    # of the previously read events in the list
+                    # previous_ucts_time_unix. The list has one element
+                    # for each of the jumps, so if there has been just
+                    # one jump we have the UCTS info of the previous
+                    # event only (which truly corresponds to the
+                    # current event). If there have been n jumps, we keep
+                    # the past n events. The info to be used for
+                    # the current event is always the first element of
+                    # the array, previous_ucts_time_unix[0], whereas the
+                    # current event's (wrong) ucts info is placed last in
+                    # the array. Each time the first array element is
+                    # used, it is removed and the rest move up in the
+                    # list. We have another similar array for the trigger
+                    # types, previous_ucts_trigger_type
+                    #
+                    if len(previous_ucts_time_unix) > 0:
+                        # keep the time & trigger type read for this
+                        # event (which really correspond to a later event):
+                        current_ucts_time = dl1_container.ucts_time
+                        current_ucts_trigger_type = dl1_container.ucts_trigger_type
+                        # put in dl1_container the proper time for this
+                        # event:
+                        dl1_container.ucts_time = \
+                            previous_ucts_time_unix.pop(0)
+                        dl1_container.ucts_trigger_type = \
+                            previous_ucts_trigger_type.pop(0)
+
+                        # now put the current values last in the list,
+                        # for later use:
+                        previous_ucts_time_unix.append(current_ucts_time)
+                        previous_ucts_trigger_type.\
+                            append(current_ucts_trigger_type)
+
+                    # Now check consistency of UCTS and Dragon times. If
+                    # UCTS time is ahead of Dragon time by more than
+                    # 1.e-6 s, most likely the UCTS info has been
+                    # lost for this event (i.e. there has been another
+                    # 'jump' of those described above), and the one we have
+                    # actually corresponds to the next event. So we put it
+                    # back first in the list, to assign it to the next
+                    # event. We also move the other elements down in the
+                    # list,  which will now be one element longer.
+                    # We leave the current event with the same time,
+                    # which will be approximately correct (depending on
+                    # event rate), and set its ucts_trigger_type to -1,
+                    # which will tell us a jump happened and hence this
+                    # event does not have proper UCTS info.
+
+                    if dl1_container.ucts_time - dl1_container.dragon_time > 1.e-6:
+                        previous_ucts_time_unix.\
+                            insert( 0, dl1_container.ucts_time)
+                        previous_ucts_trigger_type.\
+                            insert(0, dl1_container.ucts_trigger_type)
+                        dl1_container.ucts_trigger_type = -1
+
+                    # Select the timestamps to be used for pointing interpolation
+                    if config['timestamps_pointing'] == "ucts":
+                        event_timestamps = dl1_container.ucts_time
+                    elif config['timestamps_pointing'] == "dragon":
+                        event_timestamps = dragon_time_utc.unix
+                    elif config['timestamps_pointing'] == "tib":
+                        event_timestamps = tib_time_utc.unix
+                    else:
+                        raise ValueError("The timestamps_pointing option is not a valid one. \
+                                         Try ucts (default), dragon or tib.")
+
+                    if pointing_file_path and event_timestamps > 0:
+                        azimuth, altitude = pointings.cal_pointingposition(event_timestamps, drive_data)
+                        event.pointing.tel[telescope_id].azimuth = azimuth
+                        event.pointing.tel[telescope_id].altitude = altitude
+                        dl1_container.az_tel = azimuth
+                        dl1_container.alt_tel = altitude
+                    else:
+                        dl1_container.az_tel = u.Quantity(np.nan, u.rad)
+                        dl1_container.alt_tel = u.Quantity(np.nan, u.rad)
 
                     dl1_container.trigger_time = event.r0.tel[telescope_id].trigger_time
                     dl1_container.trigger_type = event.r0.tel[telescope_id].trigger_type


### PR DESCRIPTION
Some information about the events were not written in case the Hillas Parameterisation failed, although we should keep this info (otherwise there is no point keeping the event).
Interestingly enough, there was a comment in the code in this sense already:
> The condition below should now be true for all events, this dl1_container.fill_event_info(event) is a relic of the previous approach in which only survivors of cleaning and parametrization were further processed.

I also make some related cleaning.

## Changes:
- reset dl1 container before to fill it
- always fill event info (event id, obs id) and missing mc info: `mc_type` and `mc_core_distance`
- move some dl1 computation in get_dl1 or in fill_mc
- fill MC info whether or not Hillas parameters are computed
- treat events independently of the computation of the dl1 parameters

I would like to do more cleaning but there was too much (to do and to review), so more small PRs will come after this one.

## To help the review

There seems to be a lot of changes but actually, after `if dl1_filled is not None:` (line 446) I just remove an indentation from all concerned lines.
