### PR TITLE
Filters on mc_type for RF

### DIFF
--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -95,14 +95,13 @@ class DL1ParametersContainer(Container):
     mc_core_x = Field(None, 'Simulated impact point x position', unit=u.m)
     mc_core_y = Field(None, 'Simulated impact point y position', unit=u.m)
     mc_h_first_int = Field(None, 'Simulated first interaction height', unit=u.m)
-    mc_type = Field(-1, 'Simulated particle type')
+    mc_type = Field(-9999, "MC shower primary ID 0 (gamma), 1(e-),"
+                           "2(mu-), 100*A+Z for nucleons and nuclei,"
+                           "negative for antimatter.")
     mc_az_tel = Field(None, 'Telescope MC azimuth pointing', unit=u.rad)
     mc_alt_tel = Field(None, 'Telescope MC altitude pointing', unit=u.rad)
     mc_x_max = Field(None, "MC Xmax value", unit=u.g / u.cm**2)
     mc_core_distance = Field(None, "Distance from the impact point to the telescope", unit=u.m)
-    mc_shower_primary_id = Field(None, "MC shower primary ID 0 (gamma), 1(e-),"
-                                    "2(mu-), 100*A+Z for nucleons and nuclei,"
-                                    "negative for antimatter.")
 
     hadroness = Field(None, "Hadroness")
     wl = Field(u.Quantity(np.nan), "width/length")

--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -68,14 +68,14 @@ class DL1ParametersContainer(Container):
                                            'border pixels')
     leakage_pixels_width_2 = Field(np.nan, 'Fraction of signal pixels that are '
                                            'in the two outermost rings of pixels')
-    n_pixels = Field(np.nan, 'Number of pixels after cleaning')
+    n_pixels = Field(-1, 'Number of pixels after cleaning')
     concentration_cog = Field(np.nan, 'Fraction of intensity in three pixels '
                                       'closest to the cog')
     concentration_core = Field(np.nan, 'Fraction of intensity inside hillas '
                                        'ellipse')
     concentration_pixel = Field(np.nan, 'Fraction of intensity in brightest '
                                         'pixel')
-    n_islands = Field(np.nan, 'Number of Islands')
+    n_islands = Field(-1, 'Number of Islands')
     alt_tel = Field(None, 'Telescope altitude pointing',
                     unit=u.rad)
     az_tel = Field(None, 'Telescope azimuth pointing',
@@ -95,7 +95,7 @@ class DL1ParametersContainer(Container):
     mc_core_x = Field(None, 'Simulated impact point x position', unit=u.m)
     mc_core_y = Field(None, 'Simulated impact point y position', unit=u.m)
     mc_h_first_int = Field(None, 'Simulated first interaction height', unit=u.m)
-    mc_type = Field(np.nan, 'Simulated particle type')
+    mc_type = Field(-1, 'Simulated particle type')
     mc_az_tel = Field(None, 'Telescope MC azimuth pointing', unit=u.rad)
     mc_alt_tel = Field(None, 'Telescope MC altitude pointing', unit=u.rad)
     mc_x_max = Field(None, "MC Xmax value", unit=u.g / u.cm**2)

--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -68,14 +68,14 @@ class DL1ParametersContainer(Container):
                                            'border pixels')
     leakage_pixels_width_2 = Field(np.nan, 'Fraction of signal pixels that are '
                                            'in the two outermost rings of pixels')
-    n_pixels = Field(0, 'Number of pixels after cleaning')
+    n_pixels = Field(np.nan, 'Number of pixels after cleaning')
     concentration_cog = Field(np.nan, 'Fraction of intensity in three pixels '
                                       'closest to the cog')
     concentration_core = Field(np.nan, 'Fraction of intensity inside hillas '
                                        'ellipse')
     concentration_pixel = Field(np.nan, 'Fraction of intensity in brightest '
                                         'pixel')
-    n_islands = Field(0, 'Number of Islands')
+    n_islands = Field(np.nan, 'Number of Islands')
     alt_tel = Field(None, 'Telescope altitude pointing',
                     unit=u.rad)
     az_tel = Field(None, 'Telescope azimuth pointing',
@@ -95,7 +95,7 @@ class DL1ParametersContainer(Container):
     mc_core_x = Field(None, 'Simulated impact point x position', unit=u.m)
     mc_core_y = Field(None, 'Simulated impact point y position', unit=u.m)
     mc_h_first_int = Field(None, 'Simulated first interaction height', unit=u.m)
-    mc_type = Field(-1, 'Simulated particle type')
+    mc_type = Field(np.nan, 'Simulated particle type')
     mc_az_tel = Field(None, 'Telescope MC azimuth pointing', unit=u.rad)
     mc_alt_tel = Field(None, 'Telescope MC altitude pointing', unit=u.rad)
     mc_x_max = Field(None, "MC Xmax value", unit=u.g / u.cm**2)

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -431,8 +431,17 @@ def apply_models(dl1, classifier, reg_energy, reg_disp_vector, custom_config={})
     dl2['reco_az'] = src_pos_reco.az.rad
 
     dl2['reco_type'] = classifier.predict(dl2[classification_features]).astype(int)
-    probs = classifier.predict_proba(dl2[classification_features])[0:, 0]
-    dl2['gammaness'] = probs
+    probs = classifier.predict_proba(dl2[classification_features])
+
+    # This check is valid as long as we train on only two classes (gammas and protons)
+    if probs.shape[1] > 2:
+        raise ValueError("The classifier is predicting more than two classes, "
+                         "the predicted probabilty to assin as gammaness is unclear."
+                         "Please check training data")
+
+    # gammaness is the prediction probability for the first class (0)
+    dl2['gammaness'] = probs[:, 0]
+
     return dl2
 
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -436,7 +436,7 @@ def apply_models(dl1, classifier, reg_energy, reg_disp_vector, custom_config={})
     # This check is valid as long as we train on only two classes (gammas and protons)
     if probs.shape[1] > 2:
         raise ValueError("The classifier is predicting more than two classes, "
-                         "the predicted probabilty to assin as gammaness is unclear."
+                         "the predicted probabilty to assign as gammaness is unclear."
                          "Please check training data")
 
     # gammaness is the prediction probability for the first class (0)

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -301,6 +301,9 @@ def build_models(filegammas, fileprotons,
     config = replace_config(standard_config, custom_config)
     events_filters = config["events_filters"]
 
+    # Adding a filter on mc_type just for training
+    events_filters['mc_type'] = [0, np.inf]
+
     df_gamma = pd.read_hdf(filegammas, key=dl1_params_lstcam_key)
     df_proton = pd.read_hdf(fileprotons, key=dl1_params_lstcam_key)
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -302,7 +302,7 @@ def build_models(filegammas, fileprotons,
     events_filters = config["events_filters"]
 
     # Adding a filter on mc_type just for training
-    events_filters['mc_type'] = [0, np.inf]
+    events_filters['mc_type'] = [-9000, np.inf]
 
     df_gamma = pd.read_hdf(filegammas, key=dl1_params_lstcam_key)
     df_proton = pd.read_hdf(fileprotons, key=dl1_params_lstcam_key)


### PR DESCRIPTION
This comes in replacement of PR #589 as the PRs now have to be done without forking to get real data and pass the tests.
Sorry for the incovenience.

Issue:

Some of the parameters are initialized with a default value = -1.
Even in case of issues with the computation of these parameters, they can be used for training without causing issues (the values are valid predictions)
Training and inference would not raise any error and warning but make useless predictions
I encountered the problem when using dl1ab, the mc_type would be set to -1 for some events and thus the RF would predict 3 classes and the gammaness would not be assigned to the right class.
So I also add an error raise in case of more than 2 predicted classes, which should never happen in current setup.