### PR TITLE
add missing toml from environment/setup

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - jupyter
   - notebook
   - joblib
+  - toml
   - pip:
       - pytest_runner
       - pytest-ordering

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'seaborn',
         'scikit-learn',
         'tables',
+        'toml',
         'traitlets',
         'iminuit~=1.5',
     ],


### PR DESCRIPTION
After #509 was merged, there is an import of `toml` in:
https://github.com/cta-observatory/cta-lstchain/blob/b8e30215c5079cf1e456be2831a19409221b7eb0/lstchain/scripts/lstchain_post_dl2.py#L6

and the package is not included as a dependency