### PR TITLE
Refactor and simplify merging of HDF5 files

### DIFF
--- a/lstchain/io/__init__.py
+++ b/lstchain/io/__init__.py
@@ -7,7 +7,6 @@ from .event_selection import EventSelector, DL3FixedCuts, DataBinning
 from .io import (
     get_dataset_keys,
     auto_merge_h5files,
-    smart_merge_h5files,
     write_simtel_energy_histogram,
     write_mcheader,
     write_dl2_dataframe,
@@ -35,7 +34,6 @@ __all__ = [
     'DataBinning',
     'get_dataset_keys',
     'auto_merge_h5files',
-    'smart_merge_h5files',
     'write_simtel_energy_histogram',
     'write_mcheader',
     'write_dl2_dataframe',

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -209,17 +209,16 @@ def stack_tables_h5files(filenames_list, output_filename="merged.h5", keys=None)
 
 
 def auto_merge_h5files(
-        file_list,
-        output_filename='merged.h5',
-        nodes_keys=None,
-        merge_arrays=False,
-        filters=HDF5_ZSTD_FILTERS,
-        progress_bar=False,
+    file_list=None,
+    output_filename="merged.h5",
+    nodes_keys=None,
+    merge_arrays=False,
+    filters=HDF5_ZSTD_FILTERS,
 ):
     """
     Automatic merge of HDF5 files.
-    A list of nodes keys can be provided to merge only these nodes.
-    If None, all nodes are merged.
+    A list of nodes keys can be provided to merge only these nodes. If None, all nodes are merged.
+    It may be also used to create a new file output_filename from content stored in another file.
 
     Parameters
     ----------
@@ -229,6 +228,12 @@ def auto_merge_h5files(
     merge_arrays: bool
     filters
     """
+
+    if file_list is None:
+        file_list = []
+    if len(file_list) > 1:
+        file_list = merging_check(file_list)
+    assert len(file_list) > 0, "The list of files is too short"
 
     if nodes_keys is None:
         keys = set(get_dataset_keys(file_list[0]))

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -213,6 +213,7 @@ def auto_merge_h5files(
     nodes_keys=None,
     merge_arrays=False,
     filters=HDF5_ZSTD_FILTERS,
+    progress_bar=False
 ):
     """
     Automatic merge of HDF5 files.

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -244,27 +244,32 @@ def auto_merge_h5files(
         with open_file(file_list[0]) as f1:
             for k in keys:
                 if type(f1.root[k]) == tables.table.Table:
-                    merge_file.create_table(
+                    t = merge_file.create_table(
                         os.path.join('/', k.rsplit('/', maxsplit=1)[0]),
                         os.path.basename(k),
                         createparents=True,
                         obj=f1.root[k].read()
                     )
+                    for att in f1.root[k].attrs._f_list():
+                        t.attrs[att] = f1.root[k].attrs[att]
                 if type(f1.root[k]) == tables.array.Array:
                     if merge_arrays:
-                        merge_file.create_earray(
+                        a = merge_file.create_earray(
                             os.path.join('/', k.rsplit('/', maxsplit=1)[0]),
                             os.path.basename(k),
                             createparents=True,
                             obj=f1.root[k].read()
                         )
                     else:
-                        merge_file.create_array(
+                        a = merge_file.create_array(
                             os.path.join('/', k.rsplit('/', maxsplit=1)[0]),
                             os.path.basename(k),
                             createparents=True,
                             obj=f1.root[k].read()
                         )
+                    for att in f1.root[k].attrs._f_list():
+                        a.attrs[att] = f1.root[k].attrs[att]
+
         bar.update(1)
         for filename in file_list[1:]:
             common_keys = keys.intersection(get_dataset_keys(filename))
@@ -283,7 +288,7 @@ def auto_merge_h5files(
                         raise
             bar.update(1)
 
-    # merge metadata
+    # merge global metadata
     metadata0 = read_metadata(file_list[0])
     for file in file_list[1:]:
         metadata = read_metadata(file)

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -232,7 +232,7 @@ def auto_merge_h5files(
         file_list = []
     if len(file_list) > 1:
         file_list = merging_check(file_list)
-    assert len(file_list) > 0, "The list of files is too short"
+    assert len(file_list) > 0, "Please, provide a non empty file_list parameter"
 
     if nodes_keys is None:
         keys = set(get_dataset_keys(file_list[0]))

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -227,6 +227,7 @@ def auto_merge_h5files(
     nodes_keys: list of path
     merge_arrays: bool
     filters
+    progress_bar: bool
     """
 
     file_list = list(file_list)
@@ -287,11 +288,15 @@ def auto_merge_h5files(
                         raise
             bar.update(1)
 
-    # merge global metadata
+    # merge global metadata and store source file names
     metadata0 = read_metadata(file_list[0])
+    source_filenames = [str(file_list[0])]
     for file in file_list[1:]:
-        metadata = read_metadata(file)
-        metadata0.SOURCE_FILENAMES.extend(metadata.SOURCE_FILENAMES)
+        source_filenames.append(str(file))
+
+    with open_file(output_filename, mode="a") as file:
+        sources = file.create_group("/", "source_filenames", "List of files merged")
+        file.create_array(sources, "filenames", source_filenames, "List of files merged")
     write_metadata(metadata0, output_filename)
 
 

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -229,7 +229,7 @@ def auto_merge_h5files(
     """
 
     if type(file_list) != list:
-        raise ValueError("Please, provide a non empty file list type parameter")
+        raise ValueError("Please, provide a list of filenames")
     if len(file_list) > 1:
         file_list = merging_check(file_list)
 

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -208,7 +208,7 @@ def stack_tables_h5files(filenames_list, output_filename="merged.h5", keys=None)
 
 
 def auto_merge_h5files(
-    file_list=None,
+    file_list,
     output_filename="merged.h5",
     nodes_keys=None,
     merge_arrays=False,
@@ -228,11 +228,10 @@ def auto_merge_h5files(
     filters
     """
 
-    if file_list is None:
-        file_list = []
+    if type(file_list) != list:
+        raise ValueError("Please, provide a non empty file list type parameter")
     if len(file_list) > 1:
         file_list = merging_check(file_list)
-    assert len(file_list) > 0, "Please, provide a non empty file_list parameter"
 
     if nodes_keys is None:
         keys = set(get_dataset_keys(file_list[0]))

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -46,7 +46,6 @@ __all__ = [
     'check_metadata',
     'read_metadata',
     'auto_merge_h5files',
-    'smart_merge_h5files',
     'global_metadata',
     'add_global_metadata',
     'add_config_metadata',
@@ -334,44 +333,10 @@ def merging_check(file_list):
             assert subarray_info == subarray_info0
 
         except AssertionError:
-            log.exception(f"{filename} cannot be smart merged '¯\_(ツ)_/¯'")
+            log.exception(f"{filename} cannot be merged '¯\_(ツ)_/¯'")
             mergeable_list.remove(filename)
 
     return mergeable_list
-
-
-def smart_merge_h5files(
-    file_list, output_filename="merged.h5", node_keys=None, merge_arrays=False
-):
-    """
-    Check that HDF5 files are compatible for merging and merge them
-
-    Parameters
-    ----------
-    file_list: list of paths to hdf5 files
-    output_filename: path to the merged file
-    node_keys
-    merge_arrays: bool
-    """
-    smart_list = merging_check(file_list)
-    auto_merge_h5files(
-        smart_list, output_filename, nodes_keys=node_keys, merge_arrays=merge_arrays
-    )
-
-    # Merge metadata and store source file names
-    metadata0 = read_metadata(smart_list[0])
-    source_filenames = [str(smart_list[0])]
-
-    for file in smart_list[1:]:
-        metadata = read_metadata(file)
-        check_metadata(metadata0, metadata)
-        source_filenames.append(str(file))
-
-    with open_file(output_filename, mode="a") as file:
-        sources = file.create_group("/", "source_filenames", "List of files merged")
-        file.create_array(sources, "filenames", source_filenames, "List of files merged")
-
-    write_metadata(metadata0, output_filename)
 
 
 def write_simtel_energy_histogram(source, output_filename, obs_id=None, filters=HDF5_ZSTD_FILTERS, metadata={}):

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -284,6 +284,13 @@ def auto_merge_h5files(
                         raise
             bar.update(1)
 
+    # merge metadata
+    metadata0 = read_metadata(file_list[0])
+    for file in file_list[1:]:
+        metadata = read_metadata(file)
+        metadata0.SOURCE_FILENAMES.extend(metadata.SOURCE_FILENAMES)
+    write_metadata(metadata0, output_filename)
+
 
 def merging_check(file_list):
     """

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -228,8 +228,7 @@ def auto_merge_h5files(
     filters
     """
 
-    if type(file_list) != list:
-        raise ValueError("Please, provide a list of filenames")
+    file_list = list(file_list)
     if len(file_list) > 1:
         file_list = merging_check(file_list)
 

--- a/lstchain/io/tests/test_io.py
+++ b/lstchain/io/tests/test_io.py
@@ -9,11 +9,11 @@ from astropy.table import Table
 
 @pytest.fixture
 def merged_h5file(tmp_path, simulated_dl1_file):
-    """Produce a smart merged h5 file from simulated dl1 files."""
-    from lstchain.io.io import smart_merge_h5files
+    """Produce a merged h5 file from simulated dl1 files."""
+    from lstchain.io.io import auto_merge_h5files
 
     merged_dl1_file = tmp_path / "dl1_merged.h5"
-    smart_merge_h5files(
+    auto_merge_h5files(
         [simulated_dl1_file, simulated_dl1_file], output_filename=merged_dl1_file
     )
     return merged_dl1_file
@@ -102,7 +102,7 @@ def test_merging_check(simulated_dl1_file):
 
 
 @pytest.mark.run(after="test_r0_to_dl1")
-def test_smart_merge_h5files(merged_h5file):
+def test_merge_h5files(merged_h5file):
     assert merged_h5file.is_file()
 
     # check source filenames is properly written
@@ -120,7 +120,7 @@ def test_read_simu_info_hdf5(simulated_dl1_file):
     assert mcheader.num_showers == 20000
 
 
-@pytest.mark.run(after="test_smart_merge_h5files")
+@pytest.mark.run(after="test_merge_h5files")
 def test_read_simu_info_merged_hdf5(merged_h5file):
     from lstchain.io.io import read_simu_info_merged_hdf5
 

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -32,7 +32,7 @@ from lstchain.io import get_dataset_keys, auto_merge_h5files
 from lstchain.io.config import get_cleaning_parameters
 from lstchain.io.config import get_standard_config
 from lstchain.io.config import read_configuration_file, replace_config
-from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key, read_metadata, write_metadata
+from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key
 from lstchain.io.lstcontainers import DL1ParametersContainer
 from lstchain.reco.disp import disp
 
@@ -181,7 +181,6 @@ def main():
         nodes_keys.remove(dl1_images_lstcam_key)
 
     auto_merge_h5files([args.input_file], args.output_file, nodes_keys=nodes_keys)
-    metadata = read_metadata(args.input_file)
 
     with tables.open_file(args.input_file, mode='r') as input:
         image_table = input.root[dl1_images_lstcam_key]
@@ -326,8 +325,6 @@ def main():
             output.root[dl1_params_lstcam_key][:] = params
             if image_mask_save:
                 output.root[dl1_images_lstcam_key].modify_column(colname='image_mask', column=image_mask)
-
-    write_metadata(metadata, args.output_file)
 
 
 if __name__ == '__main__':

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -32,7 +32,7 @@ from lstchain.io import get_dataset_keys, auto_merge_h5files
 from lstchain.io.config import get_cleaning_parameters
 from lstchain.io.config import get_standard_config
 from lstchain.io.config import read_configuration_file, replace_config
-from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key
+from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key, read_metadata
 from lstchain.io.lstcontainers import DL1ParametersContainer
 from lstchain.reco.disp import disp
 
@@ -181,7 +181,8 @@ def main():
         nodes_keys.remove(dl1_images_lstcam_key)
 
     auto_merge_h5files([args.input_file], args.output_file, nodes_keys=nodes_keys)
-
+    metadata = read_metadata(args.input_file)
+    
     with tables.open_file(args.input_file, mode='r') as input:
         image_table = input.root[dl1_images_lstcam_key]
         dl1_params_input = input.root[dl1_params_lstcam_key].colnames

--- a/lstchain/scripts/lstchain_merge_hdf5_files.py
+++ b/lstchain/scripts/lstchain_merge_hdf5_files.py
@@ -21,7 +21,7 @@ import os
 from distutils.util import strtobool
 # import tables
 from lstchain.io import get_dataset_keys
-from lstchain.io import smart_merge_h5files, auto_merge_h5files
+from lstchain.io import auto_merge_h5files
 from glob import glob
 
 parser = argparse.ArgumentParser(description='Merge HDF5 files')
@@ -37,11 +37,6 @@ parser.add_argument('--output-file', '-o', action='store', type=str,
                     dest='outfile',
                     help='Path of the resulting merged file',
                     default='merge.h5')
-
-parser.add_argument('--smart', action='store', type=lambda x: bool(strtobool(x)),
-                    dest='smart',
-                    help='Boolean. True for smart merge, False for auto merge',
-                    default=True)
 
 parser.add_argument('--no-image', action='store', type=lambda x: bool(strtobool(x)),
                     dest='noimage',
@@ -85,15 +80,7 @@ def main():
     else:
         keys = None
 
-    if args.smart:
-        smart_merge_h5files(file_list, args.outfile, node_keys=keys)
-    else:
-        auto_merge_h5files(
-            file_list,
-            args.outfile,
-            nodes_keys=keys,
-            progress_bar=args.progress
-        )
+    auto_merge_h5files(file_list, args.outfile, nodes_keys=keys)
 
 
 if __name__ == '__main__':

--- a/lstchain/scripts/lstchain_merge_hdf5_files.py
+++ b/lstchain/scripts/lstchain_merge_hdf5_files.py
@@ -80,7 +80,7 @@ def main():
     else:
         keys = None
 
-    auto_merge_h5files(file_list, args.outfile, nodes_keys=keys)
+    auto_merge_h5files(file_list, args.outfile, nodes_keys=keys, progress_bar=args.progress)
 
 
 if __name__ == '__main__':

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -231,7 +231,6 @@ def test_lstchain_merge_dl1_hdf5_observed_files(
         merged_dl1_observed_file,
         "--no-image",
         "False",
-        "--smart",
         "False",
         "--run-number",
         "2008",

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -231,7 +231,6 @@ def test_lstchain_merge_dl1_hdf5_observed_files(
         merged_dl1_observed_file,
         "--no-image",
         "False",
-        "False",
         "--run-number",
         "2008",
         "--pattern",


### PR DESCRIPTION
This PR simplifies and improves merging of HDF5 files by having a single `auto_merge_h5files` function. This function checks that HDF5 files to merge are compatible for merging by looking at their metadata as well as simulation info and histograms for MC files. 

These checks were also performed by similar function `smart_merge_h5files`, which has been removed. Though this function could merge *only* a list of more than one file, `auto_merge_h5files` function can also create a new file from the content of another one, which is how it is used in `lstchain_dl1ab.py` script. 

`auto_merge_h5files` also keeps existing global metadata in HDF5 files as well as potential existing attributes of their internal tables.



