### PR TITLE
Remove empty plot_irfs.py

### DIFF
--- a/docs/lstchain_api/visualization/index.rst
+++ b/docs/lstchain_api/visualization/index.rst
@@ -49,13 +49,6 @@ lstchain.visualization.plot\_drs4
    :undoc-members:
    :show-inheritance:
 
-lstchain.visualization.plot\_irfs
----------------------------------
-
-.. automodule:: lstchain.visualization.plot_irfs
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 Module contents
 ---------------


### PR DESCRIPTION
I guess this was committed by mistake or does it have a purpose @vuillaut ? 