### PR TITLE
Remove source-dependent parameters from a data frame of dl2_params_lstcam_key

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -568,7 +568,7 @@ def get_expected_source_pos(data, data_type, config, focal_length=28*u.m):
             expected_src_pos_y_m = np.zeros(len(data))
         
         # compute source position in camera coordinate event by event for wobble mode
-        if config.get('observation_mode') == 'wobble':
+        elif config.get('observation_mode') == 'wobble':
 
             if 'source_name' in config:
                 source_coord = SkyCoord.from_name(config.get('source_name'))
@@ -584,4 +584,7 @@ def get_expected_source_pos(data, data_type, config, focal_length=28*u.m):
             expected_src_pos_x_m = source_pos.x.to_value(u.m)
             expected_src_pos_y_m = source_pos.y.to_value(u.m)
    
+        else:
+            raise NameError("observation_mode is not defined in a config file. The observation mode should be on or wobble.")
+
     return expected_src_pos_x_m, expected_src_pos_y_m 

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -125,6 +125,8 @@ def main():
 
         dl2_srcdep_dict = {}
 
+        srcindep_keys = data.keys()
+
         for i, k in enumerate(data_srcdep.columns.levels[0]):
             data_with_srcdep_param = pd.concat([data, data_srcdep[k]], axis=1)
             data_with_srcdep_param = filter_events(data_with_srcdep_param,
@@ -139,7 +141,7 @@ def main():
             dl2_srcdep_dict[k] = dl2_srcdep
 
             if i == 0:
-                dl2_srcindep = dl2_df.drop(data_srcdep[k].keys(), axis=1)
+                dl2_srcindep = dl2_df[srcindep_keys]
 
     os.makedirs(args.output_dir, exist_ok=True)
     output_file = os.path.join(args.output_dir, os.path.basename(args.input_file).replace('dl1', 'dl2'))


### PR DESCRIPTION
This PR is to fix a small bug in source-dependent analysis to generate dl2 data.
Source-dependent parameters should be saved in `dl2_params_src_dep_lstcam_key`, and other standard parameters should be in `dl2_params_lstcam_key`.
However, it seems some dl2 source-dependent parameters are still in `dl2_params_lstcam_key` because only dl1 source-dependent parameters are dropped...
In this PR, all of the source-dependent parameters should be dropped in a standard dl2 data frame.

I also modified the codes to raise an error if `observation_mode` is not defined mentioned as #677 