### PR TITLE
Require at least ctapipe_io_lst 0.13.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,6 @@ dependencies:
   - pip:
       - pytest_runner
       - pytest-ordering
-      - ctapipe_io_lst~=0.13.1
+      - ctapipe_io_lst~=0.13.2
       - ctaplot
       - pyirf~=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'astropy~=4.2',
         'bokeh~=1.0',
         'ctapipe~=0.11.0',
-        'ctapipe_io_lst~=0.13.1',
+        'ctapipe_io_lst~=0.13.2',
         'ctaplot~=0.5.5',
         'eventio>=1.5.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=0.18.2',


### PR DESCRIPTION
After the bugfix related to event time and ucts jump in ctapipe_io_lst, we discussed that it might be best to make a new lstchain release explicitly requiring the version with the fix.