### PR TITLE
Remove obsolete macos instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,6 @@ are unit tested and should be working as long as the build status is passing.
 - You will need to install [anaconda](https://www.anaconda.com/distribution/#download-section) first. 
 
 
-### macOS requirements
-
-lstchain depends on `protozfits` to read LST raw data via `ctapipe_io_lst`.
-Currently, prebuilt binaries are only available on linux.
-On macOS, you will need `protobuf` and `zeromq` installed so that the
-module can be build from source by `pip`.
-We recommend using `homebrew` and then `brew install zeromq protobuf`.
-
 ### As user
 
 ```


### PR DESCRIPTION
This is not needed anymore since we have the conda-forge packages.