### PR TITLE
Fix Full Enclosure IRF

### DIFF
--- a/lstchain/io/event_selection.py
+++ b/lstchain/io/event_selection.py
@@ -241,7 +241,7 @@ class DataBinning(Component):
 
         source_offset = (
             np.linspace(
-                self.source_offset_max,
+                self.source_offset_min,
                 self.source_offset_max,
                 self.source_offset_n_edges,
             )

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -145,7 +145,7 @@ class IRFFITSWriter(Tool):
     flags = {
         "point-like": (
             {"IRFFITSWriter": {"point_like": True}},
-            "Full Enclosure IRFs will be produced",
+            "Point like IRFs will be produced, otherwise Full Enclosure",
         ),
         "overwrite": (
             {"IRFFITSWriter": {"overwrite": True}},
@@ -256,10 +256,9 @@ class IRFFITSWriter(Tool):
         gammas = self.fixed_cuts.allowed_tels_filter(gammas)
         gammas = self.fixed_cuts.gh_cut(gammas)
 
-        # With point_like flag for point like IRFs.
-        # Without point_like flag for Full Enclosure IRFs
         if self.point_like:
             gammas = self.fixed_cuts.theta_cut(gammas)
+            self.log.info('Theta cuts applied for point like IRF')
 
         # Binning of parameters used in IRFs
         true_energy_bins = self.data_bin.true_energy_bins()
@@ -267,11 +266,13 @@ class IRFFITSWriter(Tool):
         migration_bins = self.data_bin.energy_migration_bins()
         source_offset_bins = self.data_bin.source_offset_bins()
 
-        if self.point_like:
+        if self.mc_particle["gamma"]["mc_type"] == "point_like":
             mean_fov_offset = round(gammas["true_source_fov_offset"].mean().to_value(), 1)
             fov_offset_bins = [mean_fov_offset - 0.1, mean_fov_offset + 0.1] * u.deg
+            self.log.info('Single offset for point like gamma MC')
         else:
             fov_offset_bins = self.data_bin.fov_offset_bins()
+            self.log.info('Multiple offset for diffuse gamma MC')
 
         if not self.only_gamma_irf:
             background = table.vstack(

--- a/lstchain/tools/tests/test_tools.py
+++ b/lstchain/tools/tests/test_tools.py
@@ -35,6 +35,21 @@ def test_create_irf(temp_dir_observed_files, simulated_dl2_file):
                 f"--input-proton-dl2={simulated_dl2_file}",
                 f"--input-electron-dl2={simulated_dl2_file}",
                 f"--output-irf-file={irf_file}",
+                "--point-like",
+                "--overwrite",
+            ],
+            cwd=temp_dir_observed_files,
+        )
+        == 0
+    )
+    assert (
+        run_tool(
+            IRFFITSWriter(),
+            argv=[
+                f"--input-gamma-dl2={simulated_dl2_file}",
+                f"--input-proton-dl2={simulated_dl2_file}",
+                f"--input-electron-dl2={simulated_dl2_file}",
+                f"--output-irf-file={irf_file}",
                 f"--config={config_file}",
                 "--overwrite",
             ],


### PR DESCRIPTION
Fixing Full Enclosure IRF by resolving a mixup between 'mc_type' and 'irf_type' and a small error in calculating source_offset_bins for PSF.