### PR TITLE
Fix CI due to ctaplot conflicts with pyparsing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - joblib
   - toml
   - protozfits=2.0
+  - pyparsing~=2.4
   - pip:
       - pytest_runner
       - pytest-ordering


### PR DESCRIPTION
This PR intends to fix the CI, broken because of possible conflicts of `ctaplot` with new release of `pyparsing` library needed by `matplotlib`

It pins the version of `pyparsing` to 2.4 in `environment.yml` file.