### PR TITLE
Refactor command line arguments of scripts

### DIFF
--- a/lstchain/io/data_management.py
+++ b/lstchain/io/data_management.py
@@ -3,7 +3,7 @@
 import os
 import shutil
 import sys
-from distutils.util import strtobool
+
 
 __all__ = [
     'check_and_make_dir',
@@ -14,6 +14,17 @@ __all__ = [
     'query_yes_no',
 ]
 
+
+def str_to_bool(answer):
+    if answer.lower() in {'y', 'yes'}:
+        return True
+
+    if answer.lower() in {'n', 'no'}:
+        return False
+
+    raise ValueError('Invalid choice, use one of [y, yes, n, no]')
+
+
 def query_yes_no(question, default="yes"):
     """
     Ask a yes/no question via raw_input() and return their answer.
@@ -22,38 +33,43 @@ def query_yes_no(question, default="yes"):
     ----------
     question: str
         question to the user
+
     default: str - "yes", "no" or None
         resumed answer if the user just hits <Enter>.
         "yes" or "no" will set a default answer for the user
         None will require a clear answer from the user
+
     Returns
     -------
     bool - True for "yes", False for "no"
     """
-    valid = {"yes": True, "y": True, "ye": True,
-             "no": False, "n": False}
+
     if default is None:
         prompt = " [y/n] "
     elif default == "yes":
         prompt = " [Y/n] "
+        default = True
     elif default == "no":
         prompt = " [y/N] "
+        default = False
     else:
         raise ValueError("invalid default answer: '%s'" % default)
 
     while True:
         sys.stdout.write(question + prompt)
         choice = input().lower()
-        if default is not None and choice == '':
-            return valid[default]
+        if choice == '' and default is not None:
+            return default
         else:
             try:
-                return bool(strtobool(choice))
-            except:
-                sys.stdout.write("Please respond with 'yes' or 'no' "
-                                 "(or 'y' or 'n').\n")
+                return str_to_bool(choice)
+            except ValueError:
+                print(
+                    "Please respond with 'yes' or 'no' (or 'y' or 'n').",
+                    file=sys.stderr,
+                )
 
-                
+
 def query_continue(question, default="no"):
     """
     Ask a question and if the answer is no, exit the program.

--- a/lstchain/scripts/lstchain_mc_r0_to_dl2.py
+++ b/lstchain/scripts/lstchain_mc_r0_to_dl2.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 """
 Pipeline to calibrate and compute image parameters at single telescope 
 level for MC.
@@ -17,8 +16,8 @@ $> python lstchain_mc_r0_to_dl2.py
 
 import argparse
 import os
-from distutils.util import strtobool
 from pathlib import Path
+import subprocess as sp
 
 from ctapipe.utils import get_dataset_path
 
@@ -33,28 +32,30 @@ parser.add_argument(
     help='path to the file with simtelarray events',
 )
 
-parser.add_argument('--path-models', '-p', action='store', type=str,
-                    dest='path_models',
-                    help='Path where to find the trained RF',
-                    default='./trained_models')
+parser.add_argument(
+    '--path-models', '-p',
+    help='Path where to find the trained RF',
+    default='./trained_models'
+)
 
 # Optional argument
-parser.add_argument('--store-dl1', '-s1', action='store', type=lambda x: bool(strtobool(x)),
-                    dest='store_dl1',
-                    help='Boolean. True for storing DL1 file'
-                         'Default=False, use True otherwise',
-                    default=True)
+parser.add_argument(
+    '--no-dl1',
+    action='store_true',
+    help='If given, the dl1 file is removed after creating the dl2 output',
+)
 
-parser.add_argument('--output-dir', '-o', type=Path,
-                    dest='outdir',
-                    help='Path where to store the reco dl2 events',
-                    default='./dl2_data')
+parser.add_argument(
+    '--output-dir', '-o', type=Path,
+    help='Path where to store the reco dl2 events',
+    default='./dl2_data'
+)
 
-parser.add_argument('--config', '-c', action='store', type=str,
-                    dest='config_file',
-                    help='Path to a configuration file. If none is given, a standard configuration is applied',
-                    default=None
-                    )
+parser.add_argument(
+    '--config', '-c',
+    dest='config_file',
+    help='Path to a configuration file. If none is given, a standard configuration is applied',
+)
 
 
 def main():
@@ -66,21 +67,30 @@ def main():
     if args.datafile is None:
         args.datafile = get_dataset_path('gamma_test_large.simtel.gz')
 
-    outdir = args.outdir.absolute()
-    dl1_file = outdir / r0_to_dl1_filename(args.datafile.name)
+    output_dir = args.output_dir.absolute()
+    dl1_file = output_dir / r0_to_dl1_filename(args.datafile.name)
 
-    cmd_r0_to_dl1 = f'lstchain_mc_r0_to_dl1 -f {args.datafile} -o {outdir}'
+    cmd_r0_to_dl1 = [
+        'lstchain_mc_r0_to_dl1',
+        '-f', str(args.datafile),
+        '-o', str(output_dir),
+    ]
     if args.config_file is not None:
-        cmd_r0_to_dl1 = cmd_r0_to_dl1 + f' -conf {args.config_file}'
+        cmd_r0_to_dl1.extend(['--config', str(args.config_file)])
 
-    cmd_dl1_to_dl2 = f'lstchain_dl1_to_dl2 -f {dl1_file} -p {args.path_models} -o {outdir}'
+    cmd_dl1_to_dl2 = [
+        'lstchain_dl1_to_dl2',
+        '-f', str(dl1_file),
+        '-p', str(args.path_models),
+        '-o', str(output_dir),
+    ]
     if args.config_file is not None:
-        cmd_dl1_to_dl2 = cmd_dl1_to_dl2 + f' -conf {args.config_file}'
+        cmd_dl1_to_dl2.extend(['--config', str(args.config_file)])
 
-    os.system(cmd_r0_to_dl1)
-    os.system(cmd_dl1_to_dl2)
+    sp.run(cmd_r0_to_dl1, check=True)
+    sp.run(cmd_dl1_to_dl2, check=True)
 
-    if not args.store_dl1:
+    if args.no_dl1:
         os.remove(dl1_file)
 
 

--- a/lstchain/scripts/lstchain_mc_rfperformance.py
+++ b/lstchain/scripts/lstchain_mc_rfperformance.py
@@ -54,12 +54,12 @@ parser.add_argument('--input-file-proton-test', '--p-test', type=str,
                     help='path to the dl1 file of proton events for test')
 
 # Optional arguments
-
-parser.add_argument('--store-rf', '-s', action='store', type=bool,
-                    dest='storerf',
-                    help='Boolean. True for storing trained RF in 3 files'
-                         'Default=False, any user input will be considered True',
-                    default=True)
+parser.add_argument(
+    '--no-save-models',
+    dest='save_models',
+    action='store_false',
+    help='Disable storing trained models',
+)
 
 parser.add_argument('--batch', '-b', action='store', type=bool,
                     dest='batch',
@@ -80,13 +80,10 @@ parser.add_argument('--config', '-c', action='store', type=str,
 
 def main():
     args = parser.parse_args()
-    
+
     custom_config = {}
     if args.config_file is not None:
-        try:
-            custom_config = read_configuration_file(args.config_file)
-        except("Custom configuration could not be loaded !!!"):
-            pass
+        custom_config = read_configuration_file(args.config_file)
 
     config = replace_config(standard_config, custom_config)
 
@@ -97,7 +94,7 @@ def main():
     reg_energy, reg_disp_norm, cls_disp_sign, cls_gh = dl1_to_dl2.build_models(
         args.gammafile,
         args.protonfile,
-        save_models=args.storerf,
+        save_models=args.save_models,
         path_models=args.path_models,
         custom_config=config,
     )

--- a/lstchain/scripts/lstchain_mc_trainpipe.py
+++ b/lstchain/scripts/lstchain_mc_trainpipe.py
@@ -10,14 +10,13 @@ Outputs are RF trained models
 
 Usage:
 
-$> python lst-trainpipe 
---input_file_gamma dl1_gamma_20deg_180deg_cta-prod3-demo-2147m-LaPalma-baseline-mono_off0.4_merge_test.h5 
---input-file-proton dl1_proton_20deg_180degcta-prod3-demo-2147m-LaPalma-baseline-mono_merge_test.h5 
+$> python lst-trainpipe
+--input_file_gamma dl1_gamma_20deg_180deg_cta-prod3-demo-2147m-LaPalma-baseline-mono_off0.4_merge_test.h5
+--input-file-proton dl1_proton_20deg_180degcta-prod3-demo-2147m-LaPalma-baseline-mono_merge_test.h5
 
 """
 
 import argparse
-from distutils.util import strtobool
 
 from lstchain.io.config import read_configuration_file
 from lstchain.reco import dl1_to_dl2
@@ -25,51 +24,58 @@ from lstchain.reco import dl1_to_dl2
 parser = argparse.ArgumentParser(description="Train Random Forests.")
 
 # Required argument
-parser.add_argument('--input-file-gamma', '--fg', type=str,
-                    dest='gammafile',
-                    help='Path to the dl1 file of gamma events for training')
+parser.add_argument(
+    '--input-file-gamma', '--fg',
+    dest='gammafile',
+    required=True,
+    help='Path to the dl1 file of gamma events for training'
+)
 
-parser.add_argument('--input-file-proton', '--fp', type=str,
-                    dest='protonfile',
-                    help='Path to the dl1 file of proton events for training')
+parser.add_argument(
+    '--input-file-proton', '--fp',
+    dest='protonfile',
+    required=True,
+    help='Path to the dl1 file of proton events for training',
+)
 
 # Optional arguments
-parser.add_argument('--store-rf', '-s', action='store', type=lambda x: bool(strtobool(x)),
-                    dest='storerf',
-                    help='Boolean. True for storing trained models in 3 files'
-                         'Default=True, use False otherwise',
-                    default=True)
+parser.add_argument(
+    '--no-save-models',
+    dest='save_models',
+    action='store_false',
+    help='Disable storing trained models',
+)
 
-parser.add_argument('--output-dir', '-o', action='store', type=str,
-                    dest='path_models',
-                    help='Path to store the resulting RF',
-                    default='./trained_models/')
+parser.add_argument(
+    '--output-dir', '-o',
+    dest='path_models',
+    default='./trained_models/',
+    help='Path to store the resulting RF',
+)
 
-parser.add_argument('--config', '-c', action='store', type=str,
-                    dest='config_file',
-                    help='Path to a configuration file. If none is given, a standard configuration is applied',
-                    default=None
-                    )
+parser.add_argument(
+    '--config', '-c',
+    dest='config_file',
+    help='Path to a configuration file. If none is given, a standard configuration is applied',
+)
 
 
 def main():
     args = parser.parse_args()
-    
+
     #Train the models
-        
+
     config = {}
     if args.config_file is not None:
-        try:
-            config = read_configuration_file(args.config_file)
-        except("Custom configuration could not be loaded !!!"):
-            pass
+        config = read_configuration_file(args.config_file)
 
-    dl1_to_dl2.build_models(args.gammafile,
-                            args.protonfile,
-                            save_models=args.storerf,
-                            path_models=args.path_models,
-                            custom_config=config,
-                            )
+    dl1_to_dl2.build_models(
+        args.gammafile,
+        args.protonfile,
+        save_models=args.save_models,
+        path_models=args.path_models,
+        custom_config=config,
+    )
 
 
 if __name__ == '__main__':

--- a/lstchain/scripts/lstchain_merge_hdf5_files.py
+++ b/lstchain/scripts/lstchain_merge_hdf5_files.py
@@ -18,7 +18,6 @@ $> python lstchain_merge_hdf5_files.py
 
 import argparse
 import os
-from distutils.util import strtobool
 from glob import glob
 
 from lstchain.io import auto_merge_h5files
@@ -27,32 +26,38 @@ from lstchain.io import get_dataset_keys
 parser = argparse.ArgumentParser(description='Merge HDF5 files')
 
 # Required arguments
-parser.add_argument('--input-dir', '-d', type=str,
-                    dest='srcdir',
-                    help='path to the source directory of files',
-                    )
+parser.add_argument(
+    '-d', '--input-dir',
+    help='path to the source directory of files',
+    required=True,
+)
 
 # Optional arguments
-parser.add_argument('--output-file', '-o', action='store', type=str,
-                    dest='outfile',
-                    help='Path of the resulting merged file',
-                    default='merge.h5')
-
-parser.add_argument('--no-image', action='store', type=lambda x: bool(strtobool(x)),
-                    dest='noimage',
-                    help='Boolean. True to remove the images',
-                    default=False)
-
-parser.add_argument('--run-number', '-r', action='store', type=int,
-                    dest='run_number',
-                    help='Merge files run-wise if a run number is passed, \
-                          otherwise merge all files in the directory',
-                    default=None)
+parser.add_argument(
+    '-o', '--output-file',
+    help='Path of the resulting merged file',
+    default='merge.h5'
+)
 
 parser.add_argument(
-    '--pattern', '-p',
-    help='Glob pattern to match files',
+    '--no-image',
+    action='store_true',
+    help='Do not include images in output file',
+)
+
+parser.add_argument(
+    '-r', '--run-number',
+    type=int,
+    help=(
+        'Merge files run-wise if a run number is passed'
+        'otherwise merge all files in the directory'
+    )
+)
+
+parser.add_argument(
+    '-p', '--pattern',
     default='*.h5',
+    help='Glob pattern to match files',
 )
 
 parser.add_argument(
@@ -69,12 +74,12 @@ def main():
         run = f'Run{args.run_number:05d}'
         file_list = sorted(filter(
             lambda f: run in f,
-            glob(os.path.join(args.srcdir, args.pattern))
+            glob(os.path.join(args.input_dir, args.pattern))
         ))
     else:
-        file_list = sorted(glob(os.path.join(args.srcdir, args.pattern)))
+        file_list = sorted(glob(os.path.join(args.input_dir, args.pattern)))
 
-    if args.noimage:
+    if args.no_image:
         keys = get_dataset_keys(file_list[0])
         keys = {k for k in keys if 'image' not in k}
     else:
@@ -82,7 +87,7 @@ def main():
 
     auto_merge_h5files(
         file_list,
-        args.outfile,
+        args.output_file,
         nodes_keys=keys,
         progress_bar=not args.no_progress
     )

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -92,7 +92,6 @@ def merged_simulated_dl1_file(simulated_dl1_file, temp_dir_simulated_files):
         "-o",
         merged_dl1_file,
         "--no-image",
-        "True",
     )
     return merged_dl1_file
 
@@ -232,8 +231,6 @@ def test_lstchain_merge_dl1_hdf5_observed_files(
         temp_dir_observed_files,
         "-o",
         merged_dl1_observed_file,
-        "--no-image",
-        "False",
         "--run-number",
         "2008",
         "--pattern",
@@ -348,7 +345,7 @@ def test_dl1ab_no_images(simulated_dl1_file, tmp_path):
         "-f", simulated_dl1_file,
         "-o", output_file,
         "-c", config_path,
-        '--no-image=True',
+        '--no-image',
     )
 
     with tables.open_file(output_file, 'r') as output:
@@ -370,14 +367,22 @@ def test_dl1ab_no_images(simulated_dl1_file, tmp_path):
 def test_observed_dl1ab(tmp_path, observed_dl1_files):
     output_dl1ab = tmp_path / "dl1ab.h5"
     run_program(
-        "lstchain_dl1ab", "-f", observed_dl1_files["dl1_file1"], "-o", output_dl1ab
+        "lstchain_dl1ab",
+        "-f", observed_dl1_files["dl1_file1"],
+        "-o", output_dl1ab,
+        "--no-pedestal-cleaning"
     )
     assert output_dl1ab.is_file()
+
     dl1ab = pd.read_hdf(output_dl1ab, key=dl1_params_lstcam_key)
     dl1 = pd.read_hdf(observed_dl1_files["dl1_file1"], key=dl1_params_lstcam_key)
-    np.testing.assert_allclose(dl1.to_numpy(dtype='float'),
-                               dl1ab.to_numpy(dtype='float'), rtol=1e-3,
-                               equal_nan=True)
+
+    np.testing.assert_allclose(
+        dl1.to_numpy(dtype='float'),
+        dl1ab.to_numpy(dtype='float'),
+        rtol=1e-3,
+        equal_nan=True,
+    )
 
 
 def test_simulated_dl1ab_validity(simulated_dl1_file, simulated_dl1ab):
@@ -395,8 +400,7 @@ def test_mc_r0_to_dl2(tmp_path, rf_models, mc_gamma_testfile):
         mc_gamma_testfile,
         "--path-models",
         rf_models["path"],
-        "--store-dl1",
-        "False",
+        "--no-dl1",
         "--output-dir",
         tmp_path,
     )


### PR DESCRIPTION
* Remove strtobool from distutils,
  use action='store_true', action='store_false' instead.

* Changes default of pedestal cleaning in dl1ab to true, use
  `--no-pedestal-cleaning` to disable