### PR TITLE
Fix mixing of Level A and Level B calibration

### DIFF
--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -7,6 +7,7 @@ full camera image is also available.
 import logging
 import math
 import os
+from copy import deepcopy
 from functools import partial
 from itertools import chain
 from pathlib import Path
@@ -347,7 +348,7 @@ def r0_to_dl1(
                     tel_id = calibration_calculator.tel_id
 
                     #initialize the event monitoring data
-                    event.mon = source.r0_r1_calibrator.mon_data
+                    event.mon = deepcopy(source.r0_r1_calibrator.mon_data)
 
                     # write the first calibration event (initialized from calibration h5 file)
                     write_calibration_data(writer,


### PR DESCRIPTION
The present code overwrites the level A calibration as soon as a Level B calibration event is ready, this is not what we want at this level