### PR TITLE
Remove n_islands from config files

### DIFF
--- a/lstchain/data/lstchain_src_dep_config.json
+++ b/lstchain/data/lstchain_src_dep_config.json
@@ -63,7 +63,6 @@
     "kurtosis",
     "time_gradient_from_source",
     "leakage_intensity_width_2",
-    "n_islands",
     "dist"
   ],
 
@@ -76,7 +75,6 @@
     "kurtosis",
     "time_gradient_from_source",
     "leakage_intensity_width_2",
-    "n_islands",
     "log_reco_energy",
     "dist"
   ],

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -68,7 +68,6 @@
     "r",
     "time_gradient",
     "leakage_intensity_width_2",
-    "n_islands"
   ],
 
   "classification_features": [
@@ -85,7 +84,6 @@
     "r",
     "time_gradient",
     "leakage_intensity_width_2",
-    "n_islands",
     "log_reco_energy",
     "reco_disp_dx",
     "reco_disp_dy"

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -67,7 +67,7 @@
     "kurtosis",
     "r",
     "time_gradient",
-    "leakage_intensity_width_2",
+    "leakage_intensity_width_2"
   ],
 
   "classification_features": [

--- a/lstchain/data/soft_cut_config.json
+++ b/lstchain/data/soft_cut_config.json
@@ -82,7 +82,6 @@
     "r",
     "time_gradient",
     "leakage_intensity_width_2",
-    "n_islands"
   ],
   "classification_features": [
     "log_intensity",
@@ -98,7 +97,6 @@
     "r",
     "time_gradient",
     "leakage_intensity_width_2",
-    "n_islands",
     "log_reco_energy",
     "reco_disp_dx",
     "reco_disp_dy"

--- a/lstchain/data/soft_cut_config.json
+++ b/lstchain/data/soft_cut_config.json
@@ -81,7 +81,7 @@
     "kurtosis",
     "r",
     "time_gradient",
-    "leakage_intensity_width_2",
+    "leakage_intensity_width_2"
   ],
   "classification_features": [
     "log_intensity",

--- a/lstchain/mc/tests/test_senstivity.py
+++ b/lstchain/mc/tests/test_senstivity.py
@@ -46,10 +46,10 @@ def test_calculate_sensitivity_lima():
     
     np.testing.assert_allclose(calculate_sensitivity_lima(
             50, 10, 0.2, 1, 0, 0),
-                               ([13.49, 26.97]), rtol = 1.e-3)
+                               ([13.48, 26.97]), rtol = 1.e-3)
     np.testing.assert_allclose(calculate_sensitivity_lima(
             200, 50, 1, 0, 1, 0),
-                               ([63.01, 31.50]), rtol = 1.e-3)
+                               ([63.00, 31.5]), rtol = 1.e-3)
     # Testing an array
     np.testing.assert_allclose(calculate_sensitivity_lima(
             np.array([100, 100]), np.array([20, 10]), np.array([1, 1]), 1, 1, 0),


### PR DESCRIPTION
As discussed some time ago, with the changes in Data/MC regarding integration windows and correction factors, the number of islands between data and MC was not matched anymore when using the standard cleaning settings, so there was a mismatch in background rates after classification noticed by @moralejo 
The temporary solution is to remove the `n_islands` from the Random Forest training 