### PR TITLE
Update lstchain_dl1ab_tune_MC_to_Crab_config.json

### DIFF
--- a/lstchain/data/lstchain_dl1ab_tune_MC_to_Crab_config.json
+++ b/lstchain/data/lstchain_dl1ab_tune_MC_to_Crab_config.json
@@ -1,12 +1,12 @@
 {
   "image_modifier": {
     "increase_nsb": true,
-    "extra_noise_in_dim_pixels": 1.5,
-    "extra_bias_in_dim_pixels": 0.6,
+    "extra_noise_in_dim_pixels": 1.25,
+    "extra_bias_in_dim_pixels": 0.55,
     "transition_charge": 8,
-    "extra_noise_in_bright_pixels": 1.44,
+    "extra_noise_in_bright_pixels": 2.05,
     "increase_psf": true,
-    "smeared_light_fraction": 0.175
+    "smeared_light_fraction": 0.125
   },
 
   "tailcut": {


### PR DESCRIPTION
Best MC tuning parameters (in dl1ab stage) to match the Nov'2020 Crab observations (as used in ICRC 2021 performance)