### PR TITLE
Update ctapipe_io_lst and ctapipe versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,6 @@ dependencies:
   - pip:
       - pytest_runner
       - pytest-ordering
-      - ctapipe_io_lst>=0.8.2
+      - ctapipe_io_lst~=0.8.2
       - ctaplot
       - pyirf~=0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,6 @@ dependencies:
   - pip:
       - pytest_runner
       - pytest-ordering
-      - ctapipe_io_lst~=0.8.0
+      - ctapipe_io_lst>=0.8.2
       - ctaplot
       - pyirf~=0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.7
   - astropy>=4.2
   - pip
-  - ctapipe>=0.10.3
+  - ctapipe>=0.10.4
   - gammapy>=0.18
   - h5py
   - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.7
   - astropy>=4.2
   - pip
-  - ctapipe>=0.10.5,<0.11.0a0
+  - ctapipe~=0.10.5
   - gammapy>=0.18
   - h5py
   - ipython

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         "astropy~=4.2",
         'ctapipe>=0.10.4',
-        'ctapipe_io_lst>=0.8.2',
+        'ctapipe_io_lst~=0.8.2',
         'ctaplot~=0.5.5',
         "eventio>=1.5.1,<2.0.0a0",  # at least 1.1.1, but not 2
         'gammapy>=0.18',

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,11 @@ setup(
     version=version,
     packages=find_packages(),
     install_requires=[
-        "astropy~=4.2",
+        'astropy~=4.2',
         'ctapipe~=0.10.5',
         'ctapipe_io_lst~=0.8.2',
         'ctaplot~=0.5.5',
-        "eventio>=1.5.1,<2.0.0a0",  # at least 1.1.1, but not 2
+        'eventio>=1.5.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy>=0.18',
         'h5py',
         'joblib',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         "astropy~=4.2",
         'ctapipe>=0.10.4',
-        'ctapipe_io_lst~=0.8.0',
+        'ctapipe_io_lst>=0.8.2',
         'ctaplot~=0.5.5',
         "eventio>=1.5.1,<2.0.0a0",  # at least 1.1.1, but not 2
         'gammapy>=0.18',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "astropy~=4.2",
-        'ctapipe>=0.10.5,<0.11.0a0',
+        'ctapipe~=0.10.5',
         'ctapipe_io_lst~=0.8.2',
         'ctaplot~=0.5.5',
         "eventio>=1.5.1,<2.0.0a0",  # at least 1.1.1, but not 2


### PR DESCRIPTION
Maybe we could explicitly include ctapipe `v0.10.5` as well? No big changes from v0.10.4, right?