### PR TITLE
Suppress Column X in Table Y is not writable warnings

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -764,10 +764,6 @@ def write_subarray_tables(writer, event, metadata=None):
         add_global_metadata(event.simulation, metadata)
         add_global_metadata(event.trigger, metadata)
 
-    writer.exclude('subarray/mc_shower', 'mc_shower')
-    writer.exclude('subarray/mc_shower', 'mc_tel')
-
-    writer.write(table_name="subarray/mc_shower", containers=[event.index, event.simulation])
     writer.write(table_name="subarray/trigger", containers=[event.index, event.trigger])
 
 

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -764,6 +764,9 @@ def write_subarray_tables(writer, event, metadata=None):
         add_global_metadata(event.simulation, metadata)
         add_global_metadata(event.trigger, metadata)
 
+    writer.exclude('subarray/mc_shower', 'mc_shower')
+    writer.exclude('subarray/mc_shower', 'mc_tel')
+
     writer.write(table_name="subarray/mc_shower", containers=[event.index, event.simulation])
     writer.write(table_name="subarray/trigger", containers=[event.index, event.trigger])
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -423,7 +423,6 @@ def r0_to_dl1(
                     dl1_container.trigger_type = event.lst.tel[telescope_id].evt.tib_masked_trigger
                 else:
                     dl1_container.trigger_type = event.trigger.event_type
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'hadroness')
                     writer.exclude(f'telescope/parameters/{tel_name}', 'dragon_time')
                     writer.exclude(f'telescope/parameters/{tel_name}', 'ucts_time')
                     writer.exclude(f'telescope/parameters/{tel_name}', 'tib_time')
@@ -445,19 +444,33 @@ def r0_to_dl1(
                     add_global_metadata(container, metadata)
 
                 event.r0.prefix = ''
-                if is_simu:
-                    # None values in telescope/image table
-                    writer.exclude(f'telescope/image/{tel_name}', 'image_mask')
-                    writer.exclude(f'telescope/image/{tel_name}', 'parameters')
-                    # None values in telescope/parameters table
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_norm')
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_dx')
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_dy')
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_angle')
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_sign')
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_miss')
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'src_x')
-                    writer.exclude(f'telescope/parameters/{tel_name}', 'src_y')
+
+                # None values in telescope/image table
+                writer.exclude(f'telescope/image/{tel_name}', 'image_mask')
+                writer.exclude(f'telescope/image/{tel_name}', 'parameters')
+                # None values in telescope/parameters table
+                writer.exclude(f'telescope/parameters/{tel_name}', 'hadroness')
+                writer.exclude(f'telescope/parameters/{tel_name}', 'disp_norm')
+                writer.exclude(f'telescope/parameters/{tel_name}', 'disp_dx')
+                writer.exclude(f'telescope/parameters/{tel_name}', 'disp_dy')
+                writer.exclude(f'telescope/parameters/{tel_name}', 'disp_angle')
+                writer.exclude(f'telescope/parameters/{tel_name}', 'disp_sign')
+                writer.exclude(f'telescope/parameters/{tel_name}', 'disp_miss')
+                writer.exclude(f'telescope/parameters/{tel_name}', 'src_x')
+                writer.exclude(f'telescope/parameters/{tel_name}', 'src_y')
+
+                if not is_simu:
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_energy')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'log_mc_energy')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_alt')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_az')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_core_x')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_core_y')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_h_first_int')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_alt_tel')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_az_tel')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_x_max')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'mc_core_distance')
 
                 writer.write(table_name=f'telescope/image/{tel_name}',
                              containers=[event.index, tel, extra_im])

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -295,6 +295,7 @@ def r0_to_dl1(
                 col_name='tels_with_trigger',
                 transform=tel_list_transform
             )
+            writer.exclude(f'subarray/trigger', 'tel')
 
         # Forcing filters for the dl1 dataset that are currently read from the pre-existing files
         # This should be fixed in ctapipe and then corrected here
@@ -422,6 +423,11 @@ def r0_to_dl1(
                     dl1_container.trigger_type = event.lst.tel[telescope_id].evt.tib_masked_trigger
                 else:
                     dl1_container.trigger_type = event.trigger.event_type
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'hadroness')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'dragon_time')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'ucts_time')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'tib_time')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'ucts_trigger_type')
 
                 dl1_container.az_tel = event.pointing.tel[telescope_id].azimuth
                 dl1_container.alt_tel = event.pointing.tel[telescope_id].altitude
@@ -439,6 +445,19 @@ def r0_to_dl1(
                     add_global_metadata(container, metadata)
 
                 event.r0.prefix = ''
+                if is_simu:
+                    # None values in telescope/image table
+                    writer.exclude(f'telescope/image/{tel_name}', 'image_mask')
+                    writer.exclude(f'telescope/image/{tel_name}', 'parameters')
+                    # None values in telescope/parameters table
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_norm')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_dx')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_dy')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_angle')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_sign')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'disp_miss')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'src_x')
+                    writer.exclude(f'telescope/parameters/{tel_name}', 'src_y')
 
                 writer.write(table_name=f'telescope/image/{tel_name}',
                              containers=[event.index, tel, extra_im])


### PR DESCRIPTION
Excludes non-existing columns from attempt to write, thus suppressing the corresponding warnings