### PR TITLE
count a number of islands after apply_time_delta_cleaning

### DIFF
--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -208,13 +208,8 @@ def main():
                                                min_n_neighbors)
 
                 n_pixels = np.count_nonzero(signal_pixels)
+
                 if n_pixels > 0:
-                    num_islands, island_labels = number_of_islands(camera_geom, signal_pixels)
-                    n_pixels_on_island = np.bincount(island_labels.astype(np.int64))
-                    n_pixels_on_island[0] = 0  # first island is no-island and should not be considered
-                    max_island_label = np.argmax(n_pixels_on_island)
-                    if use_only_main_island:
-                        signal_pixels[island_labels != max_island_label] = False
 
                     # if delta_time has been set, we require at least one
                     # neighbor within delta_time to accept a pixel in the image:
@@ -228,6 +223,15 @@ def main():
                                                              cleaned_pixel_times,
                                                              1, delta_time)
                         signal_pixels = new_mask
+
+                    # count a number of islands after all of the image cleaning steps
+                    num_islands, island_labels = number_of_islands(camera_geom, signal_pixels)
+                    n_pixels_on_island = np.bincount(island_labels.astype(np.int64))
+                    n_pixels_on_island[0] = 0  # first island is no-island and should not be considered
+                    max_island_label = np.argmax(n_pixels_on_island)
+
+                    if use_only_main_island:
+                        signal_pixels[island_labels != max_island_label] = False
 
                     # count the surviving pixels
                     n_pixels = np.count_nonzero(signal_pixels)


### PR DESCRIPTION
It seems a number of islands are counted before `apply_time_delta_cleaning` in dl1ab script, while it should be counted after all of the image cleaning procedures.
This PR solved this issue, counting a number of islands after `apply_time_delta_cleaning`.
If `use_only_main_island` is true, the main island after all cleaning steps will be survived.
