### PR TITLE
Fix gammapy error due to the new version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.7
   - pip
   - ctapipe=0.8.0
-  - gammapy>=0.17
+  - gammapy>=0.18
   - h5py
   - ipython
   - jupyter

--- a/environment.yml
+++ b/environment.yml
@@ -18,4 +18,4 @@ dependencies:
       - pytest-ordering
       - git+git://github.com/cta-observatory/ctapipe_io_lst@v0.5.3
       - ctaplot
-      - pyirf~=0.3.0
+      - pyirf~=0.4.0

--- a/lstchain/mc/sensitivity.py
+++ b/lstchain/mc/sensitivity.py
@@ -10,6 +10,7 @@ from lstchain.reco.utils import reco_source_position_sky
 from astropy.coordinates.angle_utilities import angular_separation
 from lstchain.io import read_simu_info_merged_hdf5
 from lstchain.io.io import dl2_params_lstcam_key
+from pyirf.sensitivity import relative_sensitivity
 
 __all__ = [
     'read_sim_par',
@@ -23,6 +24,10 @@ __all__ = [
     'sensitivity',
     ]
 
+
+def excess_matching_significance(n_on, n_off, alpha, significance):
+    n_excess = n_on - alpha *  n_off
+    return n_excess * relative_sensitivity(n_on=n_on, n_off=n_off, alpha=alpha)
 
 def read_sim_par(dl1_file):
     """
@@ -185,8 +190,8 @@ def calculate_sensitivity_lima(n_on_events, n_background, alpha, n_bins_energy, 
         )
 
 
-    n_excesses_5sigma = stat.n_sig_matching_significance(5)
-
+    n_excesses_5sigma = excess_matching_significance(5)
+    
     for i in range(0, n_bins_energy):
         for j in range(0, n_bins_gammaness):
             for k in range(0, n_bins_theta2):
@@ -233,8 +238,7 @@ def calculate_sensitivity_lima_ebin(n_on_events, n_background, alpha, n_bins_ene
         )
         
 
-
-    n_excesses_5sigma = stat.n_sig_matching_significance(5)
+    n_excesses_5sigma = excess_matching_significance(5)
 
     for i in range(0, n_bins_energy):
         # If the excess needed to get 5 sigma is less than 10,

--- a/lstchain/mc/sensitivity.py
+++ b/lstchain/mc/sensitivity.py
@@ -5,7 +5,6 @@ from .plot_utils import sensitivity_minimization_plot, plot_positions_survived_e
 from .mc import rate, weight
 from lstchain.spectra.crab import crab_hegra,crab_magic
 from lstchain.spectra.proton import proton_bess
-from gammapy.stats import WStatCountsStatistic
 from lstchain.reco.utils import reco_source_position_sky
 from astropy.coordinates.angle_utilities import angular_separation
 from lstchain.io import read_simu_info_merged_hdf5
@@ -183,14 +182,7 @@ def calculate_sensitivity_lima(n_on_events, n_background, alpha, n_bins_energy, 
     """
 
     
-    stat = WStatCountsStatistic(
-        n_on=n_on_events,  
-        n_off=n_background,
-        alpha=alpha
-        )
-
-
-    n_excesses_5sigma = excess_matching_significance(5)
+    n_excesses_5sigma = excess_matching_significance(n_on_events, n_background, alpha, 5)
     
     for i in range(0, n_bins_energy):
         for j in range(0, n_bins_gammaness):
@@ -227,18 +219,8 @@ def calculate_sensitivity_lima_ebin(n_on_events, n_background, alpha, n_bins_ene
                 a 5 sigma significance
 
     """
-    #if any(len(a) != n_bins_energy for a in (n_on_events, n_background, alpha)):
-    #    raise ValueError(
-     #       'Excess, background and alpha arrays must have the same length')
-
-    stat = WStatCountsStatistic(
-        n_on=n_on_events,
-        n_off=n_background,
-        alpha=alpha 
-        )
         
-
-    n_excesses_5sigma = excess_matching_significance(5)
+    n_excesses_5sigma = excess_matching_significance(n_on_events, n_background, alpha, 5)
 
     for i in range(0, n_bins_energy):
         # If the excess needed to get 5 sigma is less than 10,

--- a/lstchain/mc/sensitivity.py
+++ b/lstchain/mc/sensitivity.py
@@ -185,7 +185,7 @@ def calculate_sensitivity_lima(n_on_events, n_background, alpha, n_bins_energy, 
         )
 
 
-    n_excesses_5sigma = stat.excess_matching_significance(5)
+    n_excesses_5sigma = stat.n_sig_matching_significance(5)
 
     for i in range(0, n_bins_energy):
         for j in range(0, n_bins_gammaness):
@@ -234,7 +234,7 @@ def calculate_sensitivity_lima_ebin(n_on_events, n_background, alpha, n_bins_ene
         
 
 
-    n_excesses_5sigma = stat.excess_matching_significance(5)
+    n_excesses_5sigma = stat.n_sig_matching_significance(5)
 
     for i in range(0, n_bins_energy):
         # If the excess needed to get 5 sigma is less than 10,

--- a/lstchain/mc/tests/test_senstivity.py
+++ b/lstchain/mc/tests/test_senstivity.py
@@ -46,10 +46,10 @@ def test_calculate_sensitivity_lima():
     
     np.testing.assert_allclose(calculate_sensitivity_lima(
             50, 10, 0.2, 1, 0, 0),
-                               ([13.49, 26.97]), rtol = 1.e-3)
+                               ([13.48, 26.97]), rtol = 1.e-3)
     np.testing.assert_allclose(calculate_sensitivity_lima(
             200, 50, 1, 0, 1, 0),
-                               ([63.01, 31.50]), rtol = 1.e-3)
+                               ([63.00, 31.5]), rtol = 1.e-3)
     # Testing an array
     np.testing.assert_allclose(calculate_sensitivity_lima(
             np.array([100, 100]), np.array([20, 10]), np.array([1, 1]), 1, 1, 0),

--- a/lstchain/mc/tests/test_senstivity.py
+++ b/lstchain/mc/tests/test_senstivity.py
@@ -46,7 +46,7 @@ def test_calculate_sensitivity_lima():
     
     np.testing.assert_allclose(calculate_sensitivity_lima(
             50, 10, 0.2, 1, 0, 0),
-                               ([13.48, 26.97]), rtol = 1.e-3)
+                               ([7.429626, 14.859252]), rtol = 1.e-3)
     np.testing.assert_allclose(calculate_sensitivity_lima(
             200, 50, 1, 0, 1, 0),
                                ([63.00, 31.5]), rtol = 1.e-3)
@@ -58,12 +58,12 @@ def test_calculate_sensitivity_lima():
 def test_calculate_sensitivity_lima_ebin():
     
     np.testing.assert_allclose(calculate_sensitivity_lima_ebin(
-            [50], [10], [0.2], 1), ([13.48], [26.97]), 
+            [50], [10], [0.2], 1), ([10.], [20.]), 
                                rtol = 1.e-3)
 
     np.testing.assert_allclose(calculate_sensitivity_lima_ebin(
             [50, 20, 10], [10, 10, 10], [0.2, 0.2, 0.2], 3), 
-                               (([13.48, 13.48, 13.48]),
+                               (([10., 10., 10.]),
                                 [ 26.97208396,  67.43020989, 134.86041979]), 
                                rtol = 1.e-3)
 

--- a/lstchain/mc/tests/test_senstivity.py
+++ b/lstchain/mc/tests/test_senstivity.py
@@ -58,11 +58,11 @@ def test_calculate_sensitivity_lima():
 def test_calculate_sensitivity_lima_ebin():
     
     np.testing.assert_allclose(calculate_sensitivity_lima_ebin(
-            [50], [10], [0.2], 1), ([10.], [20.]), 
+            np.array(50), np.array(10), np.array(0.2), 1), ([10.], [20.]), 
                                rtol = 1.e-3)
 
     np.testing.assert_allclose(calculate_sensitivity_lima_ebin(
-            [50, 20, 10], [10, 10, 10], [0.2, 0.2, 0.2], 3), 
+            np.array([50, 20, 10]), np.array([10, 10, 10]), np.array([0.2, 0.2, 0.2]), 3), 
                                (([10., 10.730952,  12.1983]),
                                 [20., 53.654761, 121.982995]), 
                                rtol = 1.e-3)

--- a/lstchain/mc/tests/test_senstivity.py
+++ b/lstchain/mc/tests/test_senstivity.py
@@ -52,8 +52,8 @@ def test_calculate_sensitivity_lima():
                                ([27.71, 13.85]), rtol = 1.e-3)
     # Testing an array
     np.testing.assert_allclose(calculate_sensitivity_lima(
-            [10, 100], [50,100], [1, 1], 1, 1, 0),
-                               ([63.00, 83.57],[630.07,  83.57]), rtol = 1.e-3)
+            [10, 100], [40,100], [1, 1], 1, 1, 0),
+                               ([74.98, 83.57], [749.83, 83.57]), rtol = 1.e-3)
 
 def test_calculate_sensitivity_lima_ebin():
     

--- a/lstchain/mc/tests/test_senstivity.py
+++ b/lstchain/mc/tests/test_senstivity.py
@@ -46,25 +46,25 @@ def test_calculate_sensitivity_lima():
     
     np.testing.assert_allclose(calculate_sensitivity_lima(
             50, 10, 0.2, 1, 0, 0),
-                               ([7.429626, 14.859252]), rtol = 1.e-3)
+                               ([13.49, 26.97]), rtol = 1.e-3)
     np.testing.assert_allclose(calculate_sensitivity_lima(
             200, 50, 1, 0, 1, 0),
-                               ([27.71, 13.85]), rtol = 1.e-3)
+                               ([63.01, 31.50]), rtol = 1.e-3)
     # Testing an array
     np.testing.assert_allclose(calculate_sensitivity_lima(
-            [10, 100], [40,100], [1, 1], 1, 1, 0),
-                               ([74.98, 83.57], [749.83, 83.57]), rtol = 1.e-3)
+            np.array([100, 100]), np.array([20, 10]), np.array([1, 1]), 1, 1, 0),
+                               ([44.90, 35.92], [44.90, 35.92]), rtol = 1.e-3)
 
 def test_calculate_sensitivity_lima_ebin():
     
     np.testing.assert_allclose(calculate_sensitivity_lima_ebin(
-            np.array(50), np.array(10), np.array(0.2), 1), ([10.], [20.]), 
+            np.array([50]), np.array([10]), np.array([0.2]), 1), ([13.49], [26.97]), 
                                rtol = 1.e-3)
 
     np.testing.assert_allclose(calculate_sensitivity_lima_ebin(
-            np.array([50, 20, 10]), np.array([10, 10, 10]), np.array([0.2, 0.2, 0.2]), 3), 
-                               (([10., 10.730952,  12.1983]),
-                                [20., 53.654761, 121.982995]), 
+            np.array([50, 30, 20]), np.array([10, 10, 10]), np.array([0.2, 0.2, 0.2]), 3), 
+                               (([13.49, 13.49,  13.49]),
+                                [26.97, 44.95, 67.43]), 
                                rtol = 1.e-3)
 
 def test_bin_definition():

--- a/lstchain/mc/tests/test_senstivity.py
+++ b/lstchain/mc/tests/test_senstivity.py
@@ -49,7 +49,7 @@ def test_calculate_sensitivity_lima():
                                ([7.429626, 14.859252]), rtol = 1.e-3)
     np.testing.assert_allclose(calculate_sensitivity_lima(
             200, 50, 1, 0, 1, 0),
-                               ([63.00, 31.5]), rtol = 1.e-3)
+                               ([27.71, 13.85]), rtol = 1.e-3)
     # Testing an array
     np.testing.assert_allclose(calculate_sensitivity_lima(
             [10, 100], [50,100], [1, 1], 1, 1, 0),
@@ -63,8 +63,8 @@ def test_calculate_sensitivity_lima_ebin():
 
     np.testing.assert_allclose(calculate_sensitivity_lima_ebin(
             [50, 20, 10], [10, 10, 10], [0.2, 0.2, 0.2], 3), 
-                               (([10., 10., 10.]),
-                                [ 26.97208396,  67.43020989, 134.86041979]), 
+                               (([10., 10.730952,  12.1983]),
+                                [20., 53.654761, 121.982995]), 
                                rtol = 1.e-3)
 
 def test_bin_definition():

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'numba',
         'numpy',
         'pandas',
-        'pyirf~=0.3.0',
+        'pyirf~=0.4.0',
         'scipy',
         'seaborn',
         'scikit-learn',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'ctapipe~=0.8.0',
         'ctaplot~=0.5.3',
         "eventio>=1.1.1,<2.0.0a0",  # at least 1.1.1, but not 2
-        'gammapy>=0.17',
+        'gammapy>=0.18',
         'h5py',
         'joblib',
         'matplotlib',


### PR DESCRIPTION
Fix errors due to the name changing of function `excess_matching_significance` -> `n_sig_matching_significance` in gammapy v0.18

Also, the significance definition changed and there were some modifications on the results, so tests were also modified.