### PR TITLE
Interpolate charge and peak time of bad pixels using neighbors

### DIFF
--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -664,7 +664,7 @@ def interpolate_dl1a_of_bad_pixels(event, subarray, telescope_id):
     telescope_id: `int`
     """
     selected_gain = event.r1.tel[telescope_id].selected_gain_channel
-    bad_pixels = event.mon.tel[telescope_id].calibration.unusable_pixels[selected_gain] 
+    bad_pixels = event.mon.tel[telescope_id].calibration.unusable_pixels 
     bad_pixels_selected_gain = ((selected_gain == 0) & (bad_pixels[0] == 1)) | ((selected_gain == 1) & (bad_pixels[1] == 1))
 
     if np.sum(bad_pixels) > 0:


### PR DESCRIPTION
For now, all pixels regarded as bad using information of ped+cal run and interleaved ped+cal events during the observation have meaningless charge and peak time value (set zero to waveform).
This PR is to interpolate the charge and peak time of pixels labeled as bad using neighboring pixels, suggested by @tysaito2008. 
In this PR, neighboring pixels are searched and the average value using those neighbors is computed. Then, this value is set as parameters of bad pixels.
Please find the following slides about some quick test:
[20210518_Interpolate_bad_pixels.pdf](https://github.com/cta-observatory/cta-lstchain/files/6502558/20210518_Interpolate_bad_pixels.pdf)

<img width="652" alt="interpolation" src="https://user-images.githubusercontent.com/31307823/118681827-db317e80-b83a-11eb-8f38-4ef5c5f07e22.PNG">
