### PR TITLE
Introduced Poissonian fluctuations in the psf tuning

### DIFF
--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -172,7 +172,7 @@ def main():
         if set(dl1_params_input).intersection(disp_params):
             parameters_to_update.extend(disp_params)
 
-        if increase_nsb:
+        if increase_nsb or increase_psf:
             rng = np.random.default_rng(
                     input.root.dl1.event.subarray.trigger.col('obs_id')[0])
 
@@ -196,7 +196,7 @@ def main():
                                                 transition_charge,
                                                 extra_noise_in_bright_pixels)
                 if increase_psf:
-                    image = smear_light_in_pixels(image,
+                    image = smear_light_in_pixels(rng, image,
                                                   camera_geom,
                                                   smeared_light_fraction)
 


### PR DESCRIPTION
Introduced Poissonian fluctuations in the psf tuning, which up to now was just dividing a fixed fraction of charge per pixel equally among neighboring pixels.
This had the bad effect of reducing fluctuations, particularly visible in noise-dominated pixels.  

With old code:
![image](https://user-images.githubusercontent.com/14164282/119852717-d4c49600-bf0f-11eb-8a87-72418f90f23c.png)

One can see a deformation of the noise-dominated region of the MC (to which the psf tuning was applied).

Now the amount of p.e. to be smeared has Poissonian fluctuations, and the distribution among the neighbors follows a multinomial. The deformation is now gone with the proposed modification:

![image](https://user-images.githubusercontent.com/14164282/119853068-253bf380-bf10-11eb-886e-271c0d7e448d.png)

The new code is three times slower than the old one (6 to 18 ms per  image), and it is not because of the random number generator, but because I had to use a loop to fill a matrix (see comment in the code, suggestions are welcome).

