### PR TITLE
allow more complex naming of irf files

### DIFF
--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -166,12 +166,12 @@ class IRFFITSWriter(Tool):
                 )
 
         filename = self.output_irf_file.name
-        if filename.split(".")[1] != "fits":
+        if filename.split(".")[-2] != "fits" or filename.split(".")[-1] != "gz":
             self.log.warning(
                 f"{filename} is not a correct "
-                "compressed FITS file name. It will be corrected."
+                "compressed FITS file name (.fits.gz). It will be corrected."
             )
-            filename = filename.split(".")[0] + ".fits.gz"
+            filename += ".fits.gz"
             self.output_irf_file = self.output_irf_file.parent / filename
 
         if self.input_proton_dl2 and self.input_electron_dl2 is not None:

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -166,13 +166,8 @@ class IRFFITSWriter(Tool):
                 )
 
         filename = self.output_irf_file.name
-        if filename.split(".")[-2] != "fits" or filename.split(".")[-1] != "gz":
-            self.log.warning(
-                f"{filename} is not a correct "
-                "compressed FITS file name (.fits.gz). It will be corrected."
-            )
-            filename += ".fits.gz"
-            self.output_irf_file = self.output_irf_file.parent / filename
+        if not (filename.endswith('.fits') or filename.endswith('.fits.gz')):
+            raise ValueError("f{filename} is not a correct compressed FITS file name (use .fits or .fits.gz).")
 
         if self.input_proton_dl2 and self.input_electron_dl2 is not None:
             self.only_gamma_irf = False


### PR DESCRIPTION
It would be great to allow more complex names for IRF files.
For example, in the production, we use tags such as `20210403_v0.7.1_prod5_trans_80_local` in the names that include the lstchain version. In this case, we would end up with `20210403_v0.fits.gz` as filename.