### PR TITLE
Add correction of the systematic term to the F-factor method

### DIFF
--- a/lstchain/calib/camera/calibration_calculator.py
+++ b/lstchain/calib/camera/calibration_calculator.py
@@ -111,6 +111,7 @@ class CalibrationCalculator(Component):
         self.tel_id = self.flatfield.tel_id
 
         # load systematic correction term B
+        self.quadratic_term = None
         if self.systematic_correction_path is not None:
             try:
                 with h5py.File(self.systematic_correction_path, 'r') as hf:
@@ -173,6 +174,7 @@ class LSTCalibrationCalculator(CalibrationCalculator):
         denominator = gain
 
         n_pe = np.divide(numerator, denominator, out=np.zeros_like(numerator), where=denominator != 0)
+
         # fill WaveformCalibrationContainer
         calib_data.time = ff_data.sample_time
         calib_data.time_min = ff_data.sample_time_min
@@ -183,10 +185,8 @@ class LSTCalibrationCalculator(CalibrationCalculator):
         masked_npe = np.ma.array(n_pe, mask=calib_data.unusable_pixels)
         npe_signal_median = np.ma.median(masked_npe, axis=1)
 
-        # calibration coefficients
+        # flat-fielded calibration coefficients
         numerator = npe_signal_median[:,np.newaxis]
-
-        # signal
         denominator = (ff_data.charge_median - ped_data.charge_median)
         calib_data.dc_to_pe = np.divide(numerator, denominator, out=np.zeros_like(denominator), where=denominator != 0)
 

--- a/lstchain/calib/camera/calibration_calculator.py
+++ b/lstchain/calib/camera/calibration_calculator.py
@@ -163,7 +163,7 @@ class LSTCalibrationCalculator(CalibrationCalculator):
         gain = np.divide(numerator, denominator, out=np.zeros_like(numerator), where=denominator != 0)
 
         # correct for the quadratic term if possible
-        if self.quadratic_term is not  None:
+        if self.quadratic_term is not None:
             numerator = self.quadratic_term**2  * (ff_data.charge_median - ped_data.charge_median)
             denominator = self.squared_excess_noise_factor
             systematic_correction = np.divide(numerator, denominator, out=np.zeros_like(numerator), where=denominator != 0)

--- a/lstchain/calib/camera/time_sampling_correction.py
+++ b/lstchain/calib/camera/time_sampling_correction.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 from ctapipe.core import Component
-from ctapipe.core.traits import Unicode
+from ctapipe.core.traits import Path
 
 __all__ = [
     'TimeSamplingCorrection',
@@ -17,12 +17,10 @@ class TimeSamplingCorrection(Component):
         using Fourier series expansion.
     """
 
-    time_sampling_correction_path = Unicode(
-        '',
-        help='Path to the waveform sampling correction file',
-        allow_none = True,
+    time_sampling_correction_path = Path(
+        exists=True, directory_ok=False,
+        help='Path to time sampling correction file'
     ).tag(config=True)
-
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/lstchain/scripts/onsite/onsite_create_calibration_file.py
+++ b/lstchain/scripts/onsite/onsite_create_calibration_file.py
@@ -112,7 +112,7 @@ def main():
             # otherwise perform a link to the default time calibration file
             print(f"\n--> PRODUCING LINK TO DEFAULT TIME CALIBRATION (run {default_time_run})")
             file_list = sorted(
-                Path(f"{base_dir}/calibration/").rglob(f'*/{prod_id}/time_calibration.Run{default_time_run}*'))
+                Path(f"{base_dir}/calibration/").rglob(f'*/{prod_id}/time_calibration.Run*{default_time_run}*'))
 
             if len(file_list) == 0:
                 raise IOError(f"Time calibration file for run {default_time_run} not found\n")

--- a/lstchain/scripts/onsite/onsite_create_calibration_file.py
+++ b/lstchain/scripts/onsite/onsite_create_calibration_file.py
@@ -31,10 +31,13 @@ optional.add_argument('-s', '--statistics', help="Number of events for the flat-
 optional.add_argument('-b','--base_dir', help="Root dir for the output directory tree",type=str, default='/fefs/aswg/data/real')
 optional.add_argument('--default_time_run', help="If 0 time calibration is calculated otherwise create a link to the give run time calibration",type=int, default='1625')
 optional.add_argument('--ff_calibration', help="Perform the charge calibration (yes/no)",type=str, default='yes')
-optional.add_argument('--tel_id', help="telescope id. Default = 1", type=int, default=1)
-optional.add_argument('--sub_run', help="sub-run to be processed. Default = 0", type=int, default=0)
-optional.add_argument('--min_ff', help="Min FF intensity cut in ADC. Default = 4000", type=float, default=4000)
-optional.add_argument('--max_ff', help="Max FF intensity cut in ADC. Default = 12000", type=float, default=12000)
+optional.add_argument('--tel_id', help="telescope id.", type=int, default=1)
+optional.add_argument('--sub_run', help="sub-run to be processed.", type=int, default=0)
+optional.add_argument('--min_ff', help="Min FF intensity cut in ADC.", type=float, default=4000)
+optional.add_argument('--max_ff', help="Max FF intensity cut in ADC.", type=float, default=12000)
+default_config=os.path.join(os.path.dirname(__file__), "../../data/onsite_camera_calibration_param.json")
+optional.add_argument('--config', help="Config file", default=default_config)
+
 
 args = parser.parse_args()
 run = args.run_number
@@ -48,6 +51,9 @@ tel_id = args.tel_id
 min_ff = args.min_ff
 max_ff = args.max_ff
 sub_run = args.sub_run
+config_file = args.config
+if config_file is None:
+    config_file = os.path.join(os.path.dirname(__file__), "../../data/onsite_camera_calibration_param.json")
 
 max_events = 1000000
 
@@ -56,6 +62,12 @@ def main():
     print(f"\n--> Start calculating calibration from run {run}")
 
     try:
+        # verify config file
+        if not os.path.exists(config_file):
+            raise IOError(f"Config file {config_file} does not exists. \n")
+
+        print(f"\n--> Config file {config_file}")
+
         # verify input file
         file_list=sorted(Path(f"{base_dir}/R0").rglob(f'*{run}.{sub_run:04d}*'))
         if len(file_list) == 0:
@@ -82,13 +94,6 @@ def main():
         run_summary_path = f"{base_dir}/monitoring/RunSummary/RunSummary_{date}.ecsv"
         if not os.path.exists(run_summary_path):
             raise IOError(f"Night summary file {run_summary_path} does not exist\n")
-
-        # define config file
-        config_file = os.path.join(os.path.dirname(__file__), "../../data/onsite_camera_calibration_param.json")
-        if not os.path.exists(config_file):
-            raise IOError(f"Config file {config_file} does not exists. \n")
-
-        print(f"\n--> Config file {config_file}")
 
         #
         # produce drs4 time calibration file

--- a/lstchain/visualization/plot_calib.py
+++ b/lstchain/visualization/plot_calib.py
@@ -274,16 +274,18 @@ def plot_all(ped_data, ff_data, calib_data, run=0, plot_file=None):
                 # median_ped = ped_data.charge_median[chan]
                 mean_ped = ped_data.charge_mean[chan]
                 ped_std = ped_data.charge_std[chan]
+                dc_to_pe = calib_data.dc_to_pe[chan]
+                time_correction = calib_data.time_correction[chan]
 
                 # select good pixels
                 select = np.logical_not(mask[chan])
-                fig = plt.figure(chan + 10, figsize=(12, 18))
+                fig = plt.figure(chan + 10, figsize=(15, 24))
                 fig.tight_layout(rect=[0, 0.0, 1, 0.95])
 
                 fig.suptitle(f"Run {run} channel: {channel[chan]}", fontsize=25)
 
                 # charge
-                plt.subplot(321)
+                plt.subplot(421)
                 plt.tight_layout()
                 median = int(np.median(charge_mean[select]))
                 rms = np.std(charge_mean[select])
@@ -293,7 +295,7 @@ def plot_all(ped_data, ff_data, calib_data, run=0, plot_file=None):
                 plt.hist(charge_mean[select], bins=50, label=label)
                 plt.legend()
 
-                plt.subplot(322)
+                plt.subplot(422)
                 plt.tight_layout()
                 plt.ylabel("pixels", fontsize=20)
                 plt.xlabel("charge std", fontsize=20)
@@ -304,7 +306,7 @@ def plot_all(ped_data, ff_data, calib_data, run=0, plot_file=None):
                 plt.legend()
 
                 # pedestal charge
-                plt.subplot(323)
+                plt.subplot(423)
                 plt.tight_layout()
                 plt.ylabel("pixels", fontsize=20)
                 plt.xlabel("pedestal", fontsize=20)
@@ -315,7 +317,7 @@ def plot_all(ped_data, ff_data, calib_data, run=0, plot_file=None):
                 plt.legend()
 
                 # pedestal std
-                plt.subplot(324)
+                plt.subplot(424)
                 plt.ylabel("pixels", fontsize=20)
                 plt.xlabel("pedestal std", fontsize=20)
                 median = np.median(ped_std[select])
@@ -325,7 +327,7 @@ def plot_all(ped_data, ff_data, calib_data, run=0, plot_file=None):
                 plt.legend()
 
                 # relative gain
-                plt.subplot(325)
+                plt.subplot(425)
                 plt.tight_layout()
                 plt.ylabel("pixels", fontsize=20)
                 plt.xlabel("relative signal", fontsize=20)
@@ -336,7 +338,19 @@ def plot_all(ped_data, ff_data, calib_data, run=0, plot_file=None):
                 plt.legend()
 
                 # photon electrons
-                plt.subplot(326)
+                plt.subplot(426)
+                plt.tight_layout()
+                plt.ylabel("pixels", fontsize=20)
+                plt.xlabel("time corrections [ns]", fontsize=20)
+                median = np.median(time_correction[select])
+                rms = np.std(time_correction[select])
+                label = f"Median {median:3.2f}, std {rms:3.2f}"
+                plt.hist(time_correction[select].value, bins=50, label=label)
+                plt.legend()
+
+                plt.subplots_adjust(top=0.92)
+                # photon electrons
+                plt.subplot(427)
                 plt.tight_layout()
                 plt.ylabel("pixels", fontsize=20)
                 plt.xlabel("pe", fontsize=20)
@@ -346,6 +360,23 @@ def plot_all(ped_data, ff_data, calib_data, run=0, plot_file=None):
                 plt.hist(n_pe[select], bins=50, label=label)
                 plt.legend()
                 plt.subplots_adjust(top=0.92)
+
+                # gain
+                plt.subplot(428)
+                plt.tight_layout()
+                plt.ylabel("pixels", fontsize=20)
+                plt.xlabel("flat-fielded gain [ADC/pe]", fontsize=20)
+                denominator = dc_to_pe[select]
+                numerator = 1.
+
+                gain = np.divide(numerator, denominator, out=np.zeros_like(denominator), where=denominator != 0)
+                median = np.median(gain)
+                rms = np.std(gain)
+                label = f"Median {median:3.2f}, std {rms:3.2f}"
+                plt.hist(gain, bins=50, label=label)
+                plt.legend()
+                plt.subplots_adjust(top=0.92)
+
 
                 pdf.savefig(plt.gcf())
                 plt.close()


### PR DESCRIPTION
This PR adds:
- the possibility to correct the the F-factor method for the quadratic component if the correction file is given (by default not given for the moment)
- a trailet to the calibration script to allow the selection of a configuration file different than the default one (for tests)
- two new plots in the calibration check pdf 

I am still performing some test so this is a draft PR 