### PR TITLE
DL1 reprocess script

### DIFF
--- a/lstchain/io/subarray.py
+++ b/lstchain/io/subarray.py
@@ -1,0 +1,491 @@
+"""
+Description of Arrays or Subarrays of telescopes
+Those codes are from the latest version of ctapipe (ctapipe/instruments/subarray.py)
+"""
+
+__all__ = ["SubarrayDescription"]
+
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
+from astropy.utils import lazyproperty
+import tables
+from copy import copy
+
+import ctapipe
+
+from ctapipe.coordinates import GroundFrame, CameraFrame
+from ctapipe.instrument.telescope import TelescopeDescription
+from ctapipe.instrument.camera import CameraDescription, CameraReadout, CameraGeometry
+from ctapipe.instrument.optics import OpticsDescription
+
+
+class SubarrayDescription:
+    """
+    Collects the `TelescopeDescription` of all telescopes along with their
+    positions on the ground.
+
+    Parameters
+    ----------
+    name: str
+        name of this subarray
+    tel_positions: Dict[Array]
+        dict of x,y,z telescope positions on the ground by tel_id. These are
+        converted internally to a `SkyCoord` in the `GroundFrame`
+    tel_descriptions: Dict[TelescopeDescription]
+        dict of TelescopeDescriptions by tel_id
+
+    Attributes
+    ----------
+    name: str
+       name of subarray
+    tel_coords: astropy.coordinates.SkyCoord
+       coordinates of all telescopes
+    tels:
+       dict of TelescopeDescription for each telescope in the subarray
+    tel_ids: np.ndarray
+        array of tel_ids
+    tel_indices: dict
+        dict mapping tel_id to index in array attributes
+    """
+
+    def __init__(self, name, tel_positions=None, tel_descriptions=None):
+        self.name = name
+        self.positions = tel_positions or dict()
+        self.tels = tel_descriptions or dict()
+
+        if self.positions.keys() != self.tels.keys():
+            raise ValueError("Telescope ids in positions and descriptions do not match")
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return "{}(name='{}', num_tels={})".format(
+            self.__class__.__name__, self.name, self.num_tels
+        )
+
+    @property
+    def tel(self):
+        """ for backward compatibility"""
+        return self.tels
+
+    @property
+    def num_tels(self):
+        """number of telescopes in this subarray"""
+        return len(self.tels)
+
+    def __len__(self):
+        return len(self.tels)
+
+    def info(self, printer=print):
+        """
+        print descriptive info about subarray
+        """
+
+        teltypes = defaultdict(list)
+
+        for tel_id, desc in self.tels.items():
+            teltypes[str(desc)].append(tel_id)
+
+        printer(f"Subarray : {self.name}")
+        printer(f"Num Tels : {self.num_tels}")
+        printer(f"Footprint: {self.footprint:.2f}")
+        printer("")
+        printer("                TYPE  Num IDmin  IDmax")
+        printer("=====================================")
+
+        for teltype, tels in teltypes.items():
+            printer(
+                "{:>20s} {:4d} {:4d} ..{:4d}".format(
+                    teltype, len(tels), min(tels), max(tels)
+                )
+            )
+
+    @lazyproperty
+    def tel_coords(self):
+        """ returns telescope positions as astropy.coordinates.SkyCoord"""
+
+        pos_x = np.array([p[0].to("m").value for p in self.positions.values()]) * u.m
+        pos_y = np.array([p[1].to("m").value for p in self.positions.values()]) * u.m
+        pos_z = np.array([p[2].to("m").value for p in self.positions.values()]) * u.m
+
+        return SkyCoord(x=pos_x, y=pos_y, z=pos_z, frame=GroundFrame())
+
+    @lazyproperty
+    def tel_ids(self):
+        """ telescope IDs as an array"""
+        return np.array(list(self.tel.keys()))
+
+    @lazyproperty
+    def tel_indices(self):
+        """ returns dict mapping tel_id to tel_index, useful for unpacking
+        lists based on tel_ids into fixed-length arrays"""
+        return {tel_id: ii for ii, tel_id in enumerate(self.tels.keys())}
+
+    @lazyproperty
+    def tel_index_array(self):
+        """
+        returns an expanded array that maps tel_id to tel_index. I.e. for a given
+        telescope, this array maps the tel_id to a flat index starting at 0 for
+        the first telescope. `tel_index = tel_id_to_index_array[tel_id]`
+        If the tel_ids are not contiguous, gaps will be filled in by -1.
+        For a more compact representation use the `tel_indices`
+        """
+        idx = np.zeros(np.max(self.tel_ids) + 1, dtype=int) - 1  # start with -1
+        for key, val in self.tel_indices.items():
+            idx[key] = val
+        return idx
+
+    def tel_ids_to_indices(self, tel_ids):
+        """maps a telescope id (or array of them) to flat indices
+
+        Parameters
+        ----------
+        tel_ids : int or List[int]
+            array of tel IDs
+
+        Returns
+        -------
+        np.array:
+            array of corresponding tel indices
+        """
+        tel_ids = np.array(tel_ids, dtype=int, copy=False).ravel()
+        return self.tel_index_array[tel_ids]
+
+    def tel_ids_to_mask(self, tel_ids):
+        """Convert a list of telescope ids to a boolean mask
+        of length ``num_tels`` where the **index** of the telescope
+        is set to ``True`` for each tel_id in tel_ids
+
+        Parameters
+        ----------
+        tel_ids : int or List[int]
+            array of tel IDs
+
+        Returns
+        -------
+        np.array[dtype=bool]:
+            Boolean array of length ``num_tels`` with indices of the
+            telescopes in ``tel_ids`` set to True.
+        """
+        mask = np.zeros(self.num_tels, dtype=bool)
+        indices = self.tel_ids_to_indices(tel_ids)
+        mask[indices] = True
+        return mask
+
+    @property
+    def footprint(self):
+        """area of smallest circle containing array on ground"""
+        pos_x = self.tel_coords.x
+        pos_y = self.tel_coords.y
+        return (np.hypot(pos_x, pos_y).max() ** 2 * np.pi).to("km^2")
+
+    def to_table(self, kind="subarray"):
+        """
+        export SubarrayDescription information as an `astropy.table.Table`
+
+        Parameters
+        ----------
+        kind: str
+            which table to generate (subarray or optics)
+        """
+
+        meta = {
+            "ORIGIN": "ctapipe.instrument.SubarrayDescription",
+            "SUBARRAY": self.name,
+            "SOFT_VER": ctapipe.__version__,
+            "TAB_TYPE": kind,
+        }
+
+        if kind == "subarray":
+
+            ids = list(self.tels.keys())
+            descs = [str(t) for t in self.tels.values()]
+            num_mirrors = [t.optics.num_mirrors for t in self.tels.values()]
+            tel_names = [t.name for t in self.tels.values()]
+            tel_types = [t.type for t in self.tels.values()]
+            cam_types = [t.camera.camera_name for t in self.tels.values()]
+            tel_coords = self.tel_coords
+
+            tab = Table(
+                dict(
+                    tel_id=np.array(ids, dtype=np.short),
+                    pos_x=tel_coords.x,
+                    pos_y=tel_coords.y,
+                    pos_z=tel_coords.z,
+                    name=tel_names,
+                    type=tel_types,
+                    num_mirrors=num_mirrors,
+                    camera_type=cam_types,
+                    tel_description=descs,
+                )
+            )
+            tab.meta["TAB_VER"] = "1.0"
+
+        elif kind == "optics":
+            unique_types = set(self.tels.values())
+
+            mirror_area = u.Quantity(
+                [t.optics.mirror_area.to_value(u.m ** 2) for t in unique_types],
+                u.m ** 2,
+            )
+            focal_length = u.Quantity(
+                [t.optics.equivalent_focal_length.to_value(u.m) for t in unique_types],
+                u.m,
+            )
+            cols = {
+                "description": [str(t) for t in unique_types],
+                "name": [t.name for t in unique_types],
+                "type": [t.type for t in unique_types],
+                "mirror_area": mirror_area,
+                "num_mirrors": [t.optics.num_mirrors for t in unique_types],
+                "num_mirror_tiles": [t.optics.num_mirror_tiles for t in unique_types],
+                "equivalent_focal_length": focal_length,
+            }
+            tab = Table(cols)
+            tab.meta["TAB_VER"] = "2.0"
+
+        else:
+            raise ValueError(f"Table type '{kind}' not known")
+
+        tab.meta.update(meta)
+        return tab
+
+    def select_subarray(self, name, tel_ids):
+        """
+        return a new SubarrayDescription that is a sub-array of this one
+
+        Parameters
+        ----------
+        name: str
+            name of new sub-selection
+        tel_ids: list(int)
+            list of telescope IDs to include in the new subarray
+
+        Returns
+        -------
+        SubarrayDescription
+        """
+
+        tel_positions = {tid: self.positions[tid] for tid in tel_ids}
+        tel_descriptions = {tid: self.tel[tid] for tid in tel_ids}
+
+        newsub = SubarrayDescription(
+            name, tel_positions=tel_positions, tel_descriptions=tel_descriptions
+        )
+        return newsub
+
+    def peek(self):
+        """
+        Draw a quick matplotlib plot of the array
+        """
+        from matplotlib import pyplot as plt
+        from astropy.visualization import quantity_support
+
+        types = set(self.tels.values())
+        tab = self.to_table()
+
+        plt.figure(figsize=(8, 8))
+
+        with quantity_support():
+            for tel_type in types:
+                tels = tab[tab["tel_description"] == str(tel_type)]["tel_id"]
+                sub = self.select_subarray(tel_type, tels)
+                tel_coords = sub.tel_coords
+                radius = np.array(
+                    [
+                        np.sqrt(tel.optics.mirror_area / np.pi).value
+                        for tel in sub.tels.values()
+                    ]
+                )
+
+                plt.scatter(
+                    tel_coords.x, tel_coords.y, s=radius * 8, alpha=0.5, label=tel_type
+                )
+
+            plt.legend(loc="best")
+            plt.title(self.name)
+            plt.tight_layout()
+
+    @property
+    def telescope_types(self):
+        """ list of telescope types in the array"""
+        return list({tel for tel in self.tel.values()})
+
+    @property
+    def camera_types(self):
+        """ list of camera types in the array """
+        return list({tel.camera for tel in self.tel.values()})
+
+    @property
+    def optics_types(self):
+        """ list of optics types in the array """
+        return list({tel.optics for tel in self.tel.values()})
+
+    def get_tel_ids_for_type(self, tel_type):
+        """
+        return list of tel_ids that have the given tel_type
+
+        Parameters
+        ----------
+        tel_type: str or TelescopeDescription
+           telescope type string (e.g. 'MST:NectarCam')
+
+        """
+        if isinstance(tel_type, TelescopeDescription):
+            tel_str = str(tel_type)
+        else:
+            tel_str = tel_type
+
+        return [id for id, descr in self.tels.items() if str(descr) == tel_str]
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        if self.name != other.name:
+            return False
+
+        if self.tels.keys() != other.tels.keys():
+            return False
+
+        if self.positions.keys() != other.positions.keys():
+            return False
+
+        for tel_id in self.tels.keys():
+            if self.tels[tel_id] != other.tels[tel_id]:
+                return False
+
+        for tel_id in self.tels.keys():
+            if np.any(self.positions[tel_id] != other.positions[tel_id]):
+                return False
+        return True
+
+    def to_hdf(self, output_path, overwrite=False):
+        """write the SubarrayDescription
+
+        Parameters
+        ----------
+        subarray : ctapipe.instrument.SubarrayDescription
+            subarray description
+        """
+        serialize_meta = True
+
+        if Path(output_path).suffix not in (".h5", ".hdf", ".hdf5"):
+            raise ValueError("This function can only write to hdf files.")
+
+        self.to_table().write(
+            output_path,
+            path="/configuration/instrument/subarray/layout",
+            serialize_meta=serialize_meta,
+            append=True,
+            overwrite=overwrite,
+        )
+        self.to_table(kind="optics").write(
+            output_path,
+            path="/configuration/instrument/telescope/optics",
+            append=True,
+            serialize_meta=serialize_meta,
+            overwrite=overwrite,
+        )
+        for camera in self.camera_types:
+            camera.geometry.to_table().write(
+                output_path,
+                path=f"/configuration/instrument/telescope/camera/geometry_{camera}",
+                append=True,
+                serialize_meta=serialize_meta,
+                overwrite=overwrite,
+            )
+            camera.readout.to_table().write(
+                output_path,
+                path=f"/configuration/instrument/telescope/camera/readout_{camera}",
+                append=True,
+                serialize_meta=serialize_meta,
+                overwrite=overwrite,
+            )
+
+        with tables.open_file(output_path, mode="r+") as f:
+            f.root.configuration.instrument.subarray._v_attrs.name = self.name
+
+    @classmethod
+    def from_hdf(cls, path):
+        layout = Table.read(path, path="/configuration/instrument/subarray/layout")
+
+        optics_table = Table.read(
+            path, path="/configuration/instrument/telescope/optics"
+        )
+
+        cameras = {}
+        for name in set(layout["camera_type"]):
+            geometry = CameraGeometry.from_table(
+                Table.read(
+                    path,
+                    path=f"/configuration/instrument/telescope/camera/geometry_{name}",
+                )
+            )
+            readout = CameraReadout.from_table(
+                Table.read(
+                    path,
+                    path=f"/configuration/instrument/telescope/camera/readout_{name}",
+                )
+            )
+            cameras[name] = CameraDescription(
+                camera_name=name, readout=readout, geometry=geometry
+            )
+
+        # iterating over the rows of a table does not play well
+        # with units, convert to dict of quantity arrays
+        optics_quantities = {
+            name: optics_table[name].quantity
+            if optics_table[name].unit
+            else optics_table[name]
+            for name in optics_table.colnames
+            if name not in {"description", "type"}
+        }
+        optics = {}
+        for row, desc in enumerate(optics_table["description"]):
+            kwargs = {k: v[row] for k, v in optics_quantities.items()}
+            optics[desc] = OpticsDescription(**kwargs)
+
+        # give correct frame for the camera to each telescope
+        cameras_by_desc = {}
+        for row in layout:
+            desc = row["tel_description"]
+
+            # copy to support different telescopes with same camera geom
+            camera = copy(cameras[row["camera_type"]])
+            focal_length = optics[desc].equivalent_focal_length
+            camera.geometry.frame = CameraFrame(focal_length=focal_length)
+            cameras_by_desc[desc] = camera
+
+        telescope_descriptions = {
+            row["tel_id"]: TelescopeDescription(
+                name=row["name"],
+                tel_type=row["type"],
+                optics=optics[row["tel_description"]],
+                camera=cameras_by_desc[row["tel_description"]],
+            )
+            for row in layout
+        }
+
+        positions = np.column_stack([layout[f"pos_{c}"].quantity for c in "xyz"])
+
+        with tables.open_file(path, mode="r") as f:
+            attrs = f.root.configuration.instrument.subarray._v_attrs
+            if "name" in attrs:
+                name = str(attrs.name)
+            else:
+                name = "Unknown"
+
+        return cls(
+            name=name,
+            tel_positions={
+                tel_id: pos for tel_id, pos in zip(layout["tel_id"], positions)
+            },
+            tel_descriptions=telescope_descriptions,
+        )

--- a/lstchain/scripts/lstchain_data_reprocess_dl1.py
+++ b/lstchain/scripts/lstchain_data_reprocess_dl1.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+
+"""
+- Input: DL1 file including DL1a
+- Output: DL1 file after the reprocess with a new configulation.
+Usage:
+$> python lstchain_data_reprocess_dl1.py 
+--input-file dl1_LST-1.Run02033.0137.h5
+--output-file out.h5
+--config config.json
+--no-image True
+"""
+
+import astropy.units as u
+import logging
+import tables
+import numpy as np
+import pandas as pd
+import argparse
+from tables import open_file
+import argparse
+from distutils.util import strtobool
+import os
+
+from ctapipe.containers import EventIndexContainer
+from ctapipe.io import HDF5TableWriter
+from ctapipe_io_lst.containers import LSTDataContainer
+from lstchain.io import standard_config, replace_config, get_dataset_keys, read_configuration_file
+from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key
+from lstchain.io import DL1ParametersContainer
+from lstchain.reco.r0_to_dl1 import get_dl1
+
+from subarray import SubarrayDescription
+
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser(description="DL1 reprocess")
+
+# Required arguments
+parser.add_argument('--input-file', '-f', type=str,
+                    dest='input_file',
+                    help='path to a DL1 HDF5 file',
+                    default=None, required=True)
+
+parser.add_argument('--output-file', '-o', type=str,
+                     dest='output_file',
+                     help='Path where to store the new dl1 events',
+                     default='test_dl1.h5')
+
+parser.add_argument('--config', '-c', action='store', type=str,
+                    dest='config_file',
+                    help='Path to a configuration file. If none is given, a standard configuration is applied',
+                    default=None, required=False)
+
+parser.add_argument('--no-image', action='store', type=lambda x: bool(strtobool(x)),
+                    dest='noimage',
+                    help='Boolean. True to remove the images',
+                    default=True)
+
+args = parser.parse_args()
+
+def main():
+
+    custom_config = {}
+    if args.config_file is not None:
+        try:
+            custom_config = read_configuration_file(os.path.abspath(args.config_file))
+        except("Custom configuration could not be loaded !!!"):
+            pass
+
+    config = replace_config(standard_config, custom_config)
+    
+    input_file = args.input_file
+    output_file = args.output_file
+
+    filters = tables.Filters(
+        complevel=5,            # enable compression, with level 0=disabled, 9=max
+        complib='blosc:zstd',   # compression using blosc
+        fletcher32=True,        # attach a checksum to each chunk for error correction
+        bitshuffle=False,       # for BLOSC, shuffle bits for better compression
+    )
+
+    subarray = SubarrayDescription.from_hdf(input_file)
+    tel_id=1
+    tel_name = str(subarray.tel[tel_id])[4:]
+
+    is_simu = 'simulation/run_config' in get_dataset_keys(input_file)
+    
+    with open_file(input_file, 'r') as h5in:    
+        with HDF5TableWriter(
+                filename=output_file,
+                group_name='dl1/event',
+                mode='a',
+                filters=filters,
+                add_prefix=True,
+                overwrite=True,
+        ) as h5out:
+            
+            data = h5in.root
+        
+            # Read image parameters
+            image_group = data.dl1.event.telescope.image.LST_LSTCam
+        
+            image = np.array([x['image'] for x in image_group.iterrows()])
+            peak_time = np.array([x['peak_time'] for x in image_group.iterrows()])
+            tel_id = np.array([x['tel_id'] for x in image_group.iterrows()])
+        
+            if is_simu:
+                simu_group = data.dl1.event.subarray.mc_shower
+                mc_type = np.array([x['mc_shower_primary_id'] for x in simu_group.iterrows()])
+        
+            # Read DL1 parameters
+            dl1_group = data.dl1.event.telescope.parameters.LST_LSTCam
+
+            dl1_container = DL1ParametersContainer() 
+            index_container = EventIndexContainer()
+        
+            for i, x in enumerate(dl1_group.iterrows()):
+
+                if i % 100 == 0:
+                    logger.info(i)
+                    
+                # prepare container
+                event = LSTDataContainer()
+            
+                event.dl1.tel[tel_id[i]].image = image[i]
+                event.dl1.tel[tel_id[i]].peak_time = peak_time[i]
+            
+                if is_simu and config['mc_image_scaling_factor'] != 1:
+                    event.dl1.tel[tel_id[i]].image *= config['mc_image_scaling_factor']
+            
+                dl1_container.reset()
+                
+            
+                # get dl1 parameters after image cleaning
+                get_dl1(event,
+                    subarray,
+                    tel_id[i],
+                    dl1_container=dl1_container,
+                    custom_config=config,
+                    use_main_island=True)
+            
+                # other dl1 parameters            
+                if is_simu:
+                    dl1_container.calibration_id = x['calibration_id']
+                    dl1_container.mc_energy = u.Quantity(x['mc_energy'], u.TeV)
+                    dl1_container.log_mc_energy = x['log_mc_energy']
+                    dl1_container.mc_alt = u.Quantity(x['mc_alt'], u.rad)
+                    dl1_container.mc_az = u.Quantity(x['mc_az'], u.rad)
+                    dl1_container.mc_core_x = u.Quantity(x['mc_core_x'], u.m)
+                    dl1_container.mc_core_y = u.Quantity(x['mc_core_y'], u.m)
+                    dl1_container.mc_h_first_int = u.Quantity(x['mc_h_first_int'], u.m)
+                    dl1_container.mc_type = mc_type[i]
+                    dl1_container.mc_az_tel = u.Quantity(x['mc_az_tel'], u.rad)
+                    dl1_container.mc_alt_tel = u.Quantity(x['mc_alt_tel'], u.rad)
+                    dl1_container.mc_x_max = u.Quantity(x['mc_x_max'], u.g / u.cm / u.cm)
+                    dl1_container.mc_core_distance = u.Quantity(x['mc_core_distance'], u.m)
+                    dl1_container.tel_id = x['tel_id']
+                    dl1_container.tel_pos_x = x['tel_pos_x']
+                    dl1_container.tel_pos_y = x['tel_pos_y']
+                    dl1_container.tel_pos_z = x['tel_pos_z']
+                    dl1_container.trigger_type = x['trigger_type']
+                    dl1_container.disp_dx = u.Quantity(x['disp_dx'], u.m)
+                    dl1_container.disp_dy = u.Quantity(x['disp_dy'], u.m)
+                    dl1_container.disp_norm = u.Quantity(x['disp_norm'], u.m)
+                    dl1_container.disp_angle = u.Quantity(x['disp_angle'], u.rad)
+                    dl1_container.disp_sign = x['disp_sign']
+                    dl1_container.src_x = u.Quantity(x['src_x'], u.m)
+                    dl1_container.src_y = u.Quantity(x['src_y'], u.m)
+                    
+                else:
+                    dl1_container.alt_tel = u.Quantity(x['alt_tel'], u.rad)
+                    dl1_container.az_tel = u.Quantity(x['az_tel'], u.rad)
+                    dl1_container.calibration_id = x['calibration_id']
+                    dl1_container.dragon_time = x['dragon_time']
+                    dl1_container.ucts_time = x['ucts_time']
+                    dl1_container.tib_time = x['tib_time']
+                    dl1_container.tel_id = x['tel_id']
+                    dl1_container.tel_pos_x = x['tel_pos_x']
+                    dl1_container.tel_pos_y = x['tel_pos_y']
+                    dl1_container.tel_pos_z = x['tel_pos_z']
+                    dl1_container.trigger_type = x['trigger_type']
+                    dl1_container.ucts_trigger_type = x['ucts_trigger_type']
+                    dl1_container.trigger_time = x['trigger_time']
+
+                dl1_container.prefix = ''
+                
+                # index container
+                index_container.reset()
+                index_container = EventIndexContainer()
+                index_container.obs_id = x['obs_id']
+                index_container.event_id = x['event_id']          
+
+                h5out.write(table_name=f'telescope/parameters/{tel_name}', containers=[dl1_container, index_container])
+                              
+        
+        with open_file(output_file, 'a') as h5out:
+        
+            keys = get_dataset_keys(input_file)
+ 
+            if args.noimage:
+                if dl1_images_lstcam_key in keys:
+                    keys.remove(dl1_images_lstcam_key)
+                
+            if dl1_params_lstcam_key in keys:
+                keys.remove(dl1_params_lstcam_key)
+            
+            # Write the selected DL1 info
+            for k in keys:
+                if not k.startswith('/'):
+                    k = '/' + k
+
+                path, name = k.rsplit('/', 1)
+            
+                if path not in h5out:
+                    grouppath, groupname = path.rsplit('/', 1)
+                    g = h5out.create_group(
+                        grouppath, groupname, createparents=True
+                    )
+                else:
+                    g = h5out.get_node(path)
+
+                h5in.copy_node(k, g, overwrite=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/lstchain/scripts/lstchain_reprocess_dl1.py
+++ b/lstchain/scripts/lstchain_reprocess_dl1.py
@@ -28,9 +28,9 @@ from ctapipe_io_lst.containers import LSTDataContainer
 from lstchain.io import standard_config, replace_config, get_dataset_keys, read_configuration_file
 from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key
 from lstchain.io import DL1ParametersContainer
+from lstchain.io.subarray import SubarrayDescription
 from lstchain.reco.r0_to_dl1 import get_dl1
 
-from subarray import SubarrayDescription
 
 logger = logging.getLogger(__name__)
 
@@ -105,10 +105,6 @@ def main():
             peak_time = np.array([x['peak_time'] for x in image_group.iterrows()])
             tel_id = np.array([x['tel_id'] for x in image_group.iterrows()])
         
-            if is_simu:
-                simu_group = data.dl1.event.subarray.mc_shower
-                mc_type = np.array([x['mc_shower_primary_id'] for x in simu_group.iterrows()])
-        
             # Read DL1 parameters
             dl1_group = data.dl1.event.telescope.parameters.LST_LSTCam
 
@@ -150,7 +146,7 @@ def main():
                     dl1_container.mc_core_x = u.Quantity(x['mc_core_x'], u.m)
                     dl1_container.mc_core_y = u.Quantity(x['mc_core_y'], u.m)
                     dl1_container.mc_h_first_int = u.Quantity(x['mc_h_first_int'], u.m)
-                    dl1_container.mc_type = mc_type[i]
+                    dl1_container.mc_type = x['mc_type']
                     dl1_container.mc_az_tel = u.Quantity(x['mc_az_tel'], u.rad)
                     dl1_container.mc_alt_tel = u.Quantity(x['mc_alt_tel'], u.rad)
                     dl1_container.mc_x_max = u.Quantity(x['mc_x_max'], u.g / u.cm / u.cm)

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -13,6 +13,7 @@ from lstchain.tests.test_lstchain import test_dir, mc_gamma_testfile, produce_fa
 
 output_dir = os.path.join(test_dir, 'scripts')
 dl1_file = os.path.join(output_dir, 'dl1_gamma_test_large.h5')
+reprocessed_dl1_file = os.path.join(output_dir, 'script_reprocessed_dl1.h5')
 merged_dl1_file = os.path.join(output_dir, 'script_merged_dl1.h5')
 dl2_file = os.path.join(output_dir, 'dl2_gamma_test_large.h5')
 file_model_energy = os.path.join(output_dir, 'reg_energy.sav')
@@ -60,6 +61,16 @@ def test_lstchain_mc_r0_to_dl1():
         '-o', output_dir
     )
     assert os.path.exists(dl1_file)
+
+@pytest.mark.run(after='test_lstchain_mc_r0_to_dl1')
+def test_lstchain_reprocess_dl1():
+    input_file = dl1_file
+    run_program(
+        'lstchain_reprocess_dl1',
+        '-f', input_file,
+        '-o', reprocessed_dl1_file
+    )
+    assert os.path.exists(reprocessed_dl1_file)
 
 
 @pytest.mark.run(after='test_lstchain_mc_r0_to_dl1')


### PR DESCRIPTION
This PR adds a DL1 reprocess script, `lstchain_reprocess_dl1.py`.
In this script, image parameters are recomputed by using DL1a data and a new configuration file, and the other parameters are copied by using DL1b data.
For now, image data of all events are saved in DL1 data as DL1a. So this procedure works if analyzers want to apply different image cleaning from default.
Any comments are welcome!