### PR TITLE
Switch to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  NUMBA_NUM_THREADS: 1
+  MPLBACKEND: Agg
+  PYTEST_ADDOPTS: --color=yes
+  CTAPIPE_IO_LST_VERSION: v0.5.3
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
+        ctapipe-version: [v0.8.0]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          CTAPIPE_VERSION: ${{ matrix.ctapipe-version }}
+
+        run: |
+          . $CONDA/etc/profile.d/conda.sh
+          conda config --set always_yes yes --set changeps1 no
+          sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
+          conda env create -n ci -f environment.yml
+          conda activate ci
+          # we install ctapipe using pip to be able to select any commit, e.g. the current master
+          pip install pytest-cov 
+          pip install \
+            "git+https://github.com/cta-observatory/ctapipe@$CTAPIPE_VERSION" \
+            "git+https://github.com/cta-observatory/ctapipe_io_lst@$CTAPIPE_IO_LST_VERSION" \
+            pytest-cov
+
+          pip install -e .
+
+      - name: Tests
+        run: |
+          # github actions starts a new shell for each "step", so we need to 
+          # activate our env again
+          source $CONDA/etc/profile.d/conda.sh
+          conda activate ci
+          pytest --cov lstchain --cov-report=xml lstchain
+
+      - uses: codecov/codecov-action@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # make sure we have version info
+      - run: git fetch --tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python --version
+          pip install -U pip setuptools wheel
+          python setup.py sdist
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-# cta-lstchain
+# cta-lstchain [![Build Status](https://github.com/cta-observatory/cta-lstchain/workflows/CI/badge.svg?branch=master)](https://github.com/cta-observatory/cta-lstchain/actions?query=workflow%3ACI+branch%3Amaster)
 
-Repository for the high level analysis of the LST.    
+Repository for the high level analysis of the LST.
 The analysis is heavily based on [ctapipe](https://github.com/cta-observatory/ctapipe), adding custom code for mono reconstruction.
 
-master branch status: [![Build Status](https://travis-ci.org/cta-observatory/cta-lstchain.svg?branch=master)](https://travis-ci.org/cta-observatory/cta-lstchain)
 
-  
 Note that notebooks are currently not tested and not guaranteed to be up-to-date.   
 In doubt, refer to tested code and scripts: basic functions of lstchain (reduction steps R0-->DL1 and DL1-->DL2) 
 are unit tested and should be working as long as the build status is passing.


### PR DESCRIPTION
With the new pricing model, travis became basically unusable for cta-observatory. This switches to using github actions.

I for now removed the tests on ctapipe master because:

a) Github Actions is missing the "allowed-failures"
b) They were already failing always since lstchain is now two major versions behind the currrent ctapipe release, so it doesn't make sense to test vs. master.