### PR TITLE
Pixel noise adder & light smearer

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -34,6 +34,15 @@
     "leakage_intensity_width_2": [0, 1]
   },
 
+  "image_modifier": {
+    "modify_image": false,
+    "extra_noise_in_dim_pixels": 1.5,
+    "extra_bias_in_dim_pixels": 0.6,
+    "transition_charge": 8,
+    "extra_noise_in_bright_pixels": 1.44,
+    "smeared_light_fraction": 0.15
+  },
+
   "tailcut": {
     "picture_thresh":6,
     "boundary_thresh":3,

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -86,6 +86,8 @@ def main():
     if "image_modifier" in config:
         imconfig = config["image_modifier"]
         modify_image = imconfig["modify_image"]
+        if modify_image:
+            log.info('image_modifier configuration:', imconfig)
         extra_noise_in_dim_pixels = imconfig["extra_noise_in_dim_pixels"]
         extra_bias_in_dim_pixels = imconfig["extra_bias_in_dim_pixels"]
         transition_charge = imconfig["transition_charge"]

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -87,7 +87,7 @@ def main():
         imconfig = config["image_modifier"]
         modify_image = imconfig["modify_image"]
         if modify_image:
-            log.info('image_modifier configuration:', imconfig)
+            log.info(f"image_modifier configuration: {imconfig}")
         extra_noise_in_dim_pixels = imconfig["extra_noise_in_dim_pixels"]
         extra_bias_in_dim_pixels = imconfig["extra_bias_in_dim_pixels"]
         transition_charge = imconfig["transition_charge"]

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -162,6 +162,18 @@ def main():
                 image = row['image']
                 peak_time = row['peak_time']
 
+                # Add noise in pixels, to adjust MC to data noise levels.
+                # TO BE DONE: in case DL1a is saved, we have to save the modified image!
+                # TO BE DONE: in case of "pedestal cleaning" (not used now in MC) we should
+                # recalculate picture_th above!
+                qcopy = image.copy()
+                qlimit = 8
+                bias = -0.9
+                mu = 1.5
+                mu_2 = 1.44
+                image[qcopy < qlimit] += (np.random.poisson(mu, (qcopy < qlimit).sum()) + bias)
+                image[qcopy > qlimit] += (np.random.poisson(mu_2, (qcopy > qlimit).sum()) - mu_2)
+
                 signal_pixels = tailcuts_clean(camera_geom,
                                                image,
                                                picture_th,

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -174,6 +174,12 @@ def main():
                 image[qcopy < qlimit] += (np.random.poisson(mu, (qcopy < qlimit).sum()) + bias)
                 image[qcopy > qlimit] += (np.random.poisson(mu_2, (qcopy > qlimit).sum()) - mu_2)
 
+                # Move part of the light in each pixel (fraction) into its neighbors, to simulate a worse PSF:
+                fraction=0.25
+                q_spread = image * camera_geom.neighbor_matrix * fraction / 6
+                q_remaining = image * (1 - fraction)
+                image = q_remaining + np.sum(q_spread, axis=1)
+
                 signal_pixels = tailcuts_clean(camera_geom,
                                                image,
                                                picture_th,


### PR DESCRIPTION
This is for use in the dl1ab script when processing Monte Carlo:  optionally add noise to the pixel charges (to simulate higher NSB), and smear the light in the pixels (to simulate a worse PSF). With this one can achieve a better tuning of the MC to the data, without having to re-run sim_telarray.