### PR TITLE
Change condition for muon error in datacheck

### DIFF
--- a/lstchain/datachecks/dl1_checker.py
+++ b/lstchain/datachecks/dl1_checker.py
@@ -862,7 +862,7 @@ def plot_datacheck(datacheck_filename, out_path=None, batch=False, muons_dir=Non
                 num_rings = np.append(num_rings, 0)
                 num_contained_rings = np.append(num_contained_rings, 0)
 
-        if len(files_with_rings) == 0:
+        if len(good_files) == 0:
             write_error_page('Muons', pagesize)
             pdf.savefig()
             return


### PR DESCRIPTION
As reported by @morcuended, it is possible that there are `files_with_rings` but none of them contain good rings, which throws an error in [this line](https://github.com/cta-observatory/cta-lstchain/blob/046423a5454f79457eb05a1e6763ad3f0b1cd8c4/lstchain/datachecks/dl1_checker.py#L877). A solution would be to write the Muon error page if we have no `good_files`