### PR TITLE
Add tool to extract drs4 baseline and spike heights

### DIFF
--- a/lstchain/scripts/onsite/onsite_create_calibration_file.py
+++ b/lstchain/scripts/onsite/onsite_create_calibration_file.py
@@ -155,7 +155,7 @@ def main():
         # search the pedestal file of the same date
         if ped_run is None:
             # else search the pedestal file of the same date
-            file_list = sorted(Path(f"{ped_dir}/{date}/{pro}/").rglob(f'drs4_pedestal*.0000.fits'))
+            file_list = sorted(Path(f"{ped_dir}/{date}/{pro}/").rglob(f'drs4_pedestal*.0000.h5'))
             if len(file_list) == 0:
                 raise IOError(f"No pedestal file found for date {date}\n")
             if len(file_list) > 1:
@@ -165,7 +165,7 @@ def main():
 
         # else, if given, search a specific pedestal run
         else:
-            file_list = sorted(Path(f"{ped_dir}").rglob(f'*/{pro}/drs4_pedestal.Run{ped_run:05d}.0000.fits'))
+            file_list = sorted(Path(f"{ped_dir}").rglob(f'*/{pro}/drs4_pedestal.Run{ped_run:05d}.0000.h5'))
             if len(file_list) == 0:
                 raise IOError(f"Pedestal file from run {ped_run} not found\n")
             else:

--- a/lstchain/scripts/onsite/onsite_create_drs4_pedestal_file.py
+++ b/lstchain/scripts/onsite/onsite_create_drs4_pedestal_file.py
@@ -86,7 +86,7 @@ def main():
             os.makedirs(log_dir, exist_ok=True)
 
         # define output file
-        output_file = f"{output_dir}/drs4_pedestal.Run{run:05d}.0000.fits"
+        output_file = f"{output_dir}/drs4_pedestal.Run{run:05d}.0000.h5"
 
         if os.path.exists(output_file):
             remove = False
@@ -102,9 +102,9 @@ def main():
 
         # run lstchain script
         cmd = [
-            "lstchain_data_create_drs4_pedestal_file",
-            f"--input-file={input_file}",
-            f"--output-file={output_file}",
+            "lstchain_create_drs4_pedestal_file",
+            f"--input={input_file}",
+            f"--output={output_file}",
             f"--max-events={max_events}",
         ]
 

--- a/lstchain/scripts/onsite/onsite_create_drs4_time_file.py
+++ b/lstchain/scripts/onsite/onsite_create_drs4_time_file.py
@@ -105,7 +105,7 @@ def main():
         if ped_run is None:
             # else search the pedestal file of the same date
 
-            file_list = sorted(Path(f"{ped_dir}/{date}/{pro}/").rglob('drs4_pedestal*.0000.fits'))
+            file_list = sorted(Path(f"{ped_dir}/{date}/{pro}/").rglob('drs4_pedestal*.0000.h5'))
             if len(file_list) == 0:
                 raise IOError(f"No pedestal file found for date {date}\n")
             if len(file_list) > 1:
@@ -115,7 +115,7 @@ def main():
 
         # else, if given, search a specific pedestal run
         else:
-            file_list = sorted(Path(f"{ped_dir}").rglob(f'*/{pro}/drs4_pedestal.Run{ped_run:05d}.0000.fits'))
+            file_list = sorted(Path(f"{ped_dir}").rglob(f'*/{pro}/drs4_pedestal.Run{ped_run:05d}.0000.h5'))
             if len(file_list) == 0:
                 raise IOError(f"Pedestal file from run {ped_run} not found\n")
             else:

--- a/lstchain/statistics.py
+++ b/lstchain/statistics.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+import numba
+from numba.experimental import jitclass
+
+@jitclass(dict(
+    n=numba.uint64,
+    counts=numba.uint64[:],
+    _mean=numba.float64[:],
+    _m2=numba.float64[:],
+))
+class OnlineStats:
+    '''
+    A class implementing Welford's algorithm for online mean/variance.
+
+    The class is able to track n statistics simultaneously.
+    '''
+
+    def __init__(self, n):
+        self.n = n
+        self.counts = np.zeros(n, dtype=np.uint64)
+        self._mean = np.zeros(n, dtype=np.float64)
+        self._m2 = np.zeros(n, dtype=np.float64)
+
+    def add_value(self, idx, value):
+        '''Add a new value at idx to the statistics'''
+        self.counts[idx] += 1
+        delta = value - self._mean[idx]
+        self._mean[idx] += delta / self.counts[idx]
+        delta2 = value - self._mean[idx]
+        self._m2[idx] += delta * delta2
+
+    @property
+    def mean(self):
+        '''Get the current mean values of all tracked statistics'''
+        mean = np.full_like(self._mean, np.nan)
+        valid = self.counts > 0
+        mean[valid] = self._mean[valid]
+        return mean
+
+    @property
+    def var(self):
+        '''Get the current sample variance of all tracked statistics'''
+        var = np.full_like(self._mean, np.nan)
+        valid = self.counts > 1
+        var[valid] = self._m2[valid] / (self.counts[valid] - 1)
+        return var
+
+    @property
+    def std(self):
+        '''Get the current sample std. dev. of all tracked statistics'''
+        return np.sqrt(self.var)

--- a/lstchain/statistics.py
+++ b/lstchain/statistics.py
@@ -30,6 +30,22 @@ class OnlineStats:
         delta2 = value - self._mean[idx]
         self._m2[idx] += delta * delta2
 
+    def add_values(self, values):
+        '''Add a new value in each of the tracked statistics'''
+        if values.ndim != 1 or len(values) != self.n:
+            raise ValueError('Expected a 1d array of length OnlineStats.n')
+
+        for i in range(self.n):
+            self.add_value(i, values[i])
+
+    def add_values_at_indices(self, indices, values):
+        '''Add a new value in each of the tracked statistics'''
+        if values.ndim != 1 or len(values) != len(indices):
+            raise ValueError('Expected two 1d arrays of matching length')
+
+        for i in range(len(indices)):
+            self.add_value(indices[i], values[i])
+
     @property
     def mean(self):
         '''Get the current mean values of all tracked statistics'''

--- a/lstchain/tests/test_statistics.py
+++ b/lstchain/tests/test_statistics.py
@@ -27,3 +27,25 @@ def test_online_statistics():
         else:
             assert np.isnan(stats.var).all()
             assert np.isnan(stats.std).all()
+
+
+def test_online_statistics_at_indices():
+    from lstchain.statistics import OnlineStats
+
+
+    rng = np.random.default_rng()
+    N = 10
+    data = rng.normal(size=10000)
+    indices = rng.integers(0, N, len(data), endpoint=False)
+
+    stats = OnlineStats(n=N)
+    stats.add_values_at_indices(indices, data)
+
+
+    assert np.all(stats.counts == np.bincount(indices))
+    mean = stats.mean
+    std = stats.std
+
+    for i in range(N):
+        assert np.isclose(mean[i], np.mean(data[indices == i]))
+        assert np.isclose(std[i], np.std(data[indices == i], ddof=1))

--- a/lstchain/tests/test_statistics.py
+++ b/lstchain/tests/test_statistics.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+
+def test_online_statistics():
+    from lstchain.statistics import OnlineStats
+
+
+    rng = np.random.default_rng()
+    data = rng.normal(size=(100, 10))
+
+    stats = OnlineStats(n=10)
+    assert np.isnan(stats.mean).all()
+    assert np.isnan(stats.var).all()
+    assert np.isnan(stats.std).all()
+    assert (stats.counts == 0).all()
+
+    for row, sample in enumerate(data):
+        for i, value in enumerate(sample):
+            stats.add_value(i, value)
+
+        assert np.allclose(stats.mean, np.mean(data[:row + 1], axis=0))
+        assert np.all(stats.counts == row + 1)
+
+        if row >= 1:
+            assert np.allclose(stats.var, np.var(data[:row + 1], axis=0, ddof=1))
+            assert np.allclose(stats.std, np.std(data[:row + 1], axis=0, ddof=1))
+        else:
+            assert np.isnan(stats.var).all()
+            assert np.isnan(stats.std).all()

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -1,0 +1,161 @@
+import numpy as np
+from tqdm import tqdm
+from ctapipe_io_lst import LSTEventSource
+from ctapipe_io_lst.calibration import get_spike_A_positions
+from ctapipe_io_lst.constants import N_GAINS, N_PIXELS, N_CAPACITORS_PIXEL, N_SAMPLES
+import numba
+import tables
+
+from ctapipe.io.hdf5tableio import DEFAULT_FILTERS
+from ctapipe.core import Tool
+from ctapipe.core.traits import Path, Integer
+
+from ..statistics import OnlineStats
+
+
+@numba.njit(cache=True, inline='always')
+def flat_index(gain, pixel, cap):
+    return N_PIXELS * N_CAPACITORS_PIXEL * gain + N_CAPACITORS_PIXEL * pixel + cap
+
+
+@numba.njit(cache=True)
+def fill_stats(
+    waveform,
+    first_cap,
+    last_first_cap,
+    last_readout_time,
+    baseline_stats,
+    spike1_stats,
+    spike2_stats,
+    spike3_stats,
+    skip_samples_front,
+    skip_samples_end,
+):
+    for gain in range(N_GAINS):
+        for pixel in range(N_PIXELS):
+            fc = first_cap[gain, pixel]
+            last_fc = last_first_cap[gain, pixel]
+            spike_positions = get_spike_A_positions(fc, last_fc)
+
+            for sample in range(skip_samples_front, N_SAMPLES - skip_samples_end):
+                cap = (fc + sample) % N_CAPACITORS_PIXEL
+
+                # ignore samples where we don't have a last readout time yet
+                if last_readout_time[gain, pixel, cap] == 0:
+                    continue
+
+                idx = flat_index(gain, pixel, cap)
+
+                # if sample in spike_positions or (sample - 1) in spike_positions or (sample - 2) in spike_positions:
+                if sample in spike_positions:
+                    spike1_stats.add_value(idx, waveform[gain, pixel, sample])
+                elif sample - 1 in spike_positions:
+                    spike2_stats.add_value(idx, waveform[gain, pixel, sample])
+                elif sample - 2 in spike_positions:
+                    spike3_stats.add_value(idx, waveform[gain, pixel, sample])
+                else:
+                    baseline_stats.add_value(idx, waveform[gain, pixel, sample])
+
+
+class DRS4PedestalAndSpikeHeight(Tool):
+    name = 'lstchain_create_drs4_pedestal_file'
+
+    output_path = Path(directory_ok=False).tag(config=True)
+    skip_samples_front = Integer(default_value=10).tag(config=True)
+    skip_samples_end = Integer(default_value=1).tag(config=True)
+
+    aliases = {
+        ('i', 'input'): 'LSTEventSource.input_url',
+        ('o', 'output'): 'DRS4PedestalAndSpikeHeight.output_path',
+        ('m', 'max-events'): 'LSTEventSource.max_events',
+    }
+
+    classes = [LSTEventSource]
+
+    def setup(self):
+        self.source = LSTEventSource(
+            parent=self,
+            pointing_information=False,
+            trigger_information=False,
+        )
+
+        # set some config options, these are necessary for this tool,
+        # so we set them here and not via the config system
+        self.source.r0_r1_calibrator.r1_sample_start = 0
+        self.source.r0_r1_calibrator.r1_sample_end = N_SAMPLES
+
+        self.source.r0_r1_calibrator.offset = 0
+        self.source.r0_r1_calibrator.apply_spike_correction = False
+        self.source.r0_r1_calibrator.apply_timelapse_correction = True
+        self.source.r0_r1_calibrator.apply_drs4_pedestal_correction = False
+
+        n_stats = N_GAINS * N_PIXELS * N_CAPACITORS_PIXEL
+        self.baseline_stats = OnlineStats(n_stats)
+        self.spike1_stats = OnlineStats(n_stats)
+        self.spike2_stats = OnlineStats(n_stats)
+        self.spike3_stats = OnlineStats(n_stats)
+
+    def start(self):
+        tel_id = self.source.tel_id
+
+        total = len(self.source.multi_file)
+        if self.source.max_events is not None:
+            total = min(self.source.max_events, total)
+
+        for event in tqdm(self.source, total=total):
+            fill_stats(
+                event.r1.tel[tel_id].waveform,
+                self.source.r0_r1_calibrator.first_cap[tel_id],
+                self.source.r0_r1_calibrator.first_cap_old[tel_id],
+                self.source.r0_r1_calibrator.last_readout_time[tel_id],
+                self.baseline_stats,
+                self.spike1_stats,
+                self.spike2_stats,
+                self.spike3_stats,
+                skip_samples_front=self.skip_samples_front,
+                skip_samples_end=self.skip_samples_end,
+            )
+
+    def finish(self):
+        self.log.info('Writing output to %s', self.output_path)
+        with tables.open_file(self.output_path, 'w') as f:
+            stats = {
+                'baseline': self.baseline_stats,
+                'spike1': self.spike1_stats,
+                'spike2': self.spike2_stats,
+                'spike3': self.spike3_stats,
+            }
+            mean_baseline = self.baseline_stats.mean
+
+            for name, stat in stats.items():
+                g = f.create_group('/', name)
+
+                for attr in ('counts', 'mean', 'std'):
+                    array = getattr(stat, attr).reshape((N_GAINS, N_PIXELS, N_CAPACITORS_PIXEL))
+
+                    # store mean / std as int32 scaled by 100
+                    # aka fixed precision with two decimal digits
+                    if attr in ('mean', 'std'):
+                        array *= 100
+                    array = array.astype(np.int32)
+
+                    f.create_carray(g, attr, obj=array, filters=DEFAULT_FILTERS)
+
+                if name.startswith('spike'):
+                    mask = stat.counts > 0
+                    n_spikes = stat.counts[mask].sum()
+                    spike_height = stat.mean[mask] - mean_baseline[mask]
+                    mean_height = np.average(spike_height, weights=stat.counts[mask])
+                    self.log.info(
+                        "Found %d %s, mean height = %.2f",
+                        n_spikes, name, mean_height,
+                    )
+
+
+def main():
+    tool = DRS4PedestalAndSpikeHeight()
+    tool.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -1,14 +1,16 @@
 import numpy as np
 from tqdm import tqdm
-from ctapipe_io_lst import LSTEventSource
-from ctapipe_io_lst.calibration import get_spike_A_positions
-from ctapipe_io_lst.constants import N_GAINS, N_PIXELS, N_CAPACITORS_PIXEL, N_SAMPLES
 import numba
 import tables
+from traitlets.config import Config
 
 from ctapipe.io.hdf5tableio import DEFAULT_FILTERS
 from ctapipe.core import Tool
 from ctapipe.core.traits import Path, Integer
+
+from ctapipe_io_lst import LSTEventSource
+from ctapipe_io_lst.calibration import get_spike_A_positions
+from ctapipe_io_lst.constants import N_GAINS, N_PIXELS, N_CAPACITORS_PIXEL, N_SAMPLES
 
 from ..statistics import OnlineStats
 

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -173,7 +173,11 @@ class DRS4PedestalAndSpikeHeight(Tool):
         self.log.debug("output path: %s", self.output_path)
         Provenance().add_output_file(str(self.output_path), role="DL1/Event")
 
-        self.source = LSTEventSource(parent=self)
+        self.source = LSTEventSource(
+            parent=self,
+            pointing_information=False,
+            trigger_information=False,
+        )
 
         # set some config options, these are necessary for this tool,
         # so we set them here and not via the config system

--- a/lstchain/tools/tests/test_create_drs4_pedestal_file.py
+++ b/lstchain/tools/tests/test_create_drs4_pedestal_file.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+
+import numpy as np
+
+from ctapipe.core import run_tool
+from ctapipe_io_lst.constants import N_GAINS, N_PIXELS, N_CAPACITORS_PIXEL
+import tables
+
+
+test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
+
+
+def test_create_drs4_pedestal_file(tmp_path):
+    '''Test the lstchain_drs4_pedestal_file tool'''
+    from lstchain.tools.lstchain_create_drs4_pedestal_file import DRS4PedestalAndSpikeHeight
+
+    input_path = test_data / "real/R0/20200218/LST-1.1.Run02005.0000_first50.fits.fz"
+    output_path = tmp_path / "drs4_pedestal_02005.h5"
+
+    ret = run_tool(
+        DRS4PedestalAndSpikeHeight(),
+        argv=[
+            f"--input={input_path}",
+            f"--output={output_path}",
+            "--overwrite",
+        ],
+        cwd=tmp_path,
+    )
+
+    assert ret == 0, 'Running DRS4PedestalAndSpikeHeight tool failed'
+    assert output_path.is_file(), 'Output file not written'
+
+    with tables.open_file(output_path, 'r') as f:
+        baseline_mean = f.root.baseline.mean[:].astype(np.float32) / 100
+        baseline_counts = f.root.baseline.counts[:]
+
+        assert baseline_mean.shape == (N_GAINS, N_PIXELS, N_CAPACITORS_PIXEL)
+        assert np.isclose(np.average(baseline_mean, weights=baseline_counts), 400, rtol=0.05)
+
+        for sample, expected in zip([1, 2, 3], [47, 53, 6]):
+            spike_mean = f.root[f'spike{sample}'].mean[:].astype(np.float32) / 100
+            spike_mean[spike_mean < 0] = np.nan
+            assert np.isclose(np.nanmean(spike_mean), expected, atol=5)


### PR DESCRIPTION
Note that this does not work yet, it needs a new version of `ctapipe_io_lst` (providing the get_spike_A_positions method)  


Advantages over the current tool:

1. Skip events with unknown `last_readout_time` so that the timelapse correction is properly applied for all samples
2. By default skip 10 samples in front and 1 at the end (current script 11 int front, none at the back)
3. Skips spikes for baseline estimation
4. Estimates the 3 spike heights
5. Provides count, mean and std per gain, pixel, capacitor for baseline, spike samples 1, 2, and 3
6. Output is a compressed hdf5 file for now, we can discuss the best format / structure inside
