### PR TITLE
NSB injection in MC R1 waveform

### DIFF
--- a/lstchain/analysis/__init__.py
+++ b/lstchain/analysis/__init__.py
@@ -1,0 +1,5 @@
+from .normalised_pulse_template import NormalizedPulseTemplate
+
+__all__ = [
+    'NormalizedPulseTemplate',
+]

--- a/lstchain/analysis/normalised_pulse_template.py
+++ b/lstchain/analysis/normalised_pulse_template.py
@@ -1,0 +1,193 @@
+import numpy as np
+from scipy.interpolate import interp1d
+
+
+class NormalizedPulseTemplate:
+    """
+        Class for handling the template for the pulsed response of the pixels
+        of the camera to a single photo-electron in high and low gain.
+    """
+
+    def __init__(self, amplitude_HG, amplitude_LG, time, amplitude_HG_err=None,
+                 amplitude_LG_err=None):
+        """
+            Save the pulse template and optional error
+            and create an interpolation.
+        Parameters
+        ----------
+        amplitude_HG/LG: array
+            Amplitude of the signal produced in a pixel by a photo-electron
+            in high gain (HG) and low gain (LG) for successive time samples
+        time: array
+            Times of the samples
+        amplitude_HG/LG_err: array
+            Error on the pulse template amplitude
+        """
+        self.time = np.array(time)
+        self.amplitude_HG = np.array(amplitude_HG)
+        self.amplitude_LG = np.array(amplitude_LG)
+        if amplitude_HG_err is not None:
+            assert np.array(amplitude_HG_err).shape == self.amplitude_HG.shape
+            self.amplitude_HG_err = np.array(amplitude_HG_err)
+        else:
+            self.amplitude_HG_err = np.zeros(self.amplitude_HG.shape)
+        if amplitude_LG_err is not None:
+            assert np.array(amplitude_LG_err).shape == self.amplitude_LG.shape
+            self.amplitude_LG_err = np.array(amplitude_LG_err)
+        else:
+            self.amplitude_LG_err = self.amplitude_LG * 0
+        self._template = self._interpolate()
+        self._template_err = self._interpolate_err()
+
+    def __call__(self, time, gain, amplitude=1, t_0=0, baseline=0):
+        """
+            Use the interpolated template to access the value of the pulse at
+            time = time in gain regime = gain. Additionally, an alternative
+            normalisation, origin of time and baseline can be used.
+        Parameters
+        ----------
+        time: float array
+            Time after the origin to estimate the value of the pulse
+        gain: string array
+            Identifier of the gain channel used for each pixel
+            Either "HG" or "LG"
+        amplitude: float
+            Normalisation factor to aply to the template
+        t_0: float
+            Shift in the origin of time
+        baseline: float array
+            Baseline to be substracted for each pixel
+        Return
+        ----------
+        y: array
+            Value of the template in each pixel at the requested times
+        """
+        y = amplitude * self._template[gain](time - t_0) + baseline
+        return np.array(y)
+
+    def get_error(self, time, gain, amplitude=1, t_0=0):
+        """
+            Use the interpolated error on the template to access the value
+            of the pulse at time = time in gain regime = gain.
+            Additionally, an alternative normalisation and origin of time
+            can be used.
+        Parameters
+        ----------
+        time: float array
+            Time after the origin to estimate the value of the error
+        gain: string array
+            Identifier of the gain channel used for each pixel
+            Either "HG" or "LG"
+        amplitude: float
+            Normalisation factor to apply to the error
+        t_0: float
+            Shift in the origin of time
+        Return
+        ----------
+        y: array
+            Value of the template in each pixel at the requested times
+        """
+        y = amplitude * self._template_err[gain](time - t_0)
+        return np.array(y)
+
+    def save(self, filename):
+        """
+            Save a loaded template to a text file.
+        Parameters
+        ----------
+        filename: string
+            Location of the output text file
+        """
+        data = np.vstack([self.time, self.amplitude_HG, self.amplitude_HG_err,
+                          self.amplitude_LG, self.amplitude_LG_err])
+        np.savetxt(filename, data.T)
+
+    @classmethod
+    def load(cls, filename):
+        """
+        Load a pulse template from a text file.
+        Allows for only one gain channel and no errors,
+        two gain channels and no errors or two gain channels with errors.
+        Parameters
+        ----------
+        cls: This class
+        filename: string
+            Location of the template file
+        Return
+        ----------
+        cls(): Instance of NormalizedPulseTemplate receiving the information
+               from the input file
+        """
+        data = np.loadtxt(filename).T
+        assert len(data) in [2, 3, 5]
+        if len(data) == 2:  # one shape in file
+            t, x = data
+            return cls(amplitude_HG=x, amplitude_LG=x, time=t)
+        if len(data) == 3:  # no error in file
+            t, hg, lg = data
+            return cls(amplitude_HG=hg, amplitude_LG=lg, time=t)
+        elif len(data) == 5:  # two gains and errors
+            t, hg, lg, dhg, dlg = data
+            return cls(amplitude_HG=hg, amplitude_LG=lg, time=t,
+                       amplitude_HG_err=dhg, amplitude_LG_err=dlg)
+
+    @staticmethod
+    def _normalize(time, amplitude, error):
+        """
+        Normalize the pulse template in p.e/ns.
+        """
+        normalization = np.sum(amplitude)*(np.max(time)-np.min(time))/len(time)
+        return amplitude/normalization, error/normalization
+
+    def _interpolate(self):
+        """
+        Creates a normalised interpolation of the pulse template from a
+        discrete and non-normalised input. Also normalises the error.
+        Return
+        ----------
+        A dictionary containing a 1d cubic interpolation of the normalised
+        amplitude of the template versus time,
+        for the high and low gain channels.
+        """
+        self.amplitude_HG, self.amplitude_HG_err = self._normalize(self.time,
+                                                         self.amplitude_HG,
+                                                         self.amplitude_HG_err)
+        self.amplitude_LG, self.amplitude_LG_err = self._normalize(self.time,
+                                                         self.amplitude_LG,
+                                                         self.amplitude_LG_err)
+        return {"HG": interp1d(self.time, self.amplitude_HG, kind='cubic',
+                               bounds_error=False, fill_value=0.,
+                               assume_sorted=True),
+                "LG": interp1d(self.time, self.amplitude_LG, kind='cubic',
+                               bounds_error=False, fill_value=0.,
+                               assume_sorted=True)}
+
+    def _interpolate_err(self):
+        """
+        Creates an interpolation of the error on the pulse template
+        from a discrete and normalised input.
+        Return
+        ----------
+        A dictionary containing a 1d cubic interpolation of the error on the
+        normalised amplitude of the template versus time,
+        for the high and low gain channels.
+        """
+        return {"HG": interp1d(self.time, self.amplitude_HG_err, kind='cubic',
+                               bounds_error=False, fill_value=np.inf,
+                               assume_sorted=True),
+                "LG": interp1d(self.time, self.amplitude_LG_err, kind='cubic',
+                               bounds_error=False, fill_value=np.inf,
+                               assume_sorted=True)}
+
+    def compute_time_of_max(self):
+        """
+            Find the average of the times of maximum
+            of the high and low gain pulse shapes.
+        Returns
+        -------
+        t_max: float
+            Time of maximum of the pulse shapes (averaged)
+        """
+        t_max = (self.time[np.argmax(self.amplitude_HG)] +
+                 self.time[np.argmax(self.amplitude_LG)])/2
+        return t_max

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -24,8 +24,9 @@ from ctapipe.instrument import (
 )
 from ctapipe.io import HDF5TableReader
 from ctapipe.io import HDF5TableWriter
-from eventio import Histograms
-from eventio.search_utils import yield_toplevel_of_type
+from eventio import Histograms, EventIOFile
+from eventio.search_utils import yield_toplevel_of_type, yield_all_subobjects
+from eventio.simtel.objects import History, HistoryConfig
 from pyirf.simulations import SimulatedEventsInfo
 from tables import open_file
 from tqdm import tqdm
@@ -60,7 +61,9 @@ __all__ = [
     'extract_observation_time',
     'merge_dl2_runs',
     'get_srcdep_index_keys',
-    'get_srcdep_params'
+    'get_srcdep_params',
+    'parse_cfg_bytestring',
+    'extract_simulation_nsb'
 ]
 
 dl1_params_tel_mon_ped_key = "/dl1/event/telescope/monitoring/pedestal"
@@ -1228,3 +1231,37 @@ def get_srcdep_params(filename, key):
             [tuple(col[1:-1].replace('\'', '').replace(' ', '').split(",")) for col in data.columns])
         
     return data[key]
+
+
+def parse_cfg_bytestring(bytestring):
+    """
+    Parse configuration as read by eventio
+    :param bytes bytestring: A ``Bytes`` object with configuration data for one parameter
+    :return: Tuple in form ``('parameter_name', 'value')``
+    """
+    line_decoded = bytestring.decode('utf-8').rstrip()
+    if 'ECHO' in line_decoded or '#' in line_decoded:
+        return None
+    line_list = line_decoded.split('%', 1)[0]  # drop comment
+    res = re.sub(' +', ' ', line_list).strip().split(' ', 1)  # remove extra whitespaces and split
+    return res[0].upper(), res[1]
+
+
+def extract_simulation_nsb(filename):
+    """
+    Get current run NSB from configuration in simtel file
+    :param str filename: Input file name
+    :return array of `float` by tel_id: NSB rate
+    """
+    nsb = []
+    with EventIOFile(filename) as f:
+        for o in yield_all_subobjects(f, [History, HistoryConfig]):
+            if hasattr(o, 'parse'):
+                try:
+                    cfg_element = parse_cfg_bytestring(o.parse()[1])
+                    if cfg_element is not None:
+                        if cfg_element[0] == 'NIGHTSKY_BACKGROUND':
+                            nsb.append(float(cfg_element[1].strip('all:')))
+                except Exception as e:
+                    print('Unexpected end of %s,\n caught exception %s', filename, e)
+    return nsb

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -13,6 +13,7 @@ import astropy.units as u
 import numpy as np
 import pandas as pd
 import tables
+from scipy.interpolate import interp1d
 from astropy.table import Table
 from ctapipe.image import (
     HillasParameterizationError,
@@ -28,11 +29,13 @@ from ctapipe.containers import EventType
 from . import disp
 from .utils import sky_to_camera
 from .volume_reducer import apply_volume_reduction
+from ..analysis import NormalizedPulseTemplate
 from ..calib.camera import load_calibrator_from_config
 from ..calib.camera.calibration_calculator import CalibrationCalculator
 from ..image.muon import analyze_muon_event, tag_pix_thr
 from ..image.muon import create_muon_table, fill_muon_event
 from ..image.cleaning import apply_dynamic_cleaning
+from ..image.modifier import tune_nsb_on_waveform, calculate_required_additional_nsb
 from ..io import (
     DL1ParametersContainer,
     replace_config,
@@ -49,7 +52,7 @@ from ..io import (
     write_simtel_energy_histogram,
     write_subarray_tables,
 )
-from ..io.io import add_column_table
+from ..io.io import add_column_table, extract_simulation_nsb
 from ..io.lstcontainers import ExtraImageInfo, DL1MonitoringEventIndexContainer
 from ..paths import parse_r0_filename, run_to_dl1_filename, r0_to_dl1_filename
 from ..io.io import dl1_params_lstcam_key
@@ -329,6 +332,40 @@ def r0_to_dl1(
             filters=HDF5_ZSTD_FILTERS,
             metadata=metadata,
         )
+    if 'waveform_nsb_tuning' in config.keys():
+        nsb_tuning = config['waveform_nsb_tuning']['nsb_tuning']
+        if nsb_tuning:
+            if is_simu:
+                nsb_original = extract_simulation_nsb(input_filename)
+                pulse_template = NormalizedPulseTemplate.load(
+                            config['waveform_nsb_tuning']['pulse_template_location'])
+                if 'nsb_tuning_ratio' in config['waveform_nsb_tuning'].keys():
+                    # get value from config to possibly extract it beforehand on multiple files for averaging purposes
+                    # or gain time
+                    nsb_tuning_ratio = config['waveform_nsb_tuning']['nsb_tuning_ratio']
+                else:
+                    # extract the pedestal variance difference between the current MC file and the target data
+                    # FIXME? fails for multiple telescopes
+                    nsb_tuning_ratio = calculate_required_additional_nsb(input_filename,
+                                                                         config['waveform_nsb_tuning']['target_data'],
+                                                                         config=config)[0]
+                spe = np.loadtxt(config['waveform_nsb_tuning']['spe_location']).T
+                spe_integral = np.cumsum(spe[1])
+                charge_spe_cumulative_pdf = interp1d(spe_integral,spe[0], kind='cubic',
+                                                     bounds_error=False, fill_value=0.,
+                                                     assume_sorted=True)
+                allowed_tel = np.zeros(len(nsb_original), dtype=bool)
+                allowed_tel[np.array(config['source_config']['LSTEventSource']['allowed_tels'])] = True
+                logger.info('Tuning NSB on MC waveform from '
+                            + str(np.asarray(nsb_original)[allowed_tel])
+                            + 'GHz to {0:d}%'.format(int(nsb_tuning_ratio * 100 + 100.5))
+                            + ' for telescopes ids ' + str(config['source_config']['LSTEventSource']['allowed_tels']))
+            else:
+                logger.warning('NSB tuning on waveform active in config but file is real data, option will be ignored')
+                nsb_tuning = False
+    else:
+        nsb_tuning = False
+
 
     with HDF5TableWriter(
         filename=output_filename,
@@ -399,6 +436,19 @@ def r0_to_dl1(
 
                     # calibrate and gain select the event by hand for DL1
                     source.r0_r1_calibrator.calibrate(event)
+
+            # Option to add nsb in waveforms
+            if nsb_tuning:
+                # FIXME? assumes same correction ratio for all telescopes
+                for tel_id in config['source_config']['LSTEventSource']['allowed_tels']:
+                    waveform = event.r1.tel[tel_id].waveform
+                    readout = subarray.tel[tel_id].camera.readout
+                    sampling_rate = readout.sampling_rate.to_value(u.GHz)
+                    dt = (1.0 / sampling_rate)
+                    selected_gains = event.r1.tel[tel_id].selected_gain_channel
+                    mask_high = (selected_gains == 0)
+                    tune_nsb_on_waveform(waveform, nsb_tuning_ratio, nsb_original[tel_id] * u.GHz,
+                                         dt * u.ns, pulse_template, mask_high, charge_spe_cumulative_pdf)
 
             # create image for all events
             r1_dl1_calibrator(event)


### PR DESCRIPTION
An option to inject NSB pulses in existing Monte-Carlo simulation at the level of calibrated waveforms (R1) is implemented. 
It : 
  - extracts the simulation NSB from the analysed file
  - find the missing NSB compared to the target data file comparing the pedestal variance (or take it from the config)
  - randomly assign a number of pulses to inject in each waveform using Poisson statistic
  - randomly draw an exact injection time (uniform) and normalisation (using the spe normalisation pdf)
  - Modify the waveform accordingly accounting for AC coupling by lowering the baseline uniformly

It is controlled by adding the following block in the configuration file:
  "waveform_nsb_tuning": {
    "nsb_tuning":true,                   #false to turn it off, is ignored for real data
    "nsb_tuning_ratio": 0.89,        #Additional fraction of the original NSB to be added, if not given will be extracted from the target_data file
    "target_data": "",                     # File from which the NSB correction should be extracted. To avoid running it for each MC file, using the nsb_tuning_ratio input with pre-extracted value will often be preferred 
    "spe_location":"",                    # File containing the single photo-electron normalisation pdf
    "pulse_template_location": ""  # file containing the spe pulse template in the form "time pulseLG pulseHG" or "time pulse"
  }

The following shows a couple of results obtained with prod5_trans 80 MC taking a gamma diffuse and a proton simtel file (run1). The target data here is the run 2969, subrun 0000 of the Crab Nebula observation of November 20th 2020. They are produced using another branch from the likelihood method development where it was first developed. Assuming no error during the copy of the changes to the current branch it should be equivalent but dedicated tests of this version will be needed. The NSB increase is by ~72%.

Current injection looks as below on a couple of waveforms (without and with signal, event_id 11003  of prod5_trans80 gamma_20deg_180deg_run1___cta-prod5-lapalma_4LSTs_MAGIC_desert-2158m_mono_cone6.simtel.gz) : 
![image](https://user-images.githubusercontent.com/35919817/146215442-be7f5646-7174-46ad-80f3-45d78fff0688.png)
![image](https://user-images.githubusercontent.com/35919817/146215469-62b62495-f62a-498a-9006-0acf699c0c8d.png)

The title contains the pixel number and number of injected pulses in a time window starting 20 samples before the waveform (relative to the 0 of the pulse template which is ~10 ns before its maximum).

The effect on integrated charge is shown below (on the next event of the same file, id 16705)
![image](https://user-images.githubusercontent.com/35919817/146216570-5e12b5de-55fd-4da3-bd5d-e3d1ad1e48dc.png)

A first check of the validity of the correction was done by comparing the distribution of all extracted charges of all pixels in the low intensity range. The comparison below shows : a non modified gamma diffuse MC file, the same file after tuning to our target data set, a tuned proton file, and the target dataset. The NSB correction was independently extracted for both MC file during the processing.

![image](https://user-images.githubusercontent.com/35919817/146217473-3efc0fb2-8457-4335-9836-8daf536f7895.png)

I look at the low intensity pixels since they are dominated by pure background pixels. Higher intensities contain signal so spectral normalisation as a function of the particle type would be needed. It is clearly visible here that the correction improves the data/MC agreement in the charge extracted for low intensity pixels.

