### PR TITLE
Exit early if output file already exists and filter out NaturalNameWarnings

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from multiprocessing import Pool
+import warnings
 
 import astropy.units as u
 import ctapipe
@@ -242,31 +243,36 @@ def copy_h5_nodes(from_file, to_file, nodes=None):
 
     groups = set()
 
-    for k in keys:
-        in_node = from_file.root[k]
-        parent_path = in_node._v_parent._v_pathname
-        name = in_node._v_name
-        groups.add(parent_path)
+    with warnings.catch_warnings():
+        # when copying nodes, we have no control over names
+        # so it does not make sense to warn about them
+        warnings.simplefilter('ignore', tables.NaturalNameWarning)
 
-        if isinstance(in_node, tables.Table):
-            t = to_file.create_table(
-                parent_path,
-                name,
-                createparents=True,
-                obj=from_file.root[k].read()
-            )
-            for att in from_file.root[k].attrs._f_list():
-                t.attrs[att] = from_file.root[k].attrs[att]
+        for k in keys:
+            in_node = from_file.root[k]
+            parent_path = in_node._v_parent._v_pathname
+            name = in_node._v_name
+            groups.add(parent_path)
 
-        elif isinstance(in_node, tables.Array):
-            a = to_file.create_array(
-                parent_path,
-                name,
-                createparents=True,
-                obj=from_file.root[k].read()
-            )
-            for att in from_file.root[k].attrs._f_list():
-                a.attrs[att] = in_node.attrs[att]
+            if isinstance(in_node, tables.Table):
+                t = to_file.create_table(
+                    parent_path,
+                    name,
+                    createparents=True,
+                    obj=from_file.root[k].read()
+                )
+                for att in from_file.root[k].attrs._f_list():
+                    t.attrs[att] = from_file.root[k].attrs[att]
+
+            elif isinstance(in_node, tables.Array):
+                a = to_file.create_array(
+                    parent_path,
+                    name,
+                    createparents=True,
+                    obj=from_file.root[k].read()
+                )
+                for att in from_file.root[k].attrs._f_list():
+                    a.attrs[att] = in_node.attrs[att]
 
     # after copying the datasets, also make sure we copy group metadata
     # of all copied groups

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -11,7 +11,7 @@ Usage:
 $> python lstchain_dl1ab.py
 --input-file dl1_gamma_20deg_0deg_run8___cta-prod3-lapalma-2147m-LaPalma-FlashCam.simtel.gz
 """
-
+import sys
 import argparse
 import logging
 from distutils.util import strtobool
@@ -77,12 +77,15 @@ parser.add_argument('--pedestal-cleaning', action='store',
 def main():
     args = parser.parse_args()
 
-    std_config = get_standard_config()
-
     log.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     logging.getLogger().addHandler(handler)
 
+    if args.output_file.exists():
+        log.critical('Outputfile already exists')
+        sys.exit(1)
+
+    std_config = get_standard_config()
     if args.config_file is not None:
         config = replace_config(std_config, read_configuration_file(args.config_file))
     else:

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -14,6 +14,7 @@ $> python lstchain_dl1ab.py
 import sys
 import argparse
 import logging
+from pathlib import Path
 from distutils.util import strtobool
 
 import astropy.units as u
@@ -81,7 +82,7 @@ def main():
     handler = logging.StreamHandler()
     logging.getLogger().addHandler(handler)
 
-    if args.output_file.exists():
+    if Path(args.output_file).exists():
         log.critical('Outputfile already exists')
         sys.exit(1)
 


### PR DESCRIPTION
The warnings were created by the astropy meta data tables, which we have no control over, so a warning is just annoying.