### PR TITLE
Fix gammapy compilation in docs CI, fixes #842

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,13 @@ jobs:
         run: |
           sudo apt update --yes && sudo apt install --yes git build-essential pandoc graphviz
           pip install -U pip setuptools wheel
+
+          # hotfix for gammapy being build against a too recent numpy,
+          # remove after updating to gammapy 0.19
+          pip install 'numpy~=1.20.3' Cython 'setuptools_scm[toml]'
+          pip install --no-build-isolation 'gammapy~=0.18.2'
+          # end hotfix for gammapy
+
           pip install -e .[docs]
           git describe --tags
           python -c 'import lstchain; print(lstchain.__version__)'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.hypothesis
 test_data
 .pytest_cache
 _version.py


### PR DESCRIPTION
Gammapy 0.18 had a broken `pyproject.toml` resulting in building against a too new numpy version. This fixes it by circumventing the pep517 build and manually installing the build requirements for gammapy.