### PR TITLE
Sort events by timestamp before calculating effective observation time

### DIFF
--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -716,6 +716,9 @@ def get_effective_time(events):
     t_eff: astropy Quantity (in seconds, if input has no units)
     t_elapsed: astropy Quantity (ditto)
     """
+    # Sorting events by timestamps so the input list of events does not have 
+    # to be ordered, for example when dealing with runs from different days. 
+    events = events.sort_values(by="dragon_time")
     timestamp = np.array(events["dragon_time"])
     delta_t = np.array(events["delta_t"])
 

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -719,11 +719,7 @@ def get_effective_time(events):
     """
     # Sorting events by timestamps so the input list of events does not have 
     # to be ordered, for example when dealing with runs from different days. 
-    if isinstance(events, pd.DataFrame):
-        events = events.sort_values("dragon_time")
-    elif isinstance(events, QTable):
-        events.sort("dragon_time")
-    timestamp = np.array(events["dragon_time"])
+    timestamp = np.sort(np.array(events["dragon_time"]))
     delta_t = np.array(events["delta_t"])
 
     if not isinstance(timestamp, u.Quantity):

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -20,6 +20,7 @@ import pandas as pd
 from astropy.coordinates import AltAz, SkyCoord, EarthLocation
 from astropy.time import Time
 from astropy.utils import deprecated
+from astropy.table import QTable
 from ctapipe.coordinates import CameraFrame
 
 from . import disp
@@ -718,7 +719,10 @@ def get_effective_time(events):
     """
     # Sorting events by timestamps so the input list of events does not have 
     # to be ordered, for example when dealing with runs from different days. 
-    events = events.sort_values(by="dragon_time")
+    if isinstance(events, pd.DataFrame):
+        events = events.sort_values("dragon_time")
+    elif isinstance(events, QTable):
+        events.sort("dragon_time")
     timestamp = np.array(events["dragon_time"])
     delta_t = np.array(events["delta_t"])
 


### PR DESCRIPTION
I tried to calculate the effective and elapsed time from runs taken on different days. It happened that I did not sort the input events beforehand so I was getting nonsensical negative results.

The easiest solution would be to order first the events according to their timestamp then do the rest of the calculations as before.