### PR TITLE
Use telescope ID together with telescope name during R0 to DL1 conversion

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -418,10 +418,7 @@ def write_array_info_08(subarray, output_filename):
           if 'camera' in telescope_chidren:
             cameras_name = f.root['/configuration/instrument/telescope/camera']._v_children.keys()
             if camera_name in cameras_name:
-              print(
-                f'WARNING during lstchain.io.write_array_info_08():',
-                f'camera {camera_name} seems to be already present in the h5 file.'
-              )
+              log.warning('Camera %s seems to be already present in the h5 file', camera_name)
               continue
         camera.geometry.to_table().write(
           output_filename,
@@ -478,10 +475,7 @@ def write_array_info(subarray, output_filename):
                 if 'camera' in telescope_chidren:
                     cameras_name = f.root['instrument/telescope/camera']._v_children.keys()
                     if camera_name in cameras_name:
-                        print(
-                            f'WARNING during lstchain.io.write_array_info():',
-                            f'camera {camera_name} seems to be already present in the h5 file.'
-                        )
+                        log.warning('Camera %s seems to be already present in the h5 file', camera_name)
                         continue
 
             camera.geometry.to_table().write(
@@ -893,6 +887,9 @@ def write_subarray_tables(writer, event, metadata=None):
         add_global_metadata(event.simulation, metadata)
         add_global_metadata(event.trigger, metadata)
 
+    writer.exclude('subarray/mc_shower', 'mc_shower')
+    writer.exclude('subarray/mc_shower', 'mc_tel')
+
     writer.write(table_name="subarray/mc_shower", containers=[event.index, event.simulation])
     writer.write(table_name="subarray/trigger", containers=[event.index, event.trigger])
 
@@ -949,6 +946,7 @@ def add_column_table(table, ColClass, col_label, values):
     -------
     `tables.table.Table`
     """
+    log.debug('Adding %s column', col_label)
     # Step 1: Adjust table description
     d = table.description._v_colobjects.copy()  # original description
     d[col_label] = ColClass()  # add column
@@ -958,6 +956,7 @@ def add_column_table(table, ColClass, col_label, values):
     table.attrs._f_copy(newtable)  # copy attributes
     # Copy table rows, also add new column values:
     for row, value in zip(table, values):
+        log.debug('Row:\n%s\nValue:\n%s', list(row[:]), value)
         newtable.append([tuple(list(row[:]) + [value])])
     newtable.flush()
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -398,7 +398,7 @@ def r0_to_dl1(
                 tel.prefix = ''  # don't really need one
                 # remove the first part of the tel_name which is the type 'LST', 'MST' or 'SST'
                 #tel_name = str(subarray.tel[telescope_id])[4:]
-                tel_name = f'{str(subarray.tel[telescope_id])[4:]}-{telescope_id}'
+                tel_name = f'{str(subarray.tel[telescope_id])[4:]}_{telescope_id}'
 
                 if custom_calibration:
                     lst_calibration(event, telescope_id)
@@ -592,7 +592,7 @@ def r0_to_dl1(
             if telescope_id in config['source_config']['EventSource']['allowed_tels']:
                 logger.debug('Add DISP parameters for telescope %s' %telescope_id)
                 #tel_name = str(subarray.tel[telescope_id])[4:]
-                tel_name = f'{str(subarray.tel[telescope_id])[4:]}-{telescope_id}'
+                tel_name = f'{str(subarray.tel[telescope_id])[4:]}_{telescope_id}'
                 logger.debug('Telescope name is %s' %tel_name)
                 focal = subarray.tel[telescope_id].optics.equivalent_focal_length
                 add_disp_to_parameters_table(output_filename, f'dl1/event/telescope/parameters/{tel_name}', focal)

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -588,13 +588,14 @@ def r0_to_dl1(
 
     if is_simu:
         # Reconstruct source position from disp for all events and write the result in the output file
-        for telescope_id in config['source_config']['EventSource']['allowed_tels']:
-            logger.debug('Add DISP parameters for telescope %s' %telescope_id)
-            #tel_name = str(subarray.tel[telescope_id])[4:]
-            tel_name = f'{str(subarray.tel[telescope_id])[4:]}-{telescope_id}'
-            logger.debug('Telescope name is %s' %tel_name)
-            focal = subarray.tel[telescope_id].optics.equivalent_focal_length
-            add_disp_to_parameters_table(output_filename, f'dl1/event/telescope/parameters/{tel_name}', focal)
+        for telescope_id in subarray.tels.keys():
+            if telescope_id in config['source_config']['EventSource']['allowed_tels']:
+                logger.debug('Add DISP parameters for telescope %s' %telescope_id)
+                #tel_name = str(subarray.tel[telescope_id])[4:]
+                tel_name = f'{str(subarray.tel[telescope_id])[4:]}-{telescope_id}'
+                logger.debug('Telescope name is %s' %tel_name)
+                focal = subarray.tel[telescope_id].optics.equivalent_focal_length
+                add_disp_to_parameters_table(output_filename, f'dl1/event/telescope/parameters/{tel_name}', focal)
 
         # Write energy histogram from simtel file and extra metadata
         # ONLY of the simtel file has been read until the end, otherwise it seems to hang here forever

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -588,7 +588,7 @@ def r0_to_dl1(
 
     if is_simu:
         # Reconstruct source position from disp for all events and write the result in the output file
-        for ii, telescope_id in enumerate(event.dl1.tel.keys()):
+        for telescope_id in config['source_config']['EventSource']['allowed_tels']:
             logger.debug('Add DISP parameters for telescope %s' %telescope_id)
             #tel_name = str(subarray.tel[telescope_id])[4:]
             tel_name = f'{str(subarray.tel[telescope_id])[4:]}-{telescope_id}'


### PR DESCRIPTION
Possible fix of telescopes with the same name not being properly distinguished

Details: [Issue 633](https://github.com/cta-observatory/cta-lstchain/issues/633)