### PR TITLE
Fix run type in run summary, fixes #775

### DIFF
--- a/lstchain/conftest.py
+++ b/lstchain/conftest.py
@@ -1,6 +1,3 @@
-import tempfile
-from pathlib import Path
-
 import pandas as pd
 import pytest
 
@@ -32,26 +29,18 @@ def pytest_configure(config):
             config.option.markexpr += "not private_data"
 
 
-@pytest.fixture(scope="session")
-def temp_dir():
-    """Shared temporal directory for the tests."""
-    with tempfile.TemporaryDirectory(prefix="test_lstchain") as d:
-        yield Path(d)
-
 
 @pytest.fixture(scope="session")
-def temp_dir_simulated_files():
+def temp_dir_simulated_files(tmp_path_factory):
     """Temporal common directory for processing simulated data."""
-    with tempfile.TemporaryDirectory(prefix="test_lstchain") as d:
-        yield Path(d)
+    return tmp_path_factory.mktemp("simulated_files")
 
 
 @pytest.mark.private_data
 @pytest.fixture(scope="session")
-def temp_dir_observed_files():
+def temp_dir_observed_files(tmp_path_factory):
     """Temporal common directory for processing observed data."""
-    with tempfile.TemporaryDirectory(prefix="test_lstchain") as d:
-        yield Path(d)
+    return tmp_path_factory.mktemp("observed_files")
 
 
 @pytest.fixture(scope="session")

--- a/lstchain/scripts/lstchain_create_run_summary.py
+++ b/lstchain/scripts/lstchain_create_run_summary.py
@@ -154,6 +154,7 @@ def type_of_run(date_path, run_number, counters, n_events=500):
     filename = list_of_files[0]
 
     config = Config()
+    config.LSTEventSource.apply_drs4_corrections = False
     config.EventTimeCalculator.dragon_reference_time = int(counters["dragon_reference_time"])
     config.EventTimeCalculator.dragon_reference_counter = int(counters["dragon_reference_counter"])
     config.EventTimeCalculator.dragon_module_id = int(counters["dragon_reference_module_id"])

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -350,3 +350,5 @@ def test_run_summary(run_summary_path):
     assert "dragon_reference_module_index" in run_summary_table.columns
     assert "dragon_reference_counter" in run_summary_table.columns
     assert "dragon_reference_source" in run_summary_table.columns
+
+    assert (run_summary_table["run_type"] == ["DATA", "ERROR", "DATA"]).all()


### PR DESCRIPTION
This also switches to using pytests tmp dir factories, which enables looking at the files produced in tests after they failed 