### PR TITLE
filter events before applying models

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -395,11 +395,14 @@ def apply_models(dl1, classifier, reg_energy, reg_disp_vector, focal_length=28*u
     """
 
     config = replace_config(standard_config, custom_config)
-
-    dl2 = dl1.copy()
-
     regression_features = config["regression_features"]
     classification_features = config["classification_features"]
+    events_filters = config["events_filters"]
+
+    dl2 = utils.filter_events(dl1,
+                              filters=events_filters,
+                              finite_params=config['regression_features'] + config['classification_features'],
+                              )
       
     #Reconstruction of Energy and disp_norm distance
     dl2['log_reco_energy'] = reg_energy.predict(dl2[regression_features])


### PR DESCRIPTION
The events were not filtered before applying the models, leading to an issue when `nan` values were in the data in the latest production, nicely reported by @chaimain and @garciagenrique.

It also means that the filters were not applied in case only applying the dl1_to_dl2 step (with stricter filters than when dl1 are created).