### PR TITLE
Add instruction to set PYTHONNOUSERSITE in conda env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ conda env create -f environment.yml
 conda activate lst-dev
 ```
 
+**Note**: To prevent packages you installed with `pip install --user` from taking precedence over the conda environment, run:
+```
+conda env config vars set PYTHONNOUSERSITE=1 -n <environment_name>
+```
+
 To update the environment (e.g. when depenencies got updated), use:
 ```
 conda env update -n lst-dev -f environment.yml


### PR DESCRIPTION
I ran into a problem with a package version and @maxnoe suggested setting `export PYTHONNOUSERSITE=1` which can be automatically done by doing `conda env config vars set PYTHONNOUSERSITE=1 -n <environment_name>`