### PR TITLE
Move configuration of LST event source to json file

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -1,4 +1,30 @@
 {
+  "source_config" : {
+    "EventSource": {
+      "allowed_tels": [1, 2, 3, 4],
+      "max_events": null
+    },
+    "LSTEventSource": {
+      "default_trigger_type": "ucts",
+      "allowed_tels": [1],
+      "calibrate_flatfields_and_pedestals": false,
+      "EventTimeCalculator": {
+        "ucts_t0_dragon": null,
+        "dragon_counter0": null,
+        "ucts_t0_tib": null,
+        "tib_counter0": null
+      },
+      "PointingSource":{
+        "drive_report_path": null
+      },
+      "LSTR0Corrections":{
+        "drs4_pedestal_path": null,
+        "calibration_path": null,
+        "drs4_time_calibration_path": null
+      }
+    }
+  },
+
   "events_filters": {
     "intensity": [0, Infinity],
     "width": [0, Infinity],
@@ -90,7 +116,6 @@
   ],
 
   "allowed_tels": [1, 2, 3, 4],
-  "max_events": null,
   "custom_calibration": false,
   "write_pe_image": false,
   "mc_image_scaling_factor": 1,

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -170,14 +170,6 @@ def r0_to_dl1(
     input_filename=get_dataset_path('gamma_test_large.simtel.gz'),
     output_filename=None,
     custom_config={},
-    pedestal_path=None,
-    calibration_path=None,
-    time_calibration_path=None,
-    pointing_file_path=None,
-    ucts_t0_dragon=None,
-    dragon_counter0=None,
-    ucts_t0_tib=None,
-    tib_counter0=None,
 ):
     """
     Chain r0 to dl1
@@ -190,15 +182,6 @@ def r0_to_dl1(
     output_filename: str or None
         path to output file, defaults to writing dl1 into the current directory
     custom_config: path to a configuration file
-    pedestal_path: Path to the DRS4 pedestal file
-    calibration_path: Path to the file with calibration constants and
-        pedestals
-    time_calibration_path: Path to the DRS4 time correction file
-    pointing_file_path: path to the Drive log with the pointing information
-    ucts_t0_dragon: first valid ucts_time
-    dragon_counter0: Dragon counter corresponding to ucts_t0_dragon
-    ucts_t0_tib: first valid ucts_time for the first valid TIB counter
-    tib_counter0: first valid TIB counter
 
     Returns
     -------
@@ -219,33 +202,8 @@ def r0_to_dl1(
 
     custom_calibration = config["custom_calibration"]
 
-    source_config = {
-        "EventSource": {
-            "allowed_tels": config["allowed_tels"],
-            "max_events": config["max_events"],
-        },
-        "LSTEventSource": {
-            "allowed_tels": [1],
-            "calibrate_flatfields_and_pedestals": False,
-            "EventTimeCalculator": {
-                "ucts_t0_dragon": ucts_t0_dragon,
-                "dragon_counter0": dragon_counter0,
-                "ucts_t0_tib": ucts_t0_tib,
-                "tib_counter0": tib_counter0
-            },
-            "PointingSource":{
-                "drive_report_path": pointing_file_path
-            },
-            "LSTR0Corrections":{
-                "drs4_pedestal_path": pedestal_path,
-                "calibration_path": calibration_path,
-                "drs4_time_calibration_path": time_calibration_path,
-            }
-        }
-    }
 
-    # FIXME for ctapipe 0.8, str should be removed, as Path is supported
-    source = EventSource(input_url=input_filename, config=Config(source_config))
+    source = EventSource(input_url=input_filename, config=Config(config))
     subarray = source.subarray
     is_simu = source.is_simulation
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -203,7 +203,8 @@ def r0_to_dl1(
     custom_calibration = config["custom_calibration"]
 
 
-    source = EventSource(input_url=input_filename, config=Config(config))
+    source = EventSource(input_url=input_filename,
+                         config=Config(config["source_config"]))
     subarray = source.subarray
     is_simu = source.is_simulation
 

--- a/lstchain/scripts/lstchain_data_r0_to_dl1.py
+++ b/lstchain/scripts/lstchain_data_r0_to_dl1.py
@@ -23,6 +23,7 @@ import logging
 import sys
 from pathlib import Path
 
+from lstchain.io import  standard_config
 from lstchain.io.config import read_configuration_file
 from lstchain.paths import parse_r0_filename, run_to_dl1_filename, r0_to_dl1_filename
 from lstchain.reco import r0_to_dl1
@@ -151,21 +152,35 @@ def main():
         except Exception as e:
             log.error(f'Configuration file could not be read: {e}')
             sys.exit(1)
+    else:
+        config = standard_config
 
-    config["max_events"] = args.max_events
+    # Add to configuration config the parameters provided through command-line,
+    # which supersede those in the file:
+    config['source_config']['EventSource']['max_events'] = args.max_events
+
+    lst_event_source = config['source_config']['LSTEventSource']
+    lst_event_source['EventTimeCalculator']['ucts_t0_dragon'] = \
+        args.ucts_t0_dragon
+    lst_event_source['EventTimeCalculator']['dragon_counter0'] = \
+        args.dragon_counter0
+    lst_event_source['EventTimeCalculator']['ucts_t0_tib'] = \
+        args.ucts_t0_tib
+    lst_event_source['EventTimeCalculator']['tib_counter0'] = \
+        args.tib_counter0
+    lst_event_source['PointingSource']['drive_report_path'] = \
+        args.pointing_file
+    lst_r0_corrections = lst_event_source['LSTR0Corrections']
+    lst_r0_corrections['drs4_pedestal_path'] = args.pedestal_file
+    lst_r0_corrections['calibration_path'] = args.calibration_file
+    lst_r0_corrections['drs4_time_calibration_path'] = \
+        args.time_calibration_file
+
 
     r0_to_dl1.r0_to_dl1(
         args.input_file,
         output_filename=output_filename,
-        custom_config=config,
-        pedestal_path=args.pedestal_file,
-        calibration_path=args.calibration_file,
-        time_calibration_path=args.time_calibration_file,
-        pointing_file_path=args.pointing_file,
-        ucts_t0_dragon=args.ucts_t0_dragon,
-        dragon_counter0=args.dragon_counter0,
-        ucts_t0_tib=args.ucts_t0_tib,
-        tib_counter0=args.tib_counter0
+        custom_config=config['source_config'],
     )
 
 

--- a/lstchain/scripts/lstchain_data_r0_to_dl1.py
+++ b/lstchain/scripts/lstchain_data_r0_to_dl1.py
@@ -39,6 +39,8 @@ parser.add_argument(
     required=True,
 )
 
+# Optional arguments
+
 parser.add_argument(
     '-o', '--output-dir', type=Path,
     help='Path where to store the reco dl1 events',
@@ -48,23 +50,19 @@ parser.add_argument(
 parser.add_argument(
     '-p', '--pedestal-file', '-p', type=Path,
     dest='pedestal_file',
-    help='Path to a pedestal file',
-    required=True
+    help='Path to a pedestal file'
 )
 
 parser.add_argument(
     '--calibration-file', '--calib', type=Path,
-    help='Path to a calibration file',
-    required=True,
+    help='Path to a calibration file'
 )
 
 parser.add_argument(
     '--time-calibration-file', '-t', type=Path,
-    help='Path to a calibration file for pulse time correction',
-    required=True
+    help='Path to a calibration file for pulse time correction'
 )
 
-# Optional arguments
 parser.add_argument(
     '--config', '-c', type=Path,
     dest='config_file',
@@ -157,24 +155,34 @@ def main():
 
     # Add to configuration config the parameters provided through command-line,
     # which supersede those in the file:
-    config['source_config']['EventSource']['max_events'] = args.max_events
+    if args.max_events is not None:
+        config['source_config']['EventSource']['max_events'] = args.max_events
 
     lst_event_source = config['source_config']['LSTEventSource']
-    lst_event_source['EventTimeCalculator']['ucts_t0_dragon'] = \
-        args.ucts_t0_dragon
-    lst_event_source['EventTimeCalculator']['dragon_counter0'] = \
-        args.dragon_counter0
-    lst_event_source['EventTimeCalculator']['ucts_t0_tib'] = \
-        args.ucts_t0_tib
-    lst_event_source['EventTimeCalculator']['tib_counter0'] = \
-        args.tib_counter0
-    lst_event_source['PointingSource']['drive_report_path'] = \
-        args.pointing_file
+    if args.ucts_t0_dragon is not None:
+        lst_event_source['EventTimeCalculator']['ucts_t0_dragon'] = \
+            args.ucts_t0_dragon
+    if args.dragon_counter0 is not None:
+        lst_event_source['EventTimeCalculator']['dragon_counter0'] = \
+            args.dragon_counter0
+    if args.ucts_t0_tib is not None:
+        lst_event_source['EventTimeCalculator']['ucts_t0_tib'] = \
+            args.ucts_t0_tib
+    if args.tib_counter0 is not None:
+        lst_event_source['EventTimeCalculator']['tib_counter0'] = \
+            args.tib_counter0
+    if args.pointing_file is not None:
+        lst_event_source['PointingSource']['drive_report_path'] = \
+            args.pointing_file
+
     lst_r0_corrections = lst_event_source['LSTR0Corrections']
-    lst_r0_corrections['drs4_pedestal_path'] = args.pedestal_file
-    lst_r0_corrections['calibration_path'] = args.calibration_file
-    lst_r0_corrections['drs4_time_calibration_path'] = \
-        args.time_calibration_file
+    if args.pedestal_file is not None:
+        lst_r0_corrections['drs4_pedestal_path'] = args.pedestal_file
+    if args.calibration_file is not None:
+        lst_r0_corrections['calibration_path'] = args.calibration_file
+    if args.time_calibration_file is not None:
+        lst_r0_corrections['drs4_time_calibration_path'] = \
+            args.time_calibration_file
 
 
     r0_to_dl1.r0_to_dl1(

--- a/lstchain/scripts/lstchain_data_r0_to_dl1.py
+++ b/lstchain/scripts/lstchain_data_r0_to_dl1.py
@@ -180,7 +180,7 @@ def main():
     r0_to_dl1.r0_to_dl1(
         args.input_file,
         output_filename=output_filename,
-        custom_config=config['source_config'],
+        custom_config=config,
     )
 
 

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -49,18 +49,22 @@ def test_r0_to_dl1_observed(tmp_path):
     from lstchain.reco.r0_to_dl1 import r0_to_dl1
 
     output_path = tmp_path / ('dl1_' + test_r0_path.stem + '.h5')
+
+    config = standard_config
+    lst_event_source = config['source_config']['LSTEventSource']
+    lst_event_source['PointingSource']['drive_report_path'] = test_drive_report
+    lst_event_source['LSTR0Corrections']['drs4_pedestal_path'] = \
+        test_drs4_pedestal_path
+    lst_event_source['LSTR0Corrections']['calibration_path'] = \
+        test_calib_path
+    lst_event_source['LSTR0Corrections']['drs4_time_calibration_path']\
+        = test_time_calib_path
+
+
     r0_to_dl1(
         test_r0_path,
         output_filename=output_path,
-        custom_config=standard_config,
-        pedestal_path=test_drs4_pedestal_path,
-        calibration_path=test_calib_path,
-        time_calibration_path=test_time_calib_path,
-        pointing_file_path=test_drive_report,
-        ucts_t0_dragon=None,
-        dragon_counter0=None,
-        ucts_t0_tib=None,
-        tib_counter0=None,
+        custom_config=config
     )
 
     with tables.open_file(output_path, 'r') as f:


### PR DESCRIPTION
LST event source configuration is now in the json file (though command-line options, if present, override the settings in the file). So there should be no change of behavior. Now one can select the preferred trigger tag (ucts or tib) by setting it in the file.
