### PR TITLE
Time constrained cleaning

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -37,7 +37,8 @@
     "boundary_thresh":3,
     "keep_isolated_pixels":false,
     "min_number_picture_neighbors":1,
-    "use_only_main_island":true
+    "use_only_main_island":true,
+    "delta_time": null
   },
   "tailcuts_clean_with_pedestal_threshold": {
     "picture_thresh":8,
@@ -45,7 +46,8 @@
     "sigma":3,
     "keep_isolated_pixels":false,
     "min_number_picture_neighbors":1,
-    "use_only_main_island":false
+    "use_only_main_island":false,
+    "delta_time": null
   },
 
     "random_forest_regressor_args": {

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -148,7 +148,10 @@ def get_dl1(
                                                  peak_time, 1, delta_time)
             signal_pixels = new_mask
 
-        if np.sum(signal_pixels) > 0:
+        # count surviving pixels
+        n_pixels = np.count_nonzero(signal_pixels)
+
+        if n_pixels > 0:
             hillas = hillas_parameters(camera_geometry[signal_pixels], image[signal_pixels])
 
             # Fill container

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -115,10 +115,10 @@ def get_dl1(
         use_main_island = cleaning_parameters.pop("use_only_main_island")
 
     # time constraint for image cleaning: ewquire at least one neighbor
-    # within delta_t:
-    delta_t = None
-    if "delta_t" in cleaning_parameters.keys():
-        delta_t = cleaning_parameters.pop("delta_t")
+    # within delta_time:
+    delta_time = None
+    if "delta_time" in cleaning_parameters.keys():
+        delta_time = cleaning_parameters.pop("delta_time")
 
     dl1_container = DL1ParametersContainer() if dl1_container is None else dl1_container
 
@@ -142,10 +142,10 @@ def get_dl1(
             max_island_label = np.argmax(n_pixels_on_island)
             signal_pixels[island_labels != max_island_label] = False
 
-        if delta_t is not None:
+        if delta_time is not None:
             new_mask = apply_time_delta_cleaning(camera_geometry,
                                                  signal_pixels,
-                                                 peak_time, 1, delta_t)
+                                                 peak_time, 1, delta_time)
             signal_pixels = new_mask
 
         if np.sum(signal_pixels) > 0:

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -114,10 +114,10 @@ def get_dl1(
         # we use pop because ctapipe won't recognize that keyword in tailcuts
         use_main_island = cleaning_parameters.pop("use_only_main_island")
 
-    # time constraint for image cleaning: ewquire at least one neighbor
+    # time constraint for image cleaning: require at least one neighbor
     # within delta_time:
     delta_time = None
-    if "delta_time" in cleaning_parameters.keys():
+    if "delta_time" in cleaning_parameters:
         delta_time = cleaning_parameters.pop("delta_time")
 
     dl1_container = DL1ParametersContainer() if dl1_container is None else dl1_container

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -20,6 +20,7 @@ from ctapipe.image import (
     HillasParameterizationError,
     hillas_parameters,
     tailcuts_clean,
+    apply_time_delta_cleaning,
 )
 from ctapipe.image.morphology import number_of_islands
 from ctapipe.instrument import OpticsDescription
@@ -111,8 +112,13 @@ def get_dl1(
     use_main_island = True
     if "use_only_main_island" in cleaning_parameters.keys():
         # we use pop because ctapipe won't recognize that keyword in tailcuts
-        use_main_island = cleaning_parameters.pop('use_only_main_island')
+        use_main_island = cleaning_parameters.pop("use_only_main_island")
 
+    # time constraint for image cleaning: ewquire at least one neighbor
+    # within delta_t:
+    delta_t = None
+    if "delta_t" in cleaning_parameters.keys():
+        delta_t = cleaning_parameters.pop("delta_t")
 
     dl1_container = DL1ParametersContainer() if dl1_container is None else dl1_container
 
@@ -136,35 +142,39 @@ def get_dl1(
             max_island_label = np.argmax(n_pixels_on_island)
             signal_pixels[island_labels != max_island_label] = False
 
-        hillas = hillas_parameters(camera_geometry[signal_pixels], image[signal_pixels])
+        if delta_t is not None:
+            new_mask = apply_time_delta_cleaning(camera_geometry,
+                                                 signal_pixels,
+                                                 peak_time, 1, delta_t)
+            signal_pixels = new_mask
 
-        # Fill container
-        dl1_container.fill_hillas(hillas)
+        if np.sum(signal_pixels) > 0:
+            hillas = hillas_parameters(camera_geometry[signal_pixels], image[signal_pixels])
 
-        # convert ctapipe's width and length (in m) to deg:
-        foclen = subarray.tel[telescope_id].optics.equivalent_focal_length
-        width = np.rad2deg(np.arctan2(dl1_container.width, foclen))
-        length = np.rad2deg(np.arctan2(dl1_container.length, foclen))
-        dl1_container.width = width
-        dl1_container.length = length
-        dl1_container.wl = dl1_container.width / dl1_container.length
+            # Fill container
+            dl1_container.fill_hillas(hillas)
 
-        dl1_container.set_timing_features(camera_geometry[signal_pixels],
-                                          image[signal_pixels],
-                                          peak_time[signal_pixels],
-                                          hillas)
-        dl1_container.set_leakage(camera_geometry, image, signal_pixels)
-        dl1_container.set_concentration(camera_geometry, image, hillas)
-        dl1_container.n_pixels = n_pixels
-        dl1_container.n_islands = num_islands
-        dl1_container.set_telescope_info(subarray, telescope_id)
+            # convert ctapipe's width and length (in m) to deg:
+            foclen = subarray.tel[telescope_id].optics.equivalent_focal_length
+            width = np.rad2deg(np.arctan2(dl1_container.width, foclen))
+            length = np.rad2deg(np.arctan2(dl1_container.length, foclen))
+            dl1_container.width = width
+            dl1_container.length = length
+            dl1_container.wl = dl1_container.width / dl1_container.length
 
-        dl1_container.log_intensity = np.log10(dl1_container.intensity)
+            dl1_container.set_timing_features(camera_geometry[signal_pixels],
+                                              image[signal_pixels],
+                                              peak_time[signal_pixels],
+                                              hillas)
+            dl1_container.set_leakage(camera_geometry, image, signal_pixels)
+            dl1_container.set_concentration(camera_geometry, image, hillas)
+            dl1_container.n_pixels = n_pixels
+            dl1_container.n_islands = num_islands
+            dl1_container.log_intensity = np.log10(dl1_container.intensity)
 
-    else:
-        # We set other fields which still make sense for a non-parametrized
-        # image:
-        dl1_container.set_telescope_info(subarray, telescope_id)
+    # We set other fields which still make sense for a non-parametrized
+    # image:
+    dl1_container.set_telescope_info(subarray, telescope_id)
 
     return dl1_container
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -109,12 +109,16 @@ def get_dl1(
 
     config = replace_config(standard_config, custom_config)
     cleaning_parameters = config["tailcut"]
+    use_main_island = True
+    if "use_only_main_island" in cleaning_parameters.keys():
+        # we use pop because ctapipe won't recognize that keyword in tailcuts
+        use_main_island = cleaning_parameters.pop("use_only_main_island")
 
-    use_main_island = cleaning_parameters.pop("use_only_main_island",
-                                              default=False)
     # time constraint for image cleaning: require at least one neighbor
     # within delta_time:
-    delta_time = cleaning_parameters.pop("delta_time", default=None)
+    delta_time = None
+    if "delta_time" in cleaning_parameters:
+        delta_time = cleaning_parameters.pop("delta_time")
 
     dl1_container = DL1ParametersContainer() if dl1_container is None else dl1_container
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -109,16 +109,12 @@ def get_dl1(
 
     config = replace_config(standard_config, custom_config)
     cleaning_parameters = config["tailcut"]
-    use_main_island = True
-    if "use_only_main_island" in cleaning_parameters.keys():
-        # we use pop because ctapipe won't recognize that keyword in tailcuts
-        use_main_island = cleaning_parameters.pop("use_only_main_island")
 
+    use_main_island = cleaning_parameters.pop("use_only_main_island",
+                                              default=False)
     # time constraint for image cleaning: require at least one neighbor
     # within delta_time:
-    delta_time = None
-    if "delta_time" in cleaning_parameters:
-        delta_time = cleaning_parameters.pop("delta_time")
+    delta_time = cleaning_parameters.pop("delta_time", default=None)
 
     dl1_container = DL1ParametersContainer() if dl1_container is None else dl1_container
 

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -182,10 +182,14 @@ def main():
                     # if delta_time has been set, we require at least one
                     # neighbor within delta_time to accept a pixel in the image:
                     if delta_time is not None:
+                        cleaned_pixel_times = peak_time
+                        # makes sure only signal pixels are used in the time
+                        # check:
+                        cleaned_pixel_times[~signal_pixels] = np.nan
                         new_mask = apply_time_delta_cleaning(camera_geom,
                                                              signal_pixels,
-                                                             peak_time, 1,
-                                                             delta_time)
+                                                             cleaned_pixel_times,
+                                                             1, delta_time)
                         signal_pixels = new_mask
 
                     if np.sum(signal_pixels) > 0:

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -94,7 +94,7 @@ def main():
         cleaning_params = get_cleaning_parameters(config, clean_method_name)
         pic_th, boundary_th, isolated_pixels, min_n_neighbors = cleaning_params
         log.info(f"Fraction of pixel cleaning thresholds above picture thr.:"
-                 f"{np.sum(pedestal_thresh>pic_th) / len(pedestal_thresh):.2f}")
+                 f"{np.sum(pedestal_thresh>pic_th) / len(pedestal_thresh):.3f}")
         picture_th = np.clip(pedestal_thresh, pic_th, None)
         log.info(f"Tailcut clean with pedestal threshold config used:"
                  f"{config['tailcuts_clean_with_pedestal_threshold']}")

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -93,6 +93,8 @@ def main():
         pedestal_thresh = get_threshold_from_dl1_file(args.input_file, sigma)
         cleaning_params = get_cleaning_parameters(config, clean_method_name)
         pic_th, boundary_th, isolated_pixels, min_n_neighbors = cleaning_params
+        log.info(f"Fraction of pixel cleaning thresholds above picture thr.:"
+                 f"{np.sum(pedestal_thresh>pic_th) / len(pedestal_thresh):.2f}")
         picture_th = np.clip(pedestal_thresh, pic_th, None)
         log.info(f"Tailcut clean with pedestal threshold config used:"
                  f"{config['tailcuts_clean_with_pedestal_threshold']}")
@@ -192,7 +194,10 @@ def main():
                                                              1, delta_time)
                         signal_pixels = new_mask
 
-                    if np.sum(signal_pixels) > 0:
+                    # count the surviving pixels
+                    n_pixels = np.count_nonzero(signal_pixels)
+
+                    if n_pixels > 0:
                         hillas = hillas_parameters(camera_geom[signal_pixels],
                                                    image[signal_pixels])
 

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -22,7 +22,7 @@ import tables
 from astropy.table import Table
 from ctapipe.containers import HillasParametersContainer
 from ctapipe.image import hillas_parameters
-from ctapipe.image.cleaning import tailcuts_clean
+from ctapipe.image.cleaning import tailcuts_clean, apply_time_delta_cleaning
 from ctapipe.image.morphology import number_of_islands
 from ctapipe.instrument import CameraGeometry, OpticsDescription
 
@@ -106,6 +106,10 @@ def main():
     if "use_only_main_island" in config[clean_method_name].keys():
         use_only_main_island = config[clean_method_name]["use_only_main_island"]
 
+    delta_time = None
+    if "delta_time" in config[clean_method_name].keys():
+        delta_time = config[clean_method_name]["delta_time"]
+
     foclen = OpticsDescription.from_name('LST').equivalent_focal_length
     cam_table = Table.read(args.input_file, path="instrument/telescope/camera/LSTCam")
     camera_geom = CameraGeometry.from_table(cam_table)
@@ -175,24 +179,35 @@ def main():
                     if use_only_main_island:
                         signal_pixels[island_labels != max_island_label] = False
 
-                    hillas = hillas_parameters(camera_geom[signal_pixels], image[signal_pixels])
+                    # if delta_time has been set, we require at least one
+                    # neighbor within delta_time to accept a pixel in the image:
+                    if delta_time is not None:
+                        new_mask = apply_time_delta_cleaning(camera_geom,
+                                                             signal_pixels,
+                                                             peak_time, 1,
+                                                             delta_time)
+                        signal_pixels = new_mask
 
-                    dl1_container.fill_hillas(hillas)
-                    dl1_container.set_timing_features(camera_geom[signal_pixels],
-                                                      image[signal_pixels],
-                                                      peak_time[signal_pixels],
-                                                      hillas)
+                    if np.sum(signal_pixels) > 0:
+                        hillas = hillas_parameters(camera_geom[signal_pixels],
+                                                   image[signal_pixels])
 
-                    dl1_container.set_leakage(camera_geom, image, signal_pixels)
-                    dl1_container.set_concentration(camera_geom, image, hillas)
-                    dl1_container.n_islands = num_islands
-                    dl1_container.wl = dl1_container.width / dl1_container.length
-                    dl1_container.n_pixels = n_pixels
-                    width = np.rad2deg(np.arctan2(dl1_container.width, foclen))
-                    length = np.rad2deg(np.arctan2(dl1_container.length, foclen))
-                    dl1_container.width = width
-                    dl1_container.length = length
-                    dl1_container.log_intensity = np.log10(dl1_container.intensity)
+                        dl1_container.fill_hillas(hillas)
+                        dl1_container.set_timing_features(camera_geom[signal_pixels],
+                                                          image[signal_pixels],
+                                                          peak_time[signal_pixels],
+                                                          hillas)
+
+                        dl1_container.set_leakage(camera_geom, image, signal_pixels)
+                        dl1_container.set_concentration(camera_geom, image, hillas)
+                        dl1_container.n_islands = num_islands
+                        dl1_container.wl = dl1_container.width / dl1_container.length
+                        dl1_container.n_pixels = n_pixels
+                        width = np.rad2deg(np.arctan2(dl1_container.width, foclen))
+                        length = np.rad2deg(np.arctan2(dl1_container.length, foclen))
+                        dl1_container.width = width
+                        dl1_container.length = length
+                        dl1_container.log_intensity = np.log10(dl1_container.intensity)
 
                 if set(dl1_params_input).intersection(disp_params):
                     disp_dx, disp_dy, disp_norm, disp_angle, disp_sign = disp(

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -103,11 +103,11 @@ def main():
         log.info(f"Tailcut config used: {config['tailcut']}")
 
     use_only_main_island = True
-    if "use_only_main_island" in config[clean_method_name].keys():
+    if "use_only_main_island" in config[clean_method_name]:
         use_only_main_island = config[clean_method_name]["use_only_main_island"]
 
     delta_time = None
-    if "delta_time" in config[clean_method_name].keys():
+    if "delta_time" in config[clean_method_name]:
         delta_time = config[clean_method_name]["delta_time"]
 
     foclen = OpticsDescription.from_name('LST').equivalent_focal_length


### PR DESCRIPTION
Add the possibility to set a simple time constraint in the cleaning: right before image parametrization (i.e. after the charge-based cleaning) we require each pixel to have at least a neighbor with peak time within delta_t of the pixel's peak time. 