### PR TITLE
Fix ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ env:
   MPLBACKEND: Agg
   PYTEST_ADDOPTS: --color=yes
   CTAPIPE_IO_LST_VERSION: v0.5.3
+  TEST_DATA_USER: lstchain
 
 jobs:
   tests:
@@ -18,9 +19,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # get full history and tags
+          fetch-depth: 0
 
       # make sure we have version info
-      - run: git fetch --tags
       - run: git describe --tags
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +43,6 @@ jobs:
           conda env create -n ci -f environment.yml
           conda activate ci
           # we install ctapipe using pip to be able to select any commit, e.g. the current master
-          pip install pytest-cov
           pip install \
             "git+https://github.com/cta-observatory/ctapipe@$CTAPIPE_VERSION" \
             "git+https://github.com/cta-observatory/ctapipe_io_lst@$CTAPIPE_IO_LST_VERSION" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
+      # make sure we have version info
+      - run: git fetch --tags
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -38,7 +39,7 @@ jobs:
           conda env create -n ci -f environment.yml
           conda activate ci
           # we install ctapipe using pip to be able to select any commit, e.g. the current master
-          pip install pytest-cov 
+          pip install pytest-cov
           pip install \
             "git+https://github.com/cta-observatory/ctapipe@$CTAPIPE_VERSION" \
             "git+https://github.com/cta-observatory/ctapipe_io_lst@$CTAPIPE_IO_LST_VERSION" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
 
       - name: Download test data
         env:
-          TEST_DATA_USER: ${{ secrets.test_data_user }}
           TEST_DATA_PASSWORD: ${{ secrets.test_data_password }}
         run: |
           ./download_test_data.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
 
       # make sure we have version info
       - run: git fetch --tags
+      - run: git describe --tags
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -45,6 +46,7 @@ jobs:
             "git+https://github.com/cta-observatory/ctapipe_io_lst@$CTAPIPE_IO_LST_VERSION" \
             pytest-cov
 
+          python lstchain/version.py
           pip install .
 
       - name: Download test data

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - notebook
   - joblib
   - toml
+  - iminuit=1.5
   - pip:
       - pytest_runner
       - pytest-ordering


### PR DESCRIPTION
New pip version does not allow building wheels with "unknown" version.

This makes sure we have the git tags so version is known.

See build failure in #552 