### PR TITLE
Update requirements in setup.py and environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,5 +29,5 @@ dependencies:
   - seaborn
   - pip:
       - ctapipe_io_lst~=0.13.2
-      - ctaplot
+      - ctaplot~=0.5.5
       - pyirf~=0.5.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - default
 dependencies:
   - python=3.8
+  - numpy=1.21
   - astropy~=4.2
   - pip
   - ctapipe~=0.11

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,7 @@
 name: lst-dev
 channels:
-  - default
-  - cta-observatory
   - conda-forge
+  - default
 dependencies:
   - python=3.8
   - astropy~=4.2

--- a/environment.yml
+++ b/environment.yml
@@ -25,9 +25,10 @@ dependencies:
   - nbsphinx
   - numpydoc
   - traitlets=5.0
+  - pandas
+  - pymongo
+  - seaborn
   - pip:
-      - pytest_runner
-      - pytest-ordering
       - ctapipe_io_lst~=0.13.2
       - ctaplot
       - pyirf~=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'joblib',
         'matplotlib>=3.5',
         'numba',
-        'numpy',
+        'numpy<1.22.0a0',
         'pandas',
         'pyirf~=0.5.0',
         'scipy',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tools_list = find_scripts("lstchain/tools", "lstchain_")
 entry_points = {}
 entry_points["console_scripts"] = lstchain_list + onsite_list + tools_list
 
-tests_require = ["pytest", "pytest-ordering"]
+tests_require = ["pytest"]
 docs_require = [
     "sphinx~=4.2",
     "sphinx-automodapi",


### PR DESCRIPTION
We don't rely on pytest-runner and pytest-ordering anymore and pandas and seaborn were missing from the conda env, resulting in these packages being installed from pypi when setting up the env.