### PR TITLE
Copy group attributes, fixes #838

### DIFF
--- a/lstchain/io/__init__.py
+++ b/lstchain/io/__init__.py
@@ -7,6 +7,7 @@ from .event_selection import EventSelector, DL3FixedCuts, DataBinning
 from .io import (
     get_dataset_keys,
     auto_merge_h5files,
+    copy_h5_nodes,
     write_simtel_energy_histogram,
     write_mcheader,
     write_dl2_dataframe,
@@ -36,6 +37,7 @@ __all__ = [
     'DataBinning',
     'get_dataset_keys',
     'auto_merge_h5files',
+    'copy_h5_nodes',
     'write_simtel_energy_histogram',
     'write_mcheader',
     'write_dl2_dataframe',

--- a/lstchain/io/tests/test_io.py
+++ b/lstchain/io/tests/test_io.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 import tables
 from astropy.table import Table
+from ctapipe.instrument import SubarrayDescription
 
 
 @pytest.fixture
@@ -12,10 +13,17 @@ def merged_h5file(tmp_path, simulated_dl1_file):
     """Produce a merged h5 file from simulated dl1 files."""
     from lstchain.io.io import auto_merge_h5files
 
+    subarray_before = SubarrayDescription.from_hdf(simulated_dl1_file)
+
     merged_dl1_file = tmp_path / "dl1_merged.h5"
     auto_merge_h5files(
         [simulated_dl1_file, simulated_dl1_file], output_filename=merged_dl1_file
     )
+
+    subarray_merged = SubarrayDescription.from_hdf(merged_dl1_file)
+
+    # check that subarray name is correctly retained
+    assert subarray_before.name == subarray_merged.name
     return merged_dl1_file
 
 

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -28,7 +28,7 @@ from ctapipe.image import (
 from ctapipe.instrument import SubarrayDescription
 
 from lstchain.calib.camera.pixel_threshold_estimation import get_threshold_from_dl1_file
-from lstchain.io import get_dataset_keys, auto_merge_h5files
+from lstchain.io import get_dataset_keys, copy_h5_nodes
 from lstchain.io.config import get_cleaning_parameters
 from lstchain.io.config import get_standard_config
 from lstchain.io.config import read_configuration_file, replace_config
@@ -180,12 +180,11 @@ def main():
     if args.noimage:
         nodes_keys.remove(dl1_images_lstcam_key)
 
-    auto_merge_h5files([args.input_file], args.output_file, nodes_keys=nodes_keys)
     metadata = read_metadata(args.input_file)
-    
-    with tables.open_file(args.input_file, mode='r') as input:
-        image_table = input.root[dl1_images_lstcam_key]
-        dl1_params_input = input.root[dl1_params_lstcam_key].colnames
+
+    with tables.open_file(args.input_file, mode='r') as infile:
+        image_table = infile.root[dl1_images_lstcam_key]
+        dl1_params_input = infile.root[dl1_params_lstcam_key].colnames
         disp_params = {'disp_dx', 'disp_dy', 'disp_norm', 'disp_angle', 'disp_sign'}
         if set(dl1_params_input).intersection(disp_params):
             parameters_to_update.extend(disp_params)
@@ -195,22 +194,24 @@ def main():
 
         if increase_nsb:
             rng = np.random.default_rng(
-                    input.root.dl1.event.subarray.trigger.col('obs_id')[0])
+                    infile.root.dl1.event.subarray.trigger.col('obs_id')[0])
 
         if increase_psf:
-            set_numba_seed(input.root.dl1.event.subarray.trigger.col('obs_id')[0])
+            set_numba_seed(infile.root.dl1.event.subarray.trigger.col('obs_id')[0])
 
-        image_mask_save = not args.noimage and 'image_mask' in input.root[dl1_images_lstcam_key].colnames
+        image_mask_save = not args.noimage and 'image_mask' in infile.root[dl1_images_lstcam_key].colnames
 
-        with tables.open_file(args.output_file, mode='a') as output:
-            params = output.root[dl1_params_lstcam_key].read()
+        with tables.open_file(args.output_file, mode='a') as outfile:
+            copy_h5_nodes(infile, outfile, nodes=nodes_keys)
+
+            params = outfile.root[dl1_params_lstcam_key].read()
             if image_mask_save:
-                image_mask = output.root[dl1_images_lstcam_key].col('image_mask')
+                image_mask = outfile.root[dl1_images_lstcam_key].col('image_mask')
 
             # need container to use lstchain.io.add_global_metadata and lstchain.io.add_config_metadata
             for k, item in metadata.as_dict().items():
-                output.root[dl1_params_lstcam_key].attrs[k] = item
-            output.root[dl1_params_lstcam_key].attrs["config"] = str(config)
+                outfile.root[dl1_params_lstcam_key].attrs[k] = item
+            outfile.root[dl1_params_lstcam_key].attrs["config"] = str(config)
 
             for ii, row in enumerate(image_table):
 
@@ -323,9 +324,9 @@ def main():
                 if image_mask_save:
                     image_mask[ii] = signal_pixels
 
-            output.root[dl1_params_lstcam_key][:] = params
+            outfile.root[dl1_params_lstcam_key][:] = params
             if image_mask_save:
-                output.root[dl1_images_lstcam_key].modify_column(colname='image_mask', column=image_mask)
+                outfile.root[dl1_images_lstcam_key].modify_column(colname='image_mask', column=image_mask)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I factored out the copying part into it's own function from `auto_merge_h5files`, added the copying of group attrs and replaced the now unneeded call to `auto_merge_h5files` with a single file in dl1ab with the new `copy_h5_nodes` function.

I also removed the use of h5py to get the dataset keys to use tables instead, as we do for everything else hdf5 related.