### PR TITLE
absolute paths to tables

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -62,13 +62,13 @@ __all__ = [
     'merge_dl2_runs'
 ]
 
-dl1_params_tel_mon_ped_key = "dl1/event/telescope/monitoring/pedestal"
+dl1_params_tel_mon_ped_key = "/dl1/event/telescope/monitoring/pedestal"
 dl1_params_tel_mon_cal_key = "/dl1/event/telescope/monitoring/calibration"
-dl1_params_lstcam_key = "dl1/event/telescope/parameters/LST_LSTCam"
-dl1_images_lstcam_key = "dl1/event/telescope/image/LST_LSTCam"
-dl2_params_lstcam_key = "dl2/event/telescope/parameters/LST_LSTCam"
-dl1_params_src_dep_lstcam_key = "dl1/event/telescope/parameters_src_dependent/LST_LSTCam"
-dl2_params_src_dep_lstcam_key = "dl2/event/telescope/parameters_src_dependent/LST_LSTCam"
+dl1_params_lstcam_key = "/dl1/event/telescope/parameters/LST_LSTCam"
+dl1_images_lstcam_key = "/dl1/event/telescope/image/LST_LSTCam"
+dl2_params_lstcam_key = "/dl2/event/telescope/parameters/LST_LSTCam"
+dl1_params_src_dep_lstcam_key = "/dl1/event/telescope/parameters_src_dependent/LST_LSTCam"
+dl2_params_src_dep_lstcam_key = "/dl2/event/telescope/parameters_src_dependent/LST_LSTCam"
 
 HDF5_ZSTD_FILTERS = tables.Filters(
     complevel=5,            # enable compression, 5 is a good tradeoff between compression and speed

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -154,7 +154,7 @@ def get_dataset_keys(filename):
 
     def walk(name, obj):
         if type(obj) == h5py._hl.dataset.Dataset:
-            dataset_keys.append(name)
+            dataset_keys.append('/'+name)
 
     with h5py.File(filename, "r") as file:
         file.visititems(walk)

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -64,6 +64,7 @@ __all__ = [
 
 dl1_params_tel_mon_ped_key = "/dl1/event/telescope/monitoring/pedestal"
 dl1_params_tel_mon_cal_key = "/dl1/event/telescope/monitoring/calibration"
+dl1_params_tel_mon_flat_key = "/dl1/event/telescope/monitoring/flatfield"
 dl1_params_lstcam_key = "/dl1/event/telescope/parameters/LST_LSTCam"
 dl1_images_lstcam_key = "/dl1/event/telescope/image/LST_LSTCam"
 dl2_params_lstcam_key = "/dl2/event/telescope/parameters/LST_LSTCam"

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -212,10 +212,10 @@ def test_lstchain_merge_dl1_hdf5_observed_files(
     merged_dl1_df = pd.read_hdf(merged_dl1_observed_file, key=dl1_params_lstcam_key)
     assert merged_dl1_observed_file.is_file()
     assert len(dl1a_df) + len(dl1b_df) == len(merged_dl1_df)
-    assert "dl1/event/telescope/image/LST_LSTCam" in get_dataset_keys(
+    assert dl1_images_lstcam_key in get_dataset_keys(
         merged_dl1_observed_file
     )
-    assert "dl1/event/telescope/parameters/LST_LSTCam" in get_dataset_keys(
+    assert dl1_params_lstcam_key in get_dataset_keys(
         merged_dl1_observed_file
     )
 

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -15,6 +15,11 @@ from lstchain.io.io import (
     dl1_images_lstcam_key,
     get_dataset_keys,
     dl1_params_src_dep_lstcam_key,
+    dl1_params_tel_mon_ped_key,
+    dl1_params_tel_mon_cal_key,
+    dl1_params_tel_mon_flat_key,
+    dl1_params_src_dep_lstcam_key,
+    dl2_params_src_dep_lstcam_key
 )
 
 from lstchain.io.config import get_standard_config
@@ -113,14 +118,15 @@ def test_observed_dl1_validity(observed_dl1_files):
 
     dl1_tables = get_dataset_keys(observed_dl1_files["dl1_file1"])
 
-    assert 'dl1/event/telescope/monitoring/calibration' in dl1_tables
-    assert 'dl1/event/telescope/monitoring/flatfield' in dl1_tables
-    assert 'dl1/event/telescope/monitoring/pedestal' in dl1_tables
-    assert 'dl1/event/telescope/image/LST_LSTCam' in dl1_tables
-    assert 'configuration/instrument/subarray/layout' in dl1_tables
-    assert 'configuration/instrument/telescope/camera/geometry_LSTCam' in dl1_tables
-    assert 'configuration/instrument/telescope/camera/readout_LSTCam' in dl1_tables
-    assert 'configuration/instrument/telescope/optics' in dl1_tables
+    assert dl1_params_lstcam_key in dl1_tables
+    assert dl1_images_lstcam_key in dl1_tables
+    assert dl1_params_tel_mon_cal_key in dl1_tables
+    assert dl1_params_tel_mon_ped_key in dl1_tables
+    assert dl1_params_tel_mon_flat_key in dl1_tables
+    assert '/configuration/instrument/subarray/layout' in dl1_tables
+    assert '/configuration/instrument/telescope/camera/geometry_LSTCam' in dl1_tables
+    assert '/configuration/instrument/telescope/camera/readout_LSTCam' in dl1_tables
+    assert '/configuration/instrument/telescope/optics' in dl1_tables
 
     assert "alt_tel" in dl1_df.columns
     assert "az_tel" in dl1_df.columns


### PR DESCRIPTION
 to allow reading the table directly with `ctapipe.io.read_table`

```
from ctapipe.io import read_table
from lstchain.io.io import dl1_images_lstcam_key
read_table('dl1_gamma_test_large.h5', dl1_images_lstcam_key)
```
leads  to:
```
NameError: ``where`` must start with a slash ('/')
```
