### PR TITLE
Display progress bar by default and add --no-progress option to run in batch mode

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -215,7 +215,7 @@ def auto_merge_h5files(
     nodes_keys=None,
     merge_arrays=False,
     filters=HDF5_ZSTD_FILTERS,
-    progress_bar=False
+    progress_bar=True
 ):
     """
     Automatic merge of HDF5 files.
@@ -229,7 +229,8 @@ def auto_merge_h5files(
     nodes_keys: list of path
     merge_arrays: bool
     filters
-    progress_bar: bool
+    progress_bar : bool
+        Enabling the display of the progress bar during event processing.
     """
 
     file_list = list(file_list)

--- a/lstchain/scripts/lstchain_data_create_drs4_pedestal_file.py
+++ b/lstchain/scripts/lstchain_data_create_drs4_pedestal_file.py
@@ -65,9 +65,9 @@ parser.add_argument('--overwrite',
                     action='store_true',
                     help='Overwrite output file without asking')
 
-parser.add_argument('--progress', 
+parser.add_argument('--no-progress',
                     action='store_true',
-                    help='Display a progress bar during event processing')
+                    help='Do not display a progress bar during event processing')
 
 
 def main():
@@ -101,7 +101,7 @@ def main():
         n_module=n_modules,
         start_sample=args.start_sample,
     )
-    for event in tqdm(reader, disable=not args.progress):
+    for event in tqdm(reader, disable=args.no_progress):
         pedestal.fill_pedestal_event(event)
 
     # Finalize pedestal and write to fits file

--- a/lstchain/scripts/lstchain_data_create_time_calibration_file.py
+++ b/lstchain/scripts/lstchain_data_create_time_calibration_file.py
@@ -50,9 +50,9 @@ parser.add_argument('--pedestal-file', '-p',
 parser.add_argument('--run-summary-path',
                     help='Path to run summary file ', required=True)
 
-parser.add_argument('--progress',
+parser.add_argument('--no-progress',
                     action='store_true',
-                    help='Display a progress bar during event processing')
+                    help='Do not display a progress bar during event processing')
 
 
 def main():
@@ -104,7 +104,7 @@ def main():
 
         reader = EventSource(input_url=path, config=config)
 
-        for event in tqdm(reader, disable=not args.progress):
+        for event in tqdm(reader, disable=args.no_progress):
             timeCorr.calibrate_peak_time(event)
 
     # write output

--- a/lstchain/scripts/lstchain_merge_hdf5_files.py
+++ b/lstchain/scripts/lstchain_merge_hdf5_files.py
@@ -56,9 +56,9 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    '--progress',
+    '--no-progress',
     action='store_true',
-    help='Display a progress bar during event processing'
+    help='Do not display the progress bar during event processing'
 )
 
 
@@ -80,7 +80,12 @@ def main():
     else:
         keys = None
 
-    auto_merge_h5files(file_list, args.outfile, nodes_keys=keys, progress_bar=args.progress)
+    auto_merge_h5files(
+        file_list,
+        args.outfile,
+        nodes_keys=keys,
+        progress_bar=not args.no_progress
+    )
 
 
 if __name__ == '__main__':

--- a/lstchain/scripts/onsite/onsite_create_drs4_pedestal_file.py
+++ b/lstchain/scripts/onsite/onsite_create_drs4_pedestal_file.py
@@ -36,6 +36,11 @@ optional.add_argument('--tel_id', help="telescope id. Default = 1",
                       type=int, default=1)
 optional.add_argument('-y', '--yes', action="store_true", help='Do not ask interactively for permissions, assume true')
 optional.add_argument('--no_pro_symlink', action="store_true", help='Do not update the pro dir symbolic link, assume true')
+parser.add_argument(
+    '--no-progress',
+    action='store_true',
+    help='Do not display a progress bar during event processing'
+)
 
 
 args = parser.parse_args()
@@ -110,6 +115,9 @@ def main():
         f"--output={output_file}",
         f"--max-events={max_events}",
     ]
+
+    if args.no_progress:
+        cmd.append("--no-progress")
 
     subprocess.run(cmd, check=True)
 

--- a/lstchain/scripts/onsite/onsite_create_drs4_time_file.py
+++ b/lstchain/scripts/onsite/onsite_create_drs4_time_file.py
@@ -35,6 +35,11 @@ optional.add_argument('--sub_run', help="sub-run to be processed.", type=int, de
 default_config=os.path.join(os.path.dirname(__file__), "../../data/onsite_camera_calibration_param.json")
 optional.add_argument('--config', help="Config file", default=default_config)
 optional.add_argument('--no_pro_symlink', action="store_true", help='Do not update the pro dir symbolic link, assume true')
+parser.add_argument(
+    '--no-progress',
+    action='store_true',
+    help='Do not display a progress bar during event processing'
+)
 
 args = parser.parse_args()
 run = args.run_number
@@ -139,6 +144,9 @@ def main():
         f"--pedestal-file={pedestal_file}",
         f"--max-events={stat_events}",
     ]
+
+    if args.no_progress:
+        cmd.append("--no-progress")
 
     print("\n--> RUNNING...")
     subprocess.run(cmd, check=True)

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -1,7 +1,6 @@
 import numpy as np
 from tqdm import tqdm
 import numba
-import tables
 
 from ctapipe.io.hdf5tableio import HDF5TableWriter
 from ctapipe.io.tableio import FixedPointColumnTransform
@@ -13,7 +12,6 @@ from ctapipe_io_lst.calibration import get_spike_A_positions
 from ctapipe_io_lst.constants import N_GAINS, N_PIXELS, N_CAPACITORS_PIXEL, N_SAMPLES
 
 from ..statistics import OnlineStats
-
 
 
 class DRS4CalibrationContainer(Container):
@@ -105,7 +103,7 @@ class DRS4PedestalAndSpikeHeight(Tool):
     ).tag(config=True)
 
     progress_bar = Bool(
-        help="show progress bar during processing", default_value=False
+        help="Show progress bar during processing", default_value=True
     ).tag(config=True)
 
     full_statistics = Bool(
@@ -130,7 +128,6 @@ class DRS4PedestalAndSpikeHeight(Tool):
         ('m', 'max-events'): 'LSTEventSource.max_events',
     }
 
-
     flags = {
         **flag(
             "overwrite",
@@ -141,13 +138,13 @@ class DRS4PedestalAndSpikeHeight(Tool):
         **flag(
             "progress",
             "DRS4PedestalAndSpikeHeight.progress_bar",
-            "show a progress bar during event processing",
-            "don't show a progress bar during event processing",
+            "Show a progress bar during event processing",
+            "Do not show a progress bar during event processing",
         ),
         **flag(
             "full-statistics",
             "DRS4PedestalAndSpikeHeight.full_statistics",
-            "Wether to write the full statistics about spikes or not",
+            "Whether to write the full statistics about spikes or not",
         ),
     }
 
@@ -229,7 +226,6 @@ class DRS4PedestalAndSpikeHeight(Tool):
         tel_id = self.source.tel_id
         self.log.info('Writing output to %s', self.output_path)
         key = f'r1/monitoring/drs4_baseline/tel_{tel_id:03d}'
-
 
         with HDF5TableWriter(self.output_path) as writer:
             Provenance().add_output_file(str(self.output_path))


### PR DESCRIPTION
This PR sets the display of the progress bar by default for running interactively calibration and merging scripts and adds `--no-progress` option for running in batch disabling the display of the progress bar.

It also includes the missing `--no-progress` option to the onsite calibration scripts.