### PR TITLE
Tool to generate a HDF table of sampling interval coefficients

### DIFF
--- a/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
+++ b/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
@@ -16,8 +16,8 @@ class SamplingIntervalCalculate(Component):
         The SamplingIntervalCalculate class to create a sampling interval coefficient table for LST readout system using chip DRS4.
     """
     def __init__(self):
-        self.peak_count = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
-        self.fc_count = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
+        self.peak_count = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL], dtype=np.uint16)
+        self.fc_count = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL], dtype=np.uint16)
 
         self.peak_count_stack ={}
         self.fc_count_stack = {}
@@ -27,7 +27,7 @@ class SamplingIntervalCalculate(Component):
         self.charge_reso_array_after_corr ={}
 
         self.charge_reso_final = np.zeros(N_PIXELS)
-        self.used_run = np.zeros(N_PIXELS)
+        self.used_run = np.zeros(N_PIXELS, dtype=np.uint16)
         self.sampling_interval_coefficient_final = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
 
     def increment_peak_count(self, event, tel_id, gain, r0_r1_calibrator):
@@ -60,8 +60,8 @@ class SamplingIntervalCalculate(Component):
             
             if gain_in_file == gain:
                 if not run_id in self.peak_count_stack.keys():
-                    self.peak_count_stack[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
-                    self.fc_count_stack[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
+                    self.peak_count_stack[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL], dtype=np.uint16)
+                    self.fc_count_stack[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL], dtype=np.uint16)
                 
                 self.peak_count_stack[run_id] += peak_count
                 self.fc_count_stack[run_id] += fc_count
@@ -142,7 +142,7 @@ class SamplingIntervalCalculate(Component):
 
     def verify(self):
         n_keys=len(self.charge_reso_array_after_corr.keys())
-        run_id_array = np.zeros(n_keys)
+        run_id_array = np.zeros(n_keys, dtype=np.uint16)
         charge_reso_array_after_corr_all = np.zeros([n_keys, 1855])
         
         for i, ikey in enumerate(self.charge_reso_array_after_corr.keys()):
@@ -152,7 +152,7 @@ class SamplingIntervalCalculate(Component):
         for ipix in range(N_PIXELS):
             min_charge_reso_arg = np.argmin(charge_reso_array_after_corr_all.T[ipix])
             self.charge_reso_final[ipix] = charge_reso_array_after_corr_all[min_charge_reso_arg, ipix]
-            self.used_run[ipix] = int(run_id_array[min_charge_reso_arg])
+            self.used_run[ipix] = run_id_array[min_charge_reso_arg]
             self.sampling_interval_coefficient_final[ipix] = self.sampling_interval_coefficient[self.used_run[ipix]][ipix, :N_CAPACITORS_CHANNEL]
 
 

--- a/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
+++ b/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
@@ -80,10 +80,10 @@ class SamplingIntervalCalculate(Component):
             self.sampling_interval_coefficient[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL + N_SAMPLES])
 
             stack_events_num = np.sum(self.peak_count_stack[run_id], axis=1)
-            stack_events_num = stack_events_num.reshape(1, N_PIXELS)
+            stack_events_num = stack_events_num.reshape(1, N_PIXELS).T
 
             self.sampling_interval_coefficient[run_id][:,:N_CAPACITORS_CHANNEL] = (
-                self.peak_count_stack[run_id][pixel] / stack_events_num * N_CAPACITORS_CHANNEL )
+                self.peak_count_stack[run_id] / stack_events_num * N_CAPACITORS_CHANNEL )
 
             self.sampling_interval_coefficient[run_id][:, N_CAPACITORS_CHANNEL:] = (
                 self.sampling_interval_coefficient[run_id][:, :N_SAMPLES] )

--- a/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
+++ b/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
@@ -4,12 +4,12 @@ from numba import jit, prange
 
 from ctapipe.core import Component
 
+from ctapipe_io_lst.constants import (
+    N_PIXELS, N_SAMPLES, N_CAPACITORS_CHANNEL
+)
 
 __all__ = ['SamplingIntervalCalculate']
 
-N_PIXELS = 1855
-N_CAPACITORS_CHANNEL = 1024
-N_SAMPLES = 40
 
 class SamplingIntervalCalculate(Component):
     """
@@ -143,7 +143,7 @@ class SamplingIntervalCalculate(Component):
     def verify(self):
         n_keys=len(self.charge_reso_array_after_corr.keys())
         run_id_array = np.zeros(n_keys, dtype=np.uint16)
-        charge_reso_array_after_corr_all = np.zeros([n_keys, 1855])
+        charge_reso_array_after_corr_all = np.zeros([n_keys, N_PIXELS])
         
         for i, ikey in enumerate(self.charge_reso_array_after_corr.keys()):
             run_id_array[i] = ikey

--- a/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
+++ b/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
@@ -82,7 +82,7 @@ class SamplingIntervalCalculate(Component):
             stack_events_num = np.sum(self.peak_count_stack[run_id], axis=1)
             stack_events_num = stack_events_num.reshape(1, N_PIXELS)
 
-            self.sampling_interval_coefficient[run_id][,:N_CAPACITORS_CHANNEL] = (
+            self.sampling_interval_coefficient[run_id][:,:N_CAPACITORS_CHANNEL] = (
                 self.peak_count_stack[run_id][pixel] / stack_events_num * N_CAPACITORS_CHANNEL )
 
             self.sampling_interval_coefficient[run_id][:, N_CAPACITORS_CHANNEL:] = (

--- a/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
+++ b/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
@@ -1,70 +1,81 @@
 import numpy as np
 from astropy.io import fits
 from numba import jit, prange
+import logging
 
 from ctapipe.core import Component
-
 from ctapipe_io_lst.constants import (
     N_PIXELS, N_SAMPLES, N_CAPACITORS_CHANNEL
 )
+import matplotlib.pyplot as plt
+from ctapipe.instrument import CameraGeometry
+from ctapipe.visualization import CameraDisplay
 
-MAX_EVENTS_FOR_ARRAY = 55000
+logger = logging.getLogger(__name__)
+
 THRESHOLD_PULSE_ADC = 100
 THRESHOLD_PULS_PIX_NUM = 1800
+CHANNEL = ["HG", "LG"]
+CRITERIA = [0.07, 0.05]
 
-__all__ = ['SamplingIntervalCalculate']
+
+__all__ = ['SamplingIntervalCoefficientPeakCount', 'SamplingIntervalCoefficientCalculate']
 
 
-class SamplingIntervalCalculate(Component):
+class SamplingIntervalCoefficientPeakCount(Component):
     """
-        The SamplingIntervalCalculate class to create a sampling interval coefficient table for LST readout system using chip DRS4.
+        The SamplingIntervalCoefficientPeakCount class to create a peak count table for DRS4 sampling interval calibration.
     """
-    def __init__(self):
+    def __init__(self, gain):
+
         self.peak_count = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL], dtype=np.uint16)
         self.fc_count = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL], dtype=np.uint16)
+        self.gain = gain
 
-        self.peak_count_stack ={}
-        self.fc_count_stack = {}
-
-        self.sampling_interval_coefficient = {}
-        self.charge_array_after_corr ={}
-        self.charge_reso_array_after_corr ={}
-
-        self.charge_reso_final = np.zeros(N_PIXELS)
-        self.used_run = np.zeros(N_PIXELS, dtype=np.uint16)
-        self.sampling_interval_coefficient_final = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
-
-    def increment_peak_count(self, event, tel_id, gain, r0_r1_calibrator):
+    def increment_peak_count(self, event, tel_id, r0_r1_calibrator):
 
         waveform = event.r1.tel[tel_id].waveform
         
         first_capacitors = r0_r1_calibrator.first_cap
         r1_sample_start = r0_r1_calibrator.r1_sample_start.tel[tel_id]
 
-        # There are some eventw without test pulses for almost all modules.
+        # There are some events without test pulses for almost all modules.
         # In those events, a few modules have pulse signals of which pulse shapes are not expected...
         # For the moment, such events are just removed in the anlysis
-        pulse_event_flag = np.sum(np.max(waveform[gain], axis=1) > THRESHOLD_PULSE_ADC) > THRESHOLD_PULS_PIX_NUM
+        pulse_event_flag = np.sum(np.max(waveform[self.gain], axis=1) > THRESHOLD_PULSE_ADC) > THRESHOLD_PULS_PIX_NUM
 
         if pulse_event_flag :
             # find pulse peak position
-            pulse_flag = np.max(waveform[gain], axis=1) > THRESHOLD_PULSE_ADC
-            pulse_peak = np.argmax(waveform[gain], axis=1)
-            fc = first_capacitors[tel_id][gain]
+            pulse_flag = np.max(waveform[self.gain], axis=1) > THRESHOLD_PULSE_ADC
+            pulse_peak = np.argmax(waveform[self.gain], axis=1)
+            fc = first_capacitors[tel_id][self.gain]
             pulse_peak_abs_pos = (fc + r1_sample_start + pulse_peak) % N_CAPACITORS_CHANNEL
             
             # increment peak count array in case that test pulses exist in the readout window
             self.peak_count[np.arange(N_PIXELS), pulse_peak_abs_pos] += pulse_flag
             self.fc_count[np.arange(N_PIXELS), fc % N_CAPACITORS_CHANNEL] += pulse_flag
-            
 
-    def stack_single_sampling_interval(self, file_list, gain):
+
+class SamplingIntervalCoefficientCalculate(Component):
+    """
+        The SamplingIntervalCoefficientCalculate class to create a sampling interval coefficient table for LST readout system using chip DRS4.
+    """
+    def __init__(self, gain):
+
+        self.peak_count_stack ={}
+        self.fc_count_stack = {}
+        self.sampling_interval_coefficient = {}
+        self.gain = gain
+            
+    def stack_peak_count_fits(self, file_list):
+        # stack peak count fits files, and sort stacked peak counts by gain, run_id
 
         for single_file in file_list:
 
-            run_id, gain_in_file, peak_count, fc_count = load_single_fits_sampling_interval(single_file)
-            
-            if gain_in_file == gain:
+            run_id, gain_in_file, peak_count, fc_count = load_peak_count_fits_file(single_file)
+
+            # select only a given gain
+            if gain_in_file == self.gain:
                 if not run_id in self.peak_count_stack.keys():
                     self.peak_count_stack[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL], dtype=np.uint16)
                     self.fc_count_stack[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL], dtype=np.uint16)
@@ -72,8 +83,7 @@ class SamplingIntervalCalculate(Component):
                 self.peak_count_stack[run_id] += peak_count
                 self.fc_count_stack[run_id] += fc_count
 
-
-    def convert_to_samp_interval_coefficient(self, gain):
+    def convert_to_samp_interval_coefficient(self):
         # convert peak counts to sampling interval coefficient
 
         for run_id in self.peak_count_stack.keys():
@@ -82,99 +92,186 @@ class SamplingIntervalCalculate(Component):
             stack_events_num = np.sum(self.peak_count_stack[run_id], axis=1)
             stack_events_num = stack_events_num.reshape(1, N_PIXELS).T
 
-            self.sampling_interval_coefficient[run_id][:,:N_CAPACITORS_CHANNEL] = (
-                self.peak_count_stack[run_id] / stack_events_num * N_CAPACITORS_CHANNEL )
-
-            self.sampling_interval_coefficient[run_id][:, N_CAPACITORS_CHANNEL:] = (
-                self.sampling_interval_coefficient[run_id][:, :N_SAMPLES] )
+            self.sampling_interval_coefficient[run_id][:,:N_CAPACITORS_CHANNEL] = self.peak_count_stack[run_id] / stack_events_num * N_CAPACITORS_CHANNEL
+            self.sampling_interval_coefficient[run_id][:,N_CAPACITORS_CHANNEL:] = self.sampling_interval_coefficient[run_id][:, :N_SAMPLES]
                 
+    def set_charge_array(self):
+        # set charge array to compute charge resolutions using calculated coefficients with different observation runs  
 
-                
-    def set_charge_array(self, gain, max_events):
+        # before calibration
+        self.charge_array_before_corr = []
 
-        if max_events == None:
-            max_events = MAX_EVENTS_FOR_ARRAY
-
-        self.charge_array_before_corr = np.zeros([N_PIXELS, max_events])
-        self.charge_reso_array_before_corr = np.zeros(N_PIXELS)
+        # after calibration
+        self.charge_array_after_corr ={}
 
         for run_id in self.peak_count_stack.keys():
-            self.charge_array_after_corr[run_id] = np.zeros([N_PIXELS, max_events])
-            self.charge_reso_array_after_corr[run_id] = np.zeros(N_PIXELS)
+            self.charge_array_after_corr[run_id] = []
             
-
-    def calc_charge(self, count, event, tel_id, gain, r0_r1_calibrator):
+    def calc_charge(self, event, tel_id, r0_r1_calibrator, extractor):
 
         waveform = event.r1.tel[tel_id].waveform
         
-        first_capacitors = r0_r1_calibrator.first_cap
-        r1_sample_start = r0_r1_calibrator.r1_sample_start.tel[tel_id]
-        r1_sample_end = r0_r1_calibrator.r1_sample_end.tel[tel_id]
-
-        # There are some eventw without test pulses for almost all modules.
+        # There are some events without test pulses for almost all modules.
         # In those events, a few modules have pulse signals of which pulse shapes are not expected...
         # For the moment, such events are just removed in the anlysis
-        pulse_event_flag = np.sum(np.max(waveform[gain], axis=1) > THRESHOLD_PULSE_ADC) > THRESHOLD_PULS_PIX_NUM
-
+        pulse_event_flag = np.sum(np.max(waveform[self.gain], axis=1) > THRESHOLD_PULSE_ADC) > THRESHOLD_PULS_PIX_NUM
 
         if pulse_event_flag:
 
+            first_capacitors = r0_r1_calibrator.first_cap
+            r1_sample_start = r0_r1_calibrator.r1_sample_start.tel[tel_id]
+            r1_sample_end = r0_r1_calibrator.r1_sample_end.tel[tel_id]
+
             # find pulse peak position
-            pulse_peak = np.argmax(waveform[gain], axis=1)
-            fc = first_capacitors[tel_id][gain]
-            pulse_peak_abs_pos = (fc + r1_sample_start + pulse_peak) % N_CAPACITORS_CHANNEL
-            integ_start = pulse_peak - 2
-            integ_last = integ_start + 5
+            pulse_peak = np.argmax(waveform[self.gain], axis=1)
+            fc = first_capacitors[tel_id][self.gain]
 
-            integ_abs_start = (pulse_peak_abs_pos -2 ) % N_CAPACITORS_CHANNEL
-            integ_abs_last = integ_abs_start + 5
+            # calculate charge (before calibration)
+            charge, peak_time = extractor(waveform[self.gain], tel_id, np.full(N_PIXELS, self.gain, dtype=int))
+            self.charge_array_before_corr.append(charge.tolist())
 
-            for pixel in range(N_PIXELS):
-
-                # If there are no pulses or signals are not in the expected position (center of the ROI), just skip
-                if integ_start[pixel] < 0 or integ_last[pixel] > (r1_sample_end - r1_sample_start) or np.max(waveform[gain, pixel]) < THRESHOLD_PULSE_ADC:
-                    continue
-
-                self.charge_array_before_corr[pixel][count] = np.sum(waveform[gain, pixel,integ_start[pixel]:integ_last[pixel]])
-
-                for run_id in self.peak_count_stack.keys():
-                    samp_interval_coefficient = self.sampling_interval_coefficient[run_id]
-                    
-                    self.charge_array_after_corr[run_id][pixel][count] = (
-                        np.sum(waveform[gain,pixel,integ_start[pixel]:integ_last[pixel]] 
-                               * samp_interval_coefficient[pixel, integ_abs_start[pixel]:integ_abs_last[pixel]]))
-
-    def calc_charge_reso(self, gain):
-        
-        # Before correction
-        for pixel in range(N_PIXELS):
-            charge_array_before_corr_final = self.charge_array_before_corr[pixel]
-            charge_array_before_corr_final = charge_array_before_corr_final[charge_array_before_corr_final!=0]
-            self.charge_reso_array_before_corr[pixel] = np.std(charge_array_before_corr_final)/np.mean(charge_array_before_corr_final)
-
+            # calculate charge (after calibration with sampling interval coefficients obtained by each observation run)
             for run_id in self.peak_count_stack.keys():
-                charge_array_after_corr_final = self.charge_array_after_corr[run_id][pixel]   
-                charge_array_after_corr_final = charge_array_after_corr_final[charge_array_after_corr_final!=0] 
-                self.charge_reso_array_after_corr[run_id][pixel] = np.std(charge_array_after_corr_final)/np.mean(charge_array_after_corr_final)
+                sampling_interval_coefficient_event = np.zeros([N_PIXELS, r1_sample_end - r1_sample_start])
+
+                for pixel in range(N_PIXELS):
+                    sampling_interval_coefficient_event[pixel] = (
+                        self.sampling_interval_coefficient[run_id][pixel][fc[pixel]%N_CAPACITORS_CHANNEL + r1_sample_start:
+                                                                          fc[pixel]%N_CAPACITORS_CHANNEL + r1_sample_end]
+                    )
+
+                charge, peak_time = extractor(waveform[self.gain] * sampling_interval_coefficient_event, tel_id, np.full(N_PIXELS, self.gain, dtype=int))
+
+                self.charge_array_after_corr[run_id].append(charge.tolist())
+
+    def calc_charge_reso(self):
+        # calculate charge resolution to evaluate the sampling interval correction
+
+        # before correction
+        self.charge_reso_array_before_corr = (
+            np.std(np.array(self.charge_array_before_corr).T, axis=1)/np.mean(np.array(self.charge_array_before_corr).T, axis=1)
+        )
+
+        # after correction
+        self.charge_reso_array_after_corr ={}
+
+        for run_id in self.peak_count_stack.keys():
+            self.charge_reso_array_after_corr[run_id] = (
+                np.std(np.array(self.charge_array_after_corr[run_id]).T, axis=1)/np.mean(np.array(self.charge_array_after_corr[run_id]).T, axis=1)
+            )
 
     def verify(self):
-        n_keys=len(self.charge_reso_array_after_corr.keys())
-        run_id_array = np.zeros(n_keys, dtype=np.uint16)
-        charge_reso_array_after_corr_all = np.zeros([n_keys, N_PIXELS])
+        # verify the obtained sampling interval coefficients
+        # Coefficients which give the best charge resolution are adopted as the final ones
+        # If the charge resolution is worse than required criteria (<7% for high gain, <5% for low gain), coefficients are filled with ones.
+
+        self.charge_reso_final = np.zeros(N_PIXELS)
+        self.used_run = np.zeros(N_PIXELS, dtype=np.uint16)
+        self.sampling_interval_coefficient_final = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
+
+        n_runs = len(self.charge_reso_array_after_corr.keys())
+        run_id_array = np.zeros(n_runs, dtype=np.uint16)
+        charge_reso_array_after_corr_all = np.zeros([n_runs, N_PIXELS])
         
         for i, ikey in enumerate(self.charge_reso_array_after_corr.keys()):
             run_id_array[i] = ikey
             charge_reso_array_after_corr_all[i] = self.charge_reso_array_after_corr[ikey]
     
-        for ipix in range(N_PIXELS):
-            min_charge_reso_arg = np.argmin(charge_reso_array_after_corr_all.T[ipix])
-            self.charge_reso_final[ipix] = charge_reso_array_after_corr_all[min_charge_reso_arg, ipix]
-            self.used_run[ipix] = run_id_array[min_charge_reso_arg]
-            self.sampling_interval_coefficient_final[ipix] = self.sampling_interval_coefficient[self.used_run[ipix]][ipix, :N_CAPACITORS_CHANNEL]
+        for pixel in range(N_PIXELS):
+            min_charge_reso_arg = np.argmin(charge_reso_array_after_corr_all.T[pixel])
 
+            self.charge_reso_final[pixel] = charge_reso_array_after_corr_all[min_charge_reso_arg, pixel]                
+            self.used_run[pixel] = run_id_array[min_charge_reso_arg]
 
+            criteria_flag = self.charge_reso_final[pixel] < CRITERIA[self.gain]
 
-def load_single_fits_sampling_interval(input_file):
+            if criteria_flag:
+                self.sampling_interval_coefficient_final[pixel] = self.sampling_interval_coefficient[self.used_run[pixel]][pixel, :N_CAPACITORS_CHANNEL]
+            else:
+                logger.info(f'[charge resolution] {CHANNEL[self.gain]} pixel {pixel}: {self.charge_reso_final[pixel]} > {CRITERIA[self.gain]}')
+                self.sampling_interval_coefficient_final[pixel] = np.ones(N_CAPACITORS_CHANNEL)
+
+    def plot_results(self, verify_data_path, output_file):
+
+        plt.rcParams['font.size']=15
+        camera = CameraGeometry.from_name('LSTCam-002')
+
+        num_run = len(self.charge_reso_array_after_corr.keys())
+
+        plt.figure(figsize=(20, 6*(num_run+1)))
+        plt.tight_layout()
+        plt.subplots_adjust(top=0.94)
+        plt.suptitle("{} (data for the verification: {})".format(CHANNEL[self.gain], verify_data_path))
+
+        for i, run_id in enumerate(self.charge_reso_array_after_corr.keys()):
+    
+            # charge resolution scatter plot (before correction vs after correction)
+            plt.subplot(num_run + 1, 3, i*3+1)
+            plt.scatter(self.charge_reso_array_before_corr, self.charge_reso_array_after_corr[run_id])
+            plt.plot([0, 0.15], [0, 0.15], color='black', ls='--')
+            plt.hlines(CRITERIA[self.gain], 0, 0.15, color='red', ls='--')
+            plt.xlim(0,.15)
+            plt.ylim(0,.15)
+            plt.title('charge resolution (run {})'.format(run_id))
+            plt.xlabel('before calibration')
+            plt.ylabel('after calibration')
+            plt.grid(color='gray', alpha=0.5)
+            
+            # charge resolution histogram
+            plt.subplot(num_run + 1, 3, i*3+2)
+            plt.hist(self.charge_reso_array_after_corr[run_id], range=[0, 0.1], bins=50)
+            plt.vlines(CRITERIA[self.gain], 0.05, 500, color='red', ls='--')
+            plt.title('charge resolution (after calib.) (run {})'.format(run_id))
+            plt.xlabel('charge resolution')
+            plt.yscale('log')
+            plt.grid(color='gray', alpha=0.5)
+
+            # camera map
+            plt.subplot(num_run + 1, 3, i*3+3)
+            disp = CameraDisplay(camera)
+            disp.image = self.charge_reso_array_after_corr[run_id]
+            
+            plt.grid(color='gray', alpha=0.5)
+            disp.set_limits_minmax(0, CRITERIA[self.gain])
+            disp.highlight_pixels(self.charge_reso_array_after_corr[run_id]>CRITERIA[self.gain], color='red')
+            disp.add_colorbar()
+            
+        # Final result
+        plt.subplot(num_run + 1, 3, num_run*3+1)
+        plt.scatter(self.charge_reso_array_before_corr, self.charge_reso_final)
+        plt.plot([0, 0.15], [0, 0.15], color='black', ls='--')
+        plt.hlines(CRITERIA[self.gain], 0, 0.15, color='red', ls='--')
+        plt.xlim(0,.15)
+        plt.ylim(0,.15)
+        plt.title('charge resolution (Final)'.format(run_id))
+        plt.xlabel('before calibration')
+        plt.ylabel('after calibration')
+        plt.grid(color='gray', alpha=0.5)
+
+        plt.subplot(num_run + 1, 3, num_run*3+2)
+        plt.hist(self.charge_reso_final, range=[0, 0.1], bins=50)
+        plt.vlines(CRITERIA[self.gain], 0.05, 500, color='red', ls='--')
+        plt.title('charge resolution (after calib.) (Final)'.format(run_id))
+        plt.xlabel('charge resolution')
+        plt.yscale('log')
+        plt.grid(color='gray', alpha=0.5)
+        
+        plt.subplot(num_run + 1, 3, num_run*3+3)
+        disp = CameraDisplay(camera)
+        disp.image = self.charge_reso_final
+        
+        plt.grid(color='gray', alpha=0.5)
+        disp.set_limits_minmax(0, CRITERIA[self.gain])
+        disp.highlight_pixels(self.charge_reso_final>CRITERIA[self.gain], color='red')
+        disp.add_colorbar()
+
+        for i, bad_pixel in enumerate(np.where(self.charge_reso_final>CRITERIA[self.gain])[0]):
+            plt.text(-1.2, 1.5-0.2*i, 'pix{}: {:.3f}'.format(bad_pixel, self.charge_reso_final[bad_pixel]), color='red')
+ 
+            
+        plt.savefig(output_file)
+
+def load_peak_count_fits_file(input_file):
         
     hdulist = fits.open(input_file)
         
@@ -184,4 +281,3 @@ def load_single_fits_sampling_interval(input_file):
     fc_count = hdulist[2].data
     
     return run_id, gain, peak_count, fc_count
-

--- a/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
+++ b/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
@@ -79,12 +79,15 @@ class SamplingIntervalCalculate(Component):
         for run_id in self.peak_count_stack.keys():
             self.sampling_interval_coefficient[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL + N_SAMPLES])
 
-            for pixel in range(N_PIXELS):
-                self.sampling_interval_coefficient[run_id][pixel, :N_CAPACITORS_CHANNEL] = \
-                    self.peak_count_stack[run_id][pixel] / np.sum(self.peak_count_stack[run_id][pixel]) * N_CAPACITORS_CHANNEL
+            stack_events_num = np.sum(self.peak_count_stack[run_id], axis=1)
+            stack_events_num = stack_events_num.reshape(1, N_PIXELS)
+
+            self.sampling_interval_coefficient[run_id][,:N_CAPACITORS_CHANNEL] = (
+                self.peak_count_stack[run_id][pixel] / stack_events_num * N_CAPACITORS_CHANNEL )
+
+            self.sampling_interval_coefficient[run_id][:, N_CAPACITORS_CHANNEL:] = (
+                self.sampling_interval_coefficient[run_id][:, :N_SAMPLES] )
                 
-                self.sampling_interval_coefficient[run_id][pixel, N_CAPACITORS_CHANNEL:] = \
-                    self.sampling_interval_coefficient[run_id][pixel, :N_SAMPLES]
 
                 
     def set_charge_array(self, gain, max_events):
@@ -137,9 +140,9 @@ class SamplingIntervalCalculate(Component):
                 for run_id in self.peak_count_stack.keys():
                     samp_interval_coefficient = self.sampling_interval_coefficient[run_id]
                     
-                    self.charge_array_after_corr[run_id][pixel][count] = \
-                        np.sum(waveform[gain,pixel,integ_start[pixel]:integ_last[pixel]] \
-                               * samp_interval_coefficient[pixel, integ_abs_start[pixel]:integ_abs_last[pixel]])
+                    self.charge_array_after_corr[run_id][pixel][count] = (
+                        np.sum(waveform[gain,pixel,integ_start[pixel]:integ_last[pixel]] 
+                               * samp_interval_coefficient[pixel, integ_abs_start[pixel]:integ_abs_last[pixel]]))
 
     def calc_charge_reso(self, gain):
         

--- a/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
+++ b/lstchain/calib/camera/sampling_interval_coefficient_calculate.py
@@ -1,0 +1,170 @@
+import numpy as np
+from astropy.io import fits
+from numba import jit, prange
+
+from ctapipe.core import Component
+
+
+__all__ = ['SamplingIntervalCalculate']
+
+N_PIXELS = 1855
+N_CAPACITORS_CHANNEL = 1024
+N_SAMPLES = 40
+
+class SamplingIntervalCalculate(Component):
+    """
+        The SamplingIntervalCalculate class to create a sampling interval coefficient table for LST readout system using chip DRS4.
+    """
+    def __init__(self):
+        self.peak_count = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
+        self.fc_count = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
+
+        self.peak_count_stuck ={}
+        self.fc_count_stuck = {}
+
+        self.sampling_interval_coefficient = {}
+        self.charge_array_after_corr ={}
+        self.charge_reso_array_after_corr ={}
+
+        self.charge_reso_final = np.zeros(N_PIXELS)
+        self.used_run = np.zeros(N_PIXELS)
+        self.sampling_interval_coefficient_final = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
+
+    def increment_peak_count(self, event, tel_id, gain, r0_r1_calibrator):
+
+        waveform = event.r1.tel[tel_id].waveform
+        
+        first_capacitors = r0_r1_calibrator.first_cap
+        r1_sample_start = r0_r1_calibrator.r1_sample_start.tel[tel_id]
+
+        # Check pulse
+        pulse_event_flag = np.sum(np.max(waveform[gain], axis=1) > 100) > 1800
+    
+        if pulse_event_flag:
+
+            # find pulse peak position
+            pulse_peak = np.argmax(waveform[gain], axis=1)
+            fc = first_capacitors[tel_id][gain]
+            pulse_peak_abs_pos = (fc + r1_sample_start + pulse_peak) % N_CAPACITORS_CHANNEL
+            
+            # increment peak count array
+            self.peak_count[np.arange(N_PIXELS), pulse_peak_abs_pos] += 1
+            self.fc_count[np.arange(N_PIXELS), fc % N_CAPACITORS_CHANNEL] += 1
+            
+
+    def stuck_single_sampling_interval(self, file_list, gain):
+
+        for single_file in file_list:
+
+            run_id, gain_in_file, peak_count, fc_count = load_single_fits_sampling_interval(single_file)
+            
+            if gain_in_file == gain:
+                if not run_id in self.peak_count_stuck.keys():
+                    self.peak_count_stuck[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
+                    self.fc_count_stuck[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL])
+                
+                self.peak_count_stuck[run_id] += peak_count
+                self.fc_count_stuck[run_id] += fc_count
+
+
+    def convert_to_samp_interval_coefficient(self, gain):
+        # convert peak counts to sampling interval coefficient
+
+        for run_id in self.peak_count_stuck.keys():
+            self.sampling_interval_coefficient[run_id] = np.zeros([N_PIXELS, N_CAPACITORS_CHANNEL + N_SAMPLES])
+
+            for pixel in range(N_PIXELS):
+                self.sampling_interval_coefficient[run_id][pixel, :N_CAPACITORS_CHANNEL] = \
+                    self.peak_count_stuck[run_id][pixel] / np.sum(self.peak_count_stuck[run_id][pixel]) * N_CAPACITORS_CHANNEL
+                
+                self.sampling_interval_coefficient[run_id][pixel, N_CAPACITORS_CHANNEL:] = \
+                    self.sampling_interval_coefficient[run_id][pixel, :N_SAMPLES]
+
+                
+    def set_charge_array(self, gain):
+        self.charge_array_before_corr = np.zeros([N_PIXELS, 60000])
+        self.charge_reso_array_before_corr = np.zeros(N_PIXELS)
+
+        for run_id in self.peak_count_stuck.keys():
+            self.charge_array_after_corr[run_id] = np.zeros([N_PIXELS, 60000])
+            self.charge_reso_array_after_corr[run_id] = np.zeros(N_PIXELS)
+            
+
+    def calc_charge(self, count, event, tel_id, gain, r0_r1_calibrator):
+
+        waveform = event.r1.tel[tel_id].waveform
+        
+        first_capacitors = r0_r1_calibrator.first_cap
+        r1_sample_start = r0_r1_calibrator.r1_sample_start.tel[tel_id]
+        r1_sample_end = r0_r1_calibrator.r1_sample_end.tel[tel_id]
+
+        # Check pulse
+        pulse_event_flag = np.sum(np.max(waveform[gain], axis=1) > 100) > 1800
+
+        if pulse_event_flag:
+
+            # find pulse peak position
+            pulse_peak = np.argmax(waveform[gain], axis=1)
+            fc = first_capacitors[tel_id][gain]
+            pulse_peak_abs_pos = (fc + r1_sample_start + pulse_peak) % N_CAPACITORS_CHANNEL
+            integ_start = pulse_peak - 2
+            integ_last = integ_start + 5
+
+            integ_abs_start = (pulse_peak_abs_pos -2 ) % N_CAPACITORS_CHANNEL
+            integ_abs_last = integ_abs_start + 5
+
+            for pixel in range(N_PIXELS):
+
+                if integ_start[pixel] < 0 or integ_last[pixel] > (r1_sample_end - r1_sample_start):
+                    continue
+
+                self.charge_array_before_corr[pixel][count] = np.sum(waveform[gain, pixel,integ_start[pixel]:integ_last[pixel]])
+
+                for run_id in self.peak_count_stuck.keys():
+                    samp_interval_coefficient = self.sampling_interval_coefficient[run_id]
+                    
+                    self.charge_array_after_corr[run_id][pixel][count] = \
+                        np.sum(waveform[gain,pixel,integ_start[pixel]:integ_last[pixel]] \
+                               * samp_interval_coefficient[pixel, integ_abs_start[pixel]:integ_abs_last[pixel]])
+
+    def calc_charge_reso(self, gain):
+        
+        # Before correction
+        for pixel in range(N_PIXELS):
+            charge_array_before_corr_final = self.charge_array_before_corr[pixel]
+            charge_array_before_corr_final = charge_array_before_corr_final[charge_array_before_corr_final!=0]
+            self.charge_reso_array_before_corr[pixel] = np.std(charge_array_before_corr_final)/np.mean(charge_array_before_corr_final)
+
+            for run_id in self.peak_count_stuck.keys():
+                charge_array_after_corr_final = self.charge_array_after_corr[run_id][pixel]   
+                charge_array_after_corr_final = charge_array_after_corr_final[charge_array_after_corr_final!=0] 
+                self.charge_reso_array_after_corr[run_id][pixel] = np.std(charge_array_after_corr_final)/np.mean(charge_array_after_corr_final)
+
+    def verify(self):
+        n_keys=len(self.charge_reso_array_after_corr.keys())
+        run_id_array = np.zeros(n_keys)
+        charge_reso_array_after_corr_all = np.zeros([n_keys, 1855])
+        
+        for i, ikey in enumerate(self.charge_reso_array_after_corr.keys()):
+            run_id_array[i] = ikey
+            charge_reso_array_after_corr_all[i] = self.charge_reso_array_after_corr[ikey]
+    
+        for ipix in range(N_PIXELS):
+            min_charge_reso_arg = np.argmin(charge_reso_array_after_corr_all.T[ipix])
+            self.charge_reso_final[ipix] = charge_reso_array_after_corr_all[min_charge_reso_arg, ipix]
+            self.used_run[ipix] = int(run_id_array[min_charge_reso_arg])
+            self.sampling_interval_coefficient_final[ipix] = self.sampling_interval_coefficient[self.used_run[ipix]][ipix, :N_CAPACITORS_CHANNEL]
+
+
+
+def load_single_fits_sampling_interval(input_file):
+        
+    hdulist = fits.open(input_file)
+        
+    run_id = hdulist[0].header['run_id']
+    gain = hdulist[0].header['gain']
+    peak_count = hdulist[1].data
+    fc_count = hdulist[2].data
+    
+    return run_id, gain, peak_count, fc_count
+

--- a/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
+++ b/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
@@ -152,7 +152,7 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
                 continue
 
             #first_capacitor = self.eventsource.r0_r1_calibrator.first_cap
-            self.sampling_interval_calculate.increment_peak_count(event, tel_id = self.eventsource.tel_id, \
+            self.sampling_interval_calculate.increment_peak_count(event, tel_id = self.eventsource.tel_id, 
                                                                   gain = self.gain, r0_r1_calibrator = self.eventsource.r0_r1_calibrator)
 
     def start_stack_verify(self):
@@ -171,7 +171,7 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
             if i < 1000:
                 continue
 
-            self.sampling_interval_calculate.calc_charge(i, event, tel_id = self.eventsource.tel_id, \
+            self.sampling_interval_calculate.calc_charge(i, event, tel_id = self.eventsource.tel_id, 
                                                          gain = self.gain, r0_r1_calibrator = self.eventsource.r0_r1_calibrator)
 
         self.log.debug('calculate charge resolution using the sampling coefficients')

--- a/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
+++ b/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
@@ -1,6 +1,7 @@
 import numpy as np
 from astropy.io import fits
 import h5py
+from tqdm import tqdm
 
 from ctapipe.core import Provenance, traits
 from ctapipe.core import Tool

--- a/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
+++ b/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
@@ -1,0 +1,248 @@
+import numpy as np
+from astropy.io import fits
+import h5py
+
+from ctapipe.core import Provenance, traits
+from ctapipe.core import Tool
+from ctapipe_io_lst import LSTEventSource
+from ctapipe_io_lst.calibration import LSTR0Corrections
+from lstchain.calib.camera.sampling_interval_coefficient_calculate import SamplingIntervalCalculate
+from lstchain.paths import run_info_from_filename
+
+class SamplingIntervalCoefficientHDFWriter(Tool):
+    """
+    Tool that generates a sampling interval coefficient hdf file.
+    For getting help run:
+    lstchain_create_sampling_interval_coefficient_file --help
+    """
+
+    name = "SamplingIntervalCoefficientHDFWriter"
+    description = "Generate a sampling interval coefficient table"
+
+    input_fits = traits.Path(
+        help="Path to the generated peak count fits files",
+        directory_ok=True,
+    ).tag(config=True)
+
+    input_fits_hg = traits.Path(
+        help="Path to the generated fits sampling interval coefficient file for high gain",
+        directory_ok=False,
+    ).tag(config=True)
+
+    input_fits_lg = traits.Path(
+        help="Path to the generated fits sampling interval coefficient file for low gain",
+        directory_ok=False,
+    ).tag(config=True)
+
+    output = traits.Path(
+        help="Path to the output fits file",
+        directory_ok=False,
+    ).tag(config=True)
+
+    glob = traits.Unicode(
+        help="Filename pattern to glob files in the directory",
+        default_value="*.fits"
+    ).tag(config=True)
+
+    gain = traits.Int(
+        help="Select gain channel (0: High Gain, 1: Low Gain)",
+    ).tag(config=True)
+
+    count_flag = traits.Bool(
+        default_value=False,
+        help="First step: count peak on each capacitor"
+    ).tag(config=True)
+
+    stuck_verify_flag = traits.Bool(
+        default_value=False,
+        help="Second step: merge peak count files and verify with charge resolution"
+    ).tag(config=True)
+
+    merge_flag = traits.Bool(
+        default_value=False,
+        help="Third step: Merge sampling coefficient fits files for both gains."
+    ).tag(config=True)
+
+    progress_bar = traits.Bool(
+        help="show progress bar during processing",
+        default_value=True,
+    ).tag(config=True)
+
+    aliases = {
+        ("i", "input"): "EventSource.input_url",
+        ("o", "output"): "SamplingIntervalCoefficientHDFWriter.output",
+        ("g", "gain"): "SamplingIntervalCoefficientHDFWriter.gain",
+        "input_fits": "SamplingIntervalCoefficientHDFWriter.input_fits",
+        "input_fits_hg": "SamplingIntervalCoefficientHDFWriter.input_fits_hg",
+        "input_fits_lg": "SamplingIntervalCoefficientHDFWriter.input_fits_lg",
+        "pedestal": "LSTR0Corrections.drs4_pedestal_path",        
+        "max-events": "EventSource.max_events",
+        "r1_sample_start": "LSTR0Corrections.r1_sample_start",
+        "r1_sample_end": "LSTR0Corrections.r1_sample_end",
+    }
+
+    classes = [LSTEventSource, LSTR0Corrections, SamplingIntervalCalculate]
+
+    flags = {
+        'count_flag': (
+            {'SamplingIntervalCoefficientHDFWriter': {'count_flag': True}},
+            'First step: count peak on each capacitor',
+        ),
+        'stuck_verify_flag': (
+            {'SamplingIntervalCoefficientHDFWriter': {'stuck_verify_flag': True}},
+            'Second step: merge peak count files and verify with charge resolution',
+        ),
+        'merge_flag': (
+            {'SamplingIntervalCoefficientHDFWriter': {'merge_flag': True}},
+            'Third step: Merge sampling coefficient fits files for both gains',
+        )
+    }
+
+    def setup(self):
+        
+        self.sampling_interval_calculate = SamplingIntervalCalculate()
+
+        if self.count_flag:
+            self.setup_count()
+    
+        if self.stuck_verify_flag:
+            self.setup_stuck_verify()
+
+        if self.merge_flag:
+            self.setup_merge()
+
+
+    def setup_count(self):
+        self.log.debug('First step: count peak on each capacitor')
+        self.eventsource = LSTEventSource(parent = self)
+        self.run_id = self.eventsource.obs_ids[0]
+
+    def setup_stuck_verify(self):
+        self.log.debug('Second step: stuck and verify with charge resolution')
+        self.path_list = [str(self.input_fits)]
+        if self.input_fits.is_dir():
+            self.path_list = sorted(self.input_fits.glob(self.glob))
+        self.eventsource = LSTEventSource(parent=self)
+
+    def setup_merge(self):
+        self.log.debug('Third step: Merge sampling coefficients')
+
+
+
+    def start(self):
+        
+        if self.count_flag:
+            self.start_count()
+
+        if self.stuck_verify_flag:
+            self.start_stuck_verify()
+
+        if self.merge_flag:
+            self.start_merge()
+
+    def start_count(self):
+        self.log.debug('start peak counting')
+
+        for i, event in enumerate(self.eventsource):
+            if event.index.event_id % 500 == 0:
+                self.log.debug(f'event id = {event.index.event_id}')
+
+            # skip the first 1000 events which would not be calibrated correctly
+            if i < 1000:
+                continue
+
+            #first_capacitor = self.eventsource.r0_r1_calibrator.first_cap
+            self.sampling_interval_calculate.increment_peak_count(event, tel_id = self.eventsource.tel_id, \
+                                                                  gain = self.gain, r0_r1_calibrator = self.eventsource.r0_r1_calibrator)
+
+    def start_stuck_verify(self):
+        self.log.debug('stuck peak count tables')
+        self.sampling_interval_calculate.stuck_single_sampling_interval(self.path_list, self.gain)
+
+        self.log.debug('convert peak counts into sampling interval coefficients') 
+        self.sampling_interval_calculate.convert_to_samp_interval_coefficient(gain = self.gain)
+        self.sampling_interval_calculate.set_charge_array(gain = self.gain)
+
+        for i, event in enumerate(self.eventsource):
+            if event.index.event_id % 500 == 0:
+                self.log.debug(f'event id = {event.index.event_id}')
+
+            # skip the first 1000 events which would not be calibrated correctly
+            if i < 1000:
+                continue
+
+            #first_capacitor = self.eventsource.r0_r1_calibrator.first_cap
+            self.sampling_interval_calculate.calc_charge(i, event, tel_id = self.eventsource.tel_id, \
+                                                         gain = self.gain, r0_r1_calibrator = self.eventsource.r0_r1_calibrator)
+
+        self.log.debug('calculate charge resolution using the sampling coefficients')
+        self.sampling_interval_calculate.calc_charge_reso(gain = self.gain)
+        self.sampling_interval_calculate.verify()
+        
+
+    def start_merge(self):
+        # High Gain
+        hdulist = fits.open(self.input_fits_hg)
+        hdu = hdulist[0]
+        self.sampling_interval_coefficient_hg = hdulist[1].data
+        self.used_run_hg = hdulist[2].data
+        self.charge_reso_hg = hdulist[3].data
+
+        # Low Gain
+        hdulist = fits.open(self.input_fits_lg)
+        hdu = hdulist[0]
+        self.sampling_interval_coefficient_lg = hdulist[1].data
+        self.used_run_lg = hdulist[2].data
+        self.charge_reso_lg = hdulist[3].data
+        
+        self.sampling_interval_coefficient_merge = np.array([self.sampling_interval_coefficient_hg, self.sampling_interval_coefficient_lg])
+        self.used_run_merge = np.array([self.used_run_hg, self.used_run_lg])
+        self.charge_reso_merge = np.array([self.charge_reso_hg, self.charge_reso_lg])
+        
+
+    def finish(self):
+        
+        if self.count_flag:
+            self.finish_count()
+        
+        if self.stuck_verify_flag:
+            self.finish_stuck_verify()
+
+        if self.merge_flag:
+            self.finish_merge()
+            
+    def finish_count(self):
+        hdu_peak = fits.ImageHDU(self.sampling_interval_calculate.peak_count)
+        hdu_fc = fits.ImageHDU(self.sampling_interval_calculate.fc_count)
+        hdr = fits.Header()
+        hdr['run_id'] = self.run_id
+        hdr['gain'] = self.gain
+        primary_hdu = fits.PrimaryHDU(header=hdr)
+        hdul = fits.HDUList([primary_hdu, hdu_peak, hdu_fc])
+        hdul.writeto(self.output)
+
+    def finish_stuck_verify(self):
+        hdu_sampling_interval_coefficient = fits.ImageHDU(self.sampling_interval_calculate.sampling_interval_coefficient_final)
+        hdu_used_run = fits.ImageHDU(self.sampling_interval_calculate.used_run)
+        hdu_charge_reso_final = fits.ImageHDU(self.sampling_interval_calculate.charge_reso_final)
+
+        hdr = fits.Header()
+        hdr['gain'] = self.gain
+        primary_hdu = fits.PrimaryHDU(header=hdr)
+        hdul = fits.HDUList([primary_hdu, hdu_sampling_interval_coefficient, hdu_used_run, hdu_charge_reso_final])
+        hdul.writeto(self.output)
+
+    def finish_merge(self):
+
+        with h5py.File(self.output, 'w') as hf:
+            hf.create_dataset('sampling_interval_coefficient', data = self.sampling_interval_coefficient_merge)
+            hf.create_dataset('used_run', data = self.used_run_merge)
+            hf.create_dataset('charge_reso', data = self.charge_reso_merge)
+
+def main():
+    exe = SamplingIntervalCoefficientHDFWriter()
+    exe.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
+++ b/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
@@ -161,7 +161,7 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
 
         self.log.debug('convert peak counts into sampling interval coefficients') 
         self.sampling_interval_calculate.convert_to_samp_interval_coefficient(gain = self.gain)
-        self.sampling_interval_calculate.set_charge_array(gain = self.gain)
+        self.sampling_interval_calculate.set_charge_array(gain = self.gain, self.eventsource.max_events)
 
         for i, event in enumerate(self.eventsource):
             if event.index.event_id % 500 == 0:

--- a/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
+++ b/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
@@ -143,7 +143,14 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
     def start_count(self):
         self.log.debug('start peak counting')
 
-        for i, event in enumerate(self.eventsource):
+        for i, event in enumerate(tqdm(
+                self.eventsource,
+                desc = self.eventsource.__class__.__name__,
+                total = self.eventsource.max_events,
+                unit = "event",
+                disable = not self.progress_bar,
+        )):
+
             if event.index.event_id % 500 == 0:
                 self.log.debug(f'event id = {event.index.event_id}')
 
@@ -161,9 +168,16 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
 
         self.log.debug('convert peak counts into sampling interval coefficients') 
         self.sampling_interval_calculate.convert_to_samp_interval_coefficient(gain = self.gain)
-        self.sampling_interval_calculate.set_charge_array(gain = self.gain, self.eventsource.max_events)
+        self.sampling_interval_calculate.set_charge_array(gain = self.gain, max_events = self.eventsource.max_events)
 
-        for i, event in enumerate(self.eventsource):
+        for i, event in enumerate(tqdm(
+                self.eventsource,
+                desc = self.eventsource.__class__.__name__,
+                total = self.eventsource.max_events,
+                unit = "event",
+                disable = not self.progress_bar,
+        )):
+
             if event.index.event_id % 500 == 0:
                 self.log.debug(f'event id = {event.index.event_id}')
 

--- a/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
+++ b/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
@@ -53,9 +53,9 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
         help="First step: count peak on each capacitor"
     ).tag(config=True)
 
-    stuck_verify_flag = traits.Bool(
+    stack_verify_flag = traits.Bool(
         default_value=False,
-        help="Second step: merge peak count files and verify with charge resolution"
+        help="Second step: Stack peak count files and verify with charge resolution"
     ).tag(config=True)
 
     merge_flag = traits.Bool(
@@ -88,8 +88,8 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
             {'SamplingIntervalCoefficientHDFWriter': {'count_flag': True}},
             'First step: count peak on each capacitor',
         ),
-        'stuck_verify_flag': (
-            {'SamplingIntervalCoefficientHDFWriter': {'stuck_verify_flag': True}},
+        'stack_verify_flag': (
+            {'SamplingIntervalCoefficientHDFWriter': {'stack_verify_flag': True}},
             'Second step: merge peak count files and verify with charge resolution',
         ),
         'merge_flag': (
@@ -105,8 +105,8 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
         if self.count_flag:
             self.setup_count()
     
-        if self.stuck_verify_flag:
-            self.setup_stuck_verify()
+        if self.stack_verify_flag:
+            self.setup_stack_verify()
 
         if self.merge_flag:
             self.setup_merge()
@@ -117,8 +117,8 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
         self.eventsource = LSTEventSource(parent = self)
         self.run_id = self.eventsource.obs_ids[0]
 
-    def setup_stuck_verify(self):
-        self.log.debug('Second step: stuck and verify with charge resolution')
+    def setup_stack_verify(self):
+        self.log.debug('Second step: stack and verify with charge resolution')
         self.path_list = [str(self.input_fits)]
         if self.input_fits.is_dir():
             self.path_list = sorted(self.input_fits.glob(self.glob))
@@ -134,8 +134,8 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
         if self.count_flag:
             self.start_count()
 
-        if self.stuck_verify_flag:
-            self.start_stuck_verify()
+        if self.stack_verify_flag:
+            self.start_stack_verify()
 
         if self.merge_flag:
             self.start_merge()
@@ -155,9 +155,9 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
             self.sampling_interval_calculate.increment_peak_count(event, tel_id = self.eventsource.tel_id, \
                                                                   gain = self.gain, r0_r1_calibrator = self.eventsource.r0_r1_calibrator)
 
-    def start_stuck_verify(self):
-        self.log.debug('stuck peak count tables')
-        self.sampling_interval_calculate.stuck_single_sampling_interval(self.path_list, self.gain)
+    def start_stack_verify(self):
+        self.log.debug('stack peak count tables')
+        self.sampling_interval_calculate.stack_single_sampling_interval(self.path_list, self.gain)
 
         self.log.debug('convert peak counts into sampling interval coefficients') 
         self.sampling_interval_calculate.convert_to_samp_interval_coefficient(gain = self.gain)
@@ -205,8 +205,8 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
         if self.count_flag:
             self.finish_count()
         
-        if self.stuck_verify_flag:
-            self.finish_stuck_verify()
+        if self.stack_verify_flag:
+            self.finish_stack_verify()
 
         if self.merge_flag:
             self.finish_merge()
@@ -221,7 +221,7 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
         hdul = fits.HDUList([primary_hdu, hdu_peak, hdu_fc])
         hdul.writeto(self.output)
 
-    def finish_stuck_verify(self):
+    def finish_stack_verify(self):
         hdu_sampling_interval_coefficient = fits.ImageHDU(self.sampling_interval_calculate.sampling_interval_coefficient_final)
         hdu_used_run = fits.ImageHDU(self.sampling_interval_calculate.used_run)
         hdu_charge_reso_final = fits.ImageHDU(self.sampling_interval_calculate.charge_reso_final)

--- a/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
+++ b/lstchain/tools/lstchain_create_sampling_interval_coefficient_file.py
@@ -171,7 +171,6 @@ class SamplingIntervalCoefficientHDFWriter(Tool):
             if i < 1000:
                 continue
 
-            #first_capacitor = self.eventsource.r0_r1_calibrator.first_cap
             self.sampling_interval_calculate.calc_charge(i, event, tel_id = self.eventsource.tel_id, \
                                                          gain = self.gain, r0_r1_calibrator = self.eventsource.r0_r1_calibrator)
 


### PR DESCRIPTION
This PR is a continuation of #255.
I added a new tool and class to create sampling interval coefficients tables, which is used for `TimeSamplingCorrection`.

This tool has three stages:
- count pulse peak on each capacitor
  -   we usually use 1 million events, so better to submit a subrun-wise job to save time. It seems some modules have some problems with this method (almost synchronization between test pulse and the first capacitor id), but this trouble appears randomly for all of the modules. So we take 2-3 runs for a single gain to generate sampling interval coefficients. 

- stack single fits file, convert into sampling interval coefficients, calculate charge resolution with new coefficients for the verification
  - stack multiple fits files generated by subrun-wise jobs and convert the stucked peak counts into sampling interval coefficients for each run. Then,  charge resolutions are calculated with new coefficients for the verification. If a given module has trouble in a specific run, charge resolution would be not good than expected. So the final coefficient values would be what achieved the best resolutions. The final coefficients and used run for the generation of coefficients on each module are saved for each gain.

-  merge coefficients of both gains into a single HDF table
   - merge output files of the previous stage for each gain. The generated HDF file should be compatible with `TimeSamplingCorrection` already implemented in lstchain.
  https://github.com/cta-observatory/cta-lstchain/blob/master/lstchain/calib/camera/time_sampling_correction.py#L14