### PR TITLE
Update lstchain_standard_config.json

### DIFF
--- a/lstchain/data/lstchain_src_dep_config.json
+++ b/lstchain/data/lstchain_src_dep_config.json
@@ -7,6 +7,8 @@
     "LSTEventSource": {
       "default_trigger_type": "ucts",
       "allowed_tels": [1],
+      "min_flatfield_adc": 3000,
+      "min_flatfield_pixel_fraction": 0.8,
       "calibrate_flatfields_and_pedestals": false,
       "EventTimeCalculator": {
         "dragon_reference_counter": null,

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -7,6 +7,8 @@
     "LSTEventSource": {
       "default_trigger_type": "ucts",
       "allowed_tels": [1],
+      "min_flatfield_adc": 3000,
+      "min_flatfield_pixel_fraction": 0.8,
       "calibrate_flatfields_and_pedestals": false,
       "EventTimeCalculator": {
         "dragon_reference_counter": null,


### PR DESCRIPTION
Checking one of the runs @moralejo reported with problems for the ff tagging, I investigated a bit and came to the conclusion the we should adapt the default values for the ff tagging to min=3000, fraction=0.8.


Pixel values we are looking at for the tagging with the new min, max and the old min:

![r0_sums](https://user-images.githubusercontent.com/5488440/114037974-c0560c80-9881-11eb-964d-b6d90064d5f0.png)


New resulting ratios with the new cut in ratio:

![pixel_fraction](https://user-images.githubusercontent.com/5488440/114038000-c5b35700-9881-11eb-9972-e06c4459a52a.png)

With that, the identified FF rate goes from 86 to 92 events per second.