### PR TITLE
Correct number of ucts jumps

### DIFF
--- a/lstchain/datachecks/containers.py
+++ b/lstchain/datachecks/containers.py
@@ -131,8 +131,8 @@ class DL1DataCheckContainer(Container):
             # not be counted.
             uj = table['ucts_jump']
             # find the first False value, and set to False also all the earlier ones:
-            for k in range(np.where(uj==False)[0][0]):
-                uj[k] = False
+            first_non_jump = np.nonzero(~uj)[0][0]
+            uj[:first_non_jump] = False
             self.num_ucts_jumps = np.sum(uj[mask])
         self.mean_alt_tel = np.mean(table['alt_tel'])
         self.mean_az_tel = np.mean(table['az_tel'])

--- a/lstchain/datachecks/containers.py
+++ b/lstchain/datachecks/containers.py
@@ -125,7 +125,15 @@ class DL1DataCheckContainer(Container):
         self.trigger_type = \
             count_trig_types(table['trigger_type'][mask])
         if 'ucts_jump' in table.columns:
-            self.num_ucts_jumps = np.sum(table['ucts_jump'][mask])
+            # After one (or n) genuine UCTS jumps in a run, the first event (or n events) 
+            # of every subsequent subrun file (if analyzed on its own) will have ucts_jump=True, 
+            # but these are not new jumps, just the ones from previous subruns, so they should 
+            # not be counted.
+            uj = table['ucts_jump']
+            # find the first False value, and set to False also all the earlier ones:
+            for k in range(np.where(uj==False)[0][0]):
+                uj[k] = False
+            self.num_ucts_jumps = np.sum(uj[mask])
         self.mean_alt_tel = np.mean(table['alt_tel'])
         self.mean_az_tel = np.mean(table['az_tel'])
 

--- a/lstchain/datachecks/containers.py
+++ b/lstchain/datachecks/containers.py
@@ -131,7 +131,7 @@ class DL1DataCheckContainer(Container):
             # not be counted.
             uj = table['ucts_jump']
             # find the first False value, and set to False also all the earlier ones:
-            first_non_jump = np.nonzero(~uj)[0][0]
+            first_non_jump = np.where(uj==False)[0][0]
             uj[:first_non_jump] = False
             self.num_ucts_jumps = np.sum(uj[mask])
         self.mean_alt_tel = np.mean(table['alt_tel'])

--- a/lstchain/scripts/longterm_dl1_check.py
+++ b/lstchain/scripts/longterm_dl1_check.py
@@ -699,6 +699,8 @@ def plot(filename='longterm_dl1_check.h5', batch=False, tel_id=1):
         log.info('Attention: UCTS jumps were detected and corrected:')
         for run, njumps in zip(runsummary['runnumber'],
                                runsummary['num_ucts_jumps']):
+            if njumps == 0:
+              continue
             log.info(f'   Run {run}: {njumps}  jumps')
         log.info('')
 


### PR DESCRIPTION
Make sure not to double-count the number of UCTS jumps occurring in a run. Previous version counted each jump again in every subsequent subrun.