### PR TITLE
Unusable pixels in dl1ab

### DIFF
--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -3,6 +3,7 @@ import numpy as np
 from ctapipe_io_lst.constants import HIGH_GAIN
 from lstchain.io.io import dl1_params_tel_mon_ped_key, dl1_params_tel_mon_cal_key
 
+INTERLEAVED_CALIBRATION_ID = 1
 
 def get_bias_and_std(dl1_file):
     """
@@ -56,7 +57,7 @@ def get_threshold_from_dl1_file(dl1_path, sigma_clean):
     # std values from calibration run.
     # Correct interleaved pedestal std array should have shape (2,2,1855)
     if ped_std_pe.shape[0] == 2:
-        interleaved_events_id = 1
+        interleaved_events_id = INTERLEAVED_CALIBRATION_ID
     else:
         interleaved_events_id = 0
     threshold_clean_pe = ped_mean_pe + sigma_clean*ped_std_pe
@@ -73,7 +74,7 @@ def get_unusable_pixels(dl1_path):
     with tables.open_file(dl1_path) as f:
         calibration_id = f.root.dl1.event.telescope.monitoring.pedestal.col('calibration_id')
         unusable_pixels = np.where(f.root[dl1_params_tel_mon_cal_key].col(
-                                   'unusable_pixels')[calibration_id[1],
+                                   'unusable_pixels')[calibration_id[INTERLEAVED_CALIBRATION_ID],
                                                       HIGH_GAIN,
                                                       :] == True)
     return unusable_pixels

--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -49,7 +49,7 @@ def get_threshold_from_dl1_file(dl1_path, sigma_clean):
     picture_thresh: np.ndarray
         picture threshold calculated using interleaved pedestal events
     """
-    
+
     ped_mean_pe, ped_std_pe = get_bias_and_std(dl1_path)
 
     # If problem with interleaved pedestal std values occur, take pedestal
@@ -62,17 +62,18 @@ def get_threshold_from_dl1_file(dl1_path, sigma_clean):
     threshold_clean_pe = ped_mean_pe + sigma_clean*ped_std_pe
     # find pixels with std = 0 and mean = 0 <=> dead pixels in interleaved
     # pedestal event likely due to stars
-    unusable_pixels = get_unusable_pixels(dl1_path, interleaved_events_id)
+    unusable_pixels = get_unusable_pixels(dl1_path)
     # for dead pixels set max value of threshold
     threshold_clean_pe[interleaved_events_id, HIGH_GAIN, unusable_pixels] = \
         max(threshold_clean_pe[interleaved_events_id, HIGH_GAIN, :])
     # return pedestal interleaved threshold from data run for high gain
     return threshold_clean_pe[interleaved_events_id, HIGH_GAIN, :]
 
-def get_unusable_pixels(dl1_path, interleaved_events_id):
+def get_unusable_pixels(dl1_path):
     with tables.open_file(dl1_path) as f:
+        calibration_id = f.root.dl1.event.telescope.monitoring.pedestal.col('calibration_id')
         unusable_pixels = np.where(f.root[dl1_params_tel_mon_cal_key].col(
-                                   'unusable_pixels')[interleaved_events_id,
+                                   'unusable_pixels')[calibration_id[1],
                                                       HIGH_GAIN,
                                                       :] == True)
     return unusable_pixels

--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -58,24 +58,24 @@ def get_threshold_from_dl1_file(dl1_path, sigma_clean):
     # std values from calibration run.
     # Correct interleaved pedestal std array should have shape (2,2,1855)
     if ped_std_pe.shape[0] == 2:
-        pedestal_events_id = INTERLEAVED_CALIBRATION_ID
+        pedestal_id = INTERLEAVED_CALIBRATION_ID
     else:
-        pedestal_events_id = ORIGINAL_CALIBRATION_ID
+        pedestal_id = ORIGINAL_CALIBRATION_ID
     threshold_clean_pe = ped_mean_pe + sigma_clean*ped_std_pe
     # find pixels with std = 0 and mean = 0 <=> dead pixels in interleaved
     # pedestal event likely due to stars
-    unusable_pixels = get_unusable_pixels(dl1_path, pedestal_events_id)
+    unusable_pixels = get_unusable_pixels(dl1_path, pedestal_id)
     # for dead pixels set max value of threshold
-    threshold_clean_pe[pedestal_events_id, HIGH_GAIN, unusable_pixels] = \
-        max(threshold_clean_pe[pedestal_events_id, HIGH_GAIN, :])
+    threshold_clean_pe[pedestal_id, HIGH_GAIN, unusable_pixels] = \
+        max(threshold_clean_pe[pedestal_id, HIGH_GAIN, :])
     # return pedestal interleaved threshold from data run for high gain
-    return threshold_clean_pe[pedestal_events_id, HIGH_GAIN, :]
+    return threshold_clean_pe[pedestal_id, HIGH_GAIN, :]
 
-def get_unusable_pixels(dl1_path, pedestal_events_id):
+def get_unusable_pixels(dl1_path, pedestal_id):
     with tables.open_file(dl1_path) as f:
         calibration_id = f.root.dl1.event.telescope.monitoring.pedestal.col('calibration_id')
         unusable_pixels = np.where(f.root[dl1_params_tel_mon_cal_key].col(
-                                   'unusable_pixels')[calibration_id[pedestal_events_id],
+                                   'unusable_pixels')[calibration_id[pedestal_id],
                                                       HIGH_GAIN,
                                                       :] == True)
     return unusable_pixels


### PR DESCRIPTION
Fix Unusable pixels error in dl1ab #669.

According to @FrancaCassol and @moralejo suggestion, I took calibration_id from `f.root.dl1.event.telescope.monitoring.pedestal.col('calibration_id')` to got unusable_pixels.

This solve problem with production, but such data  as run 02927, sub-run 0164  have wrong interleaved pedestal (pedestal from calibration run instead from data run). Do you have any idea how to solve it? 