### PR TITLE
Set list of source filenames to last used

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -298,11 +298,10 @@ def auto_merge_h5files(
         source_filenames.append(str(file))
 
     with open_file(output_filename, mode="a") as file:
-        try:
-            file.root.source_filenames._f_remove(recursive=True)
-        except tables.NoSuchNodeError:
-            sources_group = file.create_group("/", "source_filenames", "List of files merged")
-            file.create_array(sources_group, "filenames", source_filenames, "List of files merged")
+        if "/source_filenames" in file.root:
+            file.remove_node("/", "source_filenames", recursive=True)
+        sources_group = file.create_group("/", "source_filenames", "List of files merged")
+        file.create_array(sources_group, "filenames", source_filenames, "List of files merged")
     write_metadata(metadata0, output_filename)
 
 

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -298,8 +298,11 @@ def auto_merge_h5files(
         source_filenames.append(str(file))
 
     with open_file(output_filename, mode="a") as file:
-        sources = file.create_group("/", "source_filenames", "List of files merged")
-        file.create_array(sources, "filenames", source_filenames, "List of files merged")
+        try:
+            file.root.source_filenames._f_remove(recursive=True)
+        except tables.NoSuchNodeError:
+            sources_group = file.create_group("/", "source_filenames", "List of files merged")
+            file.create_array(sources_group, "filenames", source_filenames, "List of files merged")
     write_metadata(metadata0, output_filename)
 
 

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -216,6 +216,8 @@ def test_lstchain_mc_rfperformance(tmp_path, simulated_dl1_file, fake_dl1_proton
 
 def test_lstchain_merge_dl1_hdf5_files(merged_simulated_dl1_file):
     assert merged_simulated_dl1_file.is_file()
+    hdf5_file = tables.open_file(merged_simulated_dl1_file)
+    assert len(hdf5_file.root.source_filenames.filenames) == 2
 
 
 @pytest.mark.private_data


### PR DESCRIPTION
This PR fixes issue #839 setting the value of the `root.source_filenames.filenames`array to the last list of filenames used when merging files.
