### PR TITLE
Update default cleaning levels 

### DIFF
--- a/lstchain/data/lstchain_src_dep_config.json
+++ b/lstchain/data/lstchain_src_dep_config.json
@@ -1,4 +1,28 @@
 {
+  "source_config" : {
+    "EventSource": {
+      "allowed_tels": [1, 2, 3, 4],
+      "max_events": null
+    },
+    "LSTEventSource": {
+      "default_trigger_type": "ucts",
+      "allowed_tels": [1],
+      "calibrate_flatfields_and_pedestals": false,
+      "EventTimeCalculator": {
+        "dragon_reference_counter": null,
+        "dragon_reference_time": null
+      },
+      "PointingSource":{
+        "drive_report_path": null
+      },
+      "LSTR0Corrections":{
+        "drs4_pedestal_path": null,
+        "calibration_path": null,
+        "drs4_time_calibration_path": null
+      }
+    }
+  },
+
   "events_filters": {
     "intensity": [0, Infinity],
     "width": [0, Infinity],
@@ -8,13 +32,16 @@
     "leakage_intensity_width_2": [0, 1]
   },
 
-  "tailcut": {
+  "tailcuts_clean_with_pedestal_threshold": {
     "picture_thresh":6,
     "boundary_thresh":3,
+    "sigma":2.5,
     "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":1
+    "min_number_picture_neighbors":2,
+    "use_only_main_island":false,
+    "delta_time": 2
   },
-
+    
     "random_forest_regressor_args": {
     "max_depth": 50,
     "min_samples_leaf": 2,

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -36,9 +36,9 @@
     "picture_thresh":6,
     "boundary_thresh":3,
     "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":1,
-    "use_only_main_island":true,
-    "delta_time": null
+    "min_number_picture_neighbors":2,
+    "use_only_main_island":false,
+    "delta_time": 2
   },
   "tailcuts_clean_with_pedestal_threshold": {
     "picture_thresh":6,

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -41,15 +41,14 @@
     "delta_time": null
   },
   "tailcuts_clean_with_pedestal_threshold": {
-    "picture_thresh":8,
-    "boundary_thresh":4,
-    "sigma":3,
+    "picture_thresh":6,
+    "boundary_thresh":3,
+    "sigma":2.5,
     "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":1,
+    "min_number_picture_neighbors":2,
     "use_only_main_island":false,
-    "delta_time": null
+    "delta_time": 2
   },
-
     "random_forest_regressor_args": {
     "max_depth": 50,
     "min_samples_leaf": 2,

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -115,9 +115,6 @@ def get_dl1(
     if "delta_time" in cleaning_parameters:
         delta_time = cleaning_parameters["delta_time"]
 
-    print('use_main_island', use_main_island)
-    print('delta_time', delta_time)
-        
     # we use pop because ctapipe won't recognize that keyword in tailcuts
     cleaning_parameters_for_tailcuts.pop("delta_time")
     cleaning_parameters_for_tailcuts.pop("use_only_main_island")

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -104,17 +104,21 @@ def get_dl1(
 
     config = replace_config(standard_config, custom_config)
     cleaning_parameters = config["tailcut"]
+    cleaning_parameters_for_tailcuts = cleaning_parameters.copy()
     use_main_island = True
     if "use_only_main_island" in cleaning_parameters.keys():
-        # we use pop because ctapipe won't recognize that keyword in tailcuts
-        use_main_island = cleaning_parameters.pop("use_only_main_island")
+        use_main_island = cleaning_parameters["use_only_main_island"]
 
     # time constraint for image cleaning: require at least one neighbor
     # within delta_time:
     delta_time = None
     if "delta_time" in cleaning_parameters:
-        delta_time = cleaning_parameters.pop("delta_time")
+        delta_time = cleaning_parameters["delta_time"]
 
+    # we use pop because ctapipe won't recognize that keyword in tailcuts
+    cleaning_parameters_for_tailcuts.pop("delta_time")
+    cleaning_parameters_for_tailcuts.pop("use_only_main_island")
+    
     dl1_container = DL1ParametersContainer() if dl1_container is None else dl1_container
 
     dl1 = calibrated_event.dl1.tel[telescope_id]
@@ -124,7 +128,7 @@ def get_dl1(
     image = dl1.image
     peak_time = dl1.peak_time
 
-    signal_pixels = cleaning_method(camera_geometry, image, **cleaning_parameters)
+    signal_pixels = cleaning_method(camera_geometry, image, **cleaning_parameters_for_tailcuts)
     n_pixels = np.count_nonzero(signal_pixels)
 
     if n_pixels > 0:

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -148,8 +148,8 @@ def get_dl1(
             cleaned_pixel_times[~signal_pixels] = np.nan
 
             new_mask = apply_time_delta_cleaning(camera_geometry,
-                                                 cleaned_pixel_times,
-                                                 peak_time, 1, delta_time)
+                                                 signal_pixels,
+                                                 cleaned_pixel_times, 1, delta_time)
             signal_pixels = new_mask
 
         # count surviving pixels

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -115,6 +115,9 @@ def get_dl1(
     if "delta_time" in cleaning_parameters:
         delta_time = cleaning_parameters["delta_time"]
 
+    print('use_main_island', use_main_island)
+    print('delta_time', delta_time)
+        
     # we use pop because ctapipe won't recognize that keyword in tailcuts
     cleaning_parameters_for_tailcuts.pop("delta_time")
     cleaning_parameters_for_tailcuts.pop("use_only_main_island")
@@ -142,8 +145,13 @@ def get_dl1(
             signal_pixels[island_labels != max_island_label] = False
 
         if delta_time is not None:
+            cleaned_pixel_times = peak_time
+            # makes sure only signal pixels are used in the time
+            # check:
+            cleaned_pixel_times[~signal_pixels] = np.nan
+
             new_mask = apply_time_delta_cleaning(camera_geometry,
-                                                 signal_pixels,
+                                                 cleaned_pixel_times,
                                                  peak_time, 1, delta_time)
             signal_pixels = new_mask
 

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -249,7 +249,7 @@ def test_observed_dl1ab(tmp_path, observed_dl1_files):
     assert output_dl1ab.is_file()
     dl1ab = pd.read_hdf(output_dl1ab, key=dl1_params_lstcam_key)
     dl1 = pd.read_hdf(observed_dl1_files["dl1_file1"], key=dl1_params_lstcam_key)
-    np.testing.assert_allclose(dl1, dl1ab, rtol=1e-4, equal_nan=True)
+    np.testing.assert_allclose(dl1, dl1ab, rtol=1e-3, equal_nan=True)
 
 
 def test_simulated_dl1ab_validity(simulated_dl1_file, simulated_dl1ab):


### PR DESCRIPTION
After discussion in #628, we finally decided for a standard cleaning defined by:
- picture threshold = 6
- boundary threshold = 3 
- sigma = 2.5
- time delta cleaning = 2
- min_number_picture_neighbors = 2

as it is included now in the configuration of `tailcuts_clean_with_pedestal_threshold`. There is still the point raised by @moralejo that `tailcut` would still be applied at the `r0_to_dl1` level, but in principle we need to compute the events using the proper cleaning by running the `lstchain_dl1ab.py`

Other places where the regular `tailcuts_clean` is used are:
- `lstchain/reco/volume_reducer.py`
- `lstchain/image/muon/muon_analysis.py` -> here a [hardcoded [10, 5] cleaning is applied](https://github.com/cta-observatory/cta-lstchain/blob/5183119f3fb732163d03bb463dd4efdac3122f48/lstchain/image/muon/muon_analysis.py#L134)