### PR TITLE
Update only disp params if already present in the file

### DIFF
--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -101,10 +101,7 @@ def main():
         'time_gradient',
         'n_pixels',
         'wl',
-        'r',
-        'log_intensity',
-        'x',
-        'y',
+        'log_intensity'
     ])
 
     nodes_keys = get_dataset_keys(args.input_file)

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -105,11 +105,6 @@ def main():
         'log_intensity',
         'x',
         'y',
-        'disp_dx',
-        'disp_dy',
-        'disp_norm',
-        'disp_angle',
-        'disp_sign',
     ])
 
     nodes_keys = get_dataset_keys(args.input_file)
@@ -120,6 +115,8 @@ def main():
 
     with tables.open_file(args.input_file, mode='r') as input:
         image_table = input.root[dl1_images_lstcam_key]
+        dl1_params_input = input.root[dl1_params_lstcam_key].colnames
+
         with tables.open_file(args.output_file, mode='a') as output:
 
             params = output.root[dl1_params_lstcam_key].read()
@@ -161,16 +158,27 @@ def main():
                     dl1_container.r = np.sqrt(dl1_container.x ** 2 + dl1_container.y ** 2)
                     dl1_container.log_intensity = np.log10(dl1_container.intensity)
 
-                disp_dx, disp_dy, disp_norm, disp_angle, disp_sign = disp(dl1_container['x'].to_value(u.m),
-                                                                          dl1_container['y'].to_value(u.m),
-                                                                          params['src_x'][ii],
-                                                                          params['src_y'][ii],
-                                                                          )
-                dl1_container['disp_dx'] = disp_dx
-                dl1_container['disp_dy'] = disp_dy
-                dl1_container['disp_norm'] = disp_norm
-                dl1_container['disp_angle'] = disp_angle
-                dl1_container['disp_sign'] = disp_sign
+                if ['disp_dx', 'disp_dy', 'disp_norm', 'disp_angle', 'disp_sign'] in dl1_params_input:
+                    parameters_to_update.extend([
+                        'disp_dx',
+                        'disp_dy',
+                        'disp_norm',
+                        'disp_angle',
+                        'disp_sign'
+                    ])
+
+                    disp_dx, disp_dy, disp_norm, disp_angle, disp_sign = disp(
+                        dl1_container['x'].to_value(u.m),
+                        dl1_container['y'].to_value(u.m),
+                        params['src_x'][ii],
+                        params['src_y'][ii]
+                    )
+
+                    dl1_container['disp_dx'] = disp_dx
+                    dl1_container['disp_dy'] = disp_dy
+                    dl1_container['disp_norm'] = disp_norm
+                    dl1_container['disp_angle'] = disp_angle
+                    dl1_container['disp_sign'] = disp_sign
 
                 for p in parameters_to_update:
                     params[ii][p] = u.Quantity(dl1_container[p]).value

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -113,11 +113,12 @@ def main():
     with tables.open_file(args.input_file, mode='r') as input:
         image_table = input.root[dl1_images_lstcam_key]
         dl1_params_input = input.root[dl1_params_lstcam_key].colnames
+        disp_params = {'disp_dx', 'disp_dy', 'disp_norm', 'disp_angle', 'disp_sign'}
+        if set(dl1_params_input).intersection(disp_params):
+            parameters_to_update.extend(disp_params)
 
         with tables.open_file(args.output_file, mode='a') as output:
-
             params = output.root[dl1_params_lstcam_key].read()
-
             for ii, row in enumerate(image_table):
 
                 dl1_container.reset()
@@ -154,15 +155,7 @@ def main():
                     dl1_container.length = length
                     dl1_container.log_intensity = np.log10(dl1_container.intensity)
 
-                if ['disp_dx', 'disp_dy', 'disp_norm', 'disp_angle', 'disp_sign'] in dl1_params_input:
-                    parameters_to_update.extend([
-                        'disp_dx',
-                        'disp_dy',
-                        'disp_norm',
-                        'disp_angle',
-                        'disp_sign'
-                    ])
-
+                if set(dl1_params_input).intersection(disp_params):
                     disp_dx, disp_dy, disp_norm, disp_angle, disp_sign = disp(
                         dl1_container['x'].to_value(u.m),
                         dl1_container['y'].to_value(u.m),

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -152,7 +152,6 @@ def main():
                     length = np.rad2deg(np.arctan2(dl1_container.length, foclen))
                     dl1_container.width = width
                     dl1_container.length = length
-                    dl1_container.r = np.sqrt(dl1_container.x ** 2 + dl1_container.y ** 2)
                     dl1_container.log_intensity = np.log10(dl1_container.intensity)
 
                 if ['disp_dx', 'disp_dy', 'disp_norm', 'disp_angle', 'disp_sign'] in dl1_params_input:


### PR DESCRIPTION
Trying to fix #543 for real data since there are no disp related parameters in those files. They are only in MC files

I removed the re-calculation of `r` because it is already done by the `hillas_parameters` function.