### PR TITLE
Add source-dependent parameters during RF training or dl1_to_dl2 process

### DIFF
--- a/lstchain/io/__init__.py
+++ b/lstchain/io/__init__.py
@@ -21,7 +21,7 @@ from .io import (
     read_mc_dl2_to_QTable,
     read_data_dl2_to_QTable,
     HDF5_ZSTD_FILTERS,
-    get_srcdep_wobble_angles,
+    get_srcdep_assumed_positions,
     get_srcdep_params,
     add_source_filenames,
 )
@@ -52,7 +52,7 @@ __all__ = [
     'HDF5_ZSTD_FILTERS',
     'read_mc_dl2_to_QTable',
     'read_data_dl2_to_QTable',
-    'get_srcdep_wobble_angles',
+    'get_srcdep_assumed_positions',
     'get_srcdep_params',
     'add_source_filenames'
 ]

--- a/lstchain/io/__init__.py
+++ b/lstchain/io/__init__.py
@@ -21,7 +21,7 @@ from .io import (
     read_mc_dl2_to_QTable,
     read_data_dl2_to_QTable,
     HDF5_ZSTD_FILTERS,
-    get_srcdep_index_keys,
+    get_srcdep_wobble_angles,
     get_srcdep_params,
     add_source_filenames,
 )
@@ -52,7 +52,7 @@ __all__ = [
     'HDF5_ZSTD_FILTERS',
     'read_mc_dl2_to_QTable',
     'read_data_dl2_to_QTable',
-    'get_srcdep_index_keys',
+    'get_srcdep_wobble_angles',
     'get_srcdep_params',
     'add_source_filenames'
 ]

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -55,7 +55,7 @@ __all__ = [
     'extract_simulation_nsb',
     'extract_observation_time',
     'get_dataset_keys',
-    'get_srcdep_index_keys',
+    'get_srcdep_wobble_angles',
     'get_srcdep_params',
     'get_stacked_table',
     'global_metadata',
@@ -1262,9 +1262,9 @@ def merge_dl2_runs(data_tag, runs, columns_to_read=None, n_process=4):
     return observation_time, df
 
 
-def get_srcdep_index_keys(filename):
+def get_srcdep_wobble_angles(filename):
     """
-    get index column name of source-dependent multi index columns
+    get wobble angles of source-dependent multi index columns
 
     Parameters
     ----------
@@ -1272,7 +1272,7 @@ def get_srcdep_index_keys(filename):
 
     Returns
     -------
-    source-dependent index names
+    wobble angles for source-dependent parameters
     """
     dataset_keys = get_dataset_keys(filename)
 
@@ -1282,6 +1282,9 @@ def get_srcdep_index_keys(filename):
     elif dl1_params_src_dep_lstcam_key in dataset_keys:
         data = pd.read_hdf(filename, key=dl1_params_src_dep_lstcam_key)
 
+    else:
+        raise IOError('File does not contain source-dependent parameters')
+
     if not isinstance(data.columns, pd.MultiIndex):
         data.columns = pd.MultiIndex.from_tuples(
             [tuple(col[1:-1].replace('\'', '').replace(' ', '').split(",")) for col in data.columns])
@@ -1289,15 +1292,15 @@ def get_srcdep_index_keys(filename):
     return data.columns.levels[0]
 
 
-def get_srcdep_params(filename, key=None):
+def get_srcdep_params(filename, wobble_angles=None):
     """
     get srcdep parameter data frame
 
     Parameters
     ----------
     filename: str - path to the HDF5 file
-    key: `str` - multi index key corresponding to an expected source position (e.g. 'on', 'off_180')
-    If it is not specified, all keys are loaded
+    wobble_angles: `str` - multi index key corresponding to an expected source position (e.g. 'on', 'off_180')
+    If it is not specified, source-dependent parameters with each assumed position are loaded
 
     Returns
     -------
@@ -1311,12 +1314,15 @@ def get_srcdep_params(filename, key=None):
     elif dl1_params_src_dep_lstcam_key in dataset_keys:
         data = pd.read_hdf(filename, key=dl1_params_src_dep_lstcam_key)
 
+    else:
+        raise IOError('File does not contain source-dependent parameters')
+
     if not isinstance(data.columns, pd.MultiIndex):
         data.columns = pd.MultiIndex.from_tuples(
             [tuple(col[1:-1].replace('\'', '').replace(' ', '').split(",")) for col in data.columns])
 
-    if key is not None:
-        data = data[key]
+    if wobble_angles is not None:
+        data = data[wobble_angles]
 
     return data
 

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1289,7 +1289,7 @@ def get_srcdep_index_keys(filename):
     return data.columns.levels[0]
 
 
-def get_srcdep_params(filename, key):
+def get_srcdep_params(filename, key=None):
     """
     get srcdep parameter data frame
 
@@ -1297,6 +1297,7 @@ def get_srcdep_params(filename, key):
     ----------
     filename: str - path to the HDF5 file
     key: `str` - multi index key corresponding to an expected source position (e.g. 'on', 'off_180')
+    If it is not specidied, all keys are loaded
 
     Returns
     -------
@@ -1314,7 +1315,10 @@ def get_srcdep_params(filename, key):
         data.columns = pd.MultiIndex.from_tuples(
             [tuple(col[1:-1].replace('\'', '').replace(' ', '').split(",")) for col in data.columns])
 
-    return data[key]
+    if key is not None:
+        data = data[key]
+
+    return data
 
 
 def parse_cfg_bytestring(bytestring):

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1297,7 +1297,7 @@ def get_srcdep_params(filename, key=None):
     ----------
     filename: str - path to the HDF5 file
     key: `str` - multi index key corresponding to an expected source position (e.g. 'on', 'off_180')
-    If it is not specidied, all keys are loaded
+    If it is not specified, all keys are loaded
 
     Returns
     -------

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -55,7 +55,7 @@ __all__ = [
     'extract_simulation_nsb',
     'extract_observation_time',
     'get_dataset_keys',
-    'get_srcdep_wobble_angles',
+    'get_srcdep_assumed_positions',
     'get_srcdep_params',
     'get_stacked_table',
     'global_metadata',
@@ -1262,9 +1262,9 @@ def merge_dl2_runs(data_tag, runs, columns_to_read=None, n_process=4):
     return observation_time, df
 
 
-def get_srcdep_wobble_angles(filename):
+def get_srcdep_assumed_positions(filename):
     """
-    get wobble angles of source-dependent multi index columns
+    get assumed positions of source-dependent multi index columns
 
     Parameters
     ----------
@@ -1272,7 +1272,7 @@ def get_srcdep_wobble_angles(filename):
 
     Returns
     -------
-    wobble angles for source-dependent parameters
+    assumed positions for source-dependent parameters
     """
     dataset_keys = get_dataset_keys(filename)
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -20,7 +20,12 @@ from sklearn.model_selection import train_test_split
 
 from . import disp
 from . import utils
-from ..io import standard_config, replace_config, get_dataset_keys, get_srcdep_params
+from ..io import (
+    standard_config, 
+    replace_config, 
+    get_dataset_keys, 
+    get_srcdep_params,
+)
 from ..io.io import dl1_params_lstcam_key, dl1_params_src_dep_lstcam_key
 
 from ctapipe.image.hillas import camera_to_shower_coordinates

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -314,9 +314,9 @@ def build_models(filegammas, fileprotons,
             subarray_info = SubarrayDescription.from_hdf(filegammas)
             tel_id = config["allowed_tels"][0] if "allowed_tels" in config else 1
             focal_length = subarray_info.tel[tel_id].optics.equivalent_focal_length
-            src_dep_df_gamma =pd.concat(get_source_dependent_parameters(df_gamma, config, focal_length=focal_length), axis=1)
-
-        df_gamma = pd.concat([df_gamma, src_dep_df_gamma], axis=1)
+            src_dep_df_gamma = get_source_dependent_parameters(df_gamma, config, focal_length=focal_length)
+            
+        df_gamma = pd.concat([df_gamma, src_dep_df_gamma['on']], axis=1)
 
         # if source-dependent parameters are already in dl1 data, just read those data
         # if not, source-dependent parameters are added here
@@ -327,9 +327,9 @@ def build_models(filegammas, fileprotons,
             subarray_info = SubarrayDescription.from_hdf(fileprotons)
             tel_id = config["allowed_tels"][0] if "allowed_tels" in config else 1
             focal_length = subarray_info.tel[tel_id].optics.equivalent_focal_length
-            src_dep_df_proton =pd.concat(get_source_dependent_parameters(df_proton, config, focal_length=focal_length), axis=1)
+            src_dep_df_proton = get_source_dependent_parameters(df_proton, config, focal_length=focal_length)
 
-        df_proton = pd.concat([df_proton, src_dep_df_proton], axis=1)
+        df_proton = pd.concat([df_proton, src_dep_df_proton['on']], axis=1)
 
     df_gamma = utils.filter_events(df_gamma,
                                    filters=events_filters,

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -20,10 +20,11 @@ from sklearn.model_selection import train_test_split
 
 from . import disp
 from . import utils
-from ..io import standard_config, replace_config, get_srcdep_index_keys, get_srcdep_params,
+from ..io import standard_config, replace_config, get_dataset_keys, get_srcdep_params
 from ..io.io import dl1_params_lstcam_key, dl1_params_src_dep_lstcam_key
 
 from ctapipe.image.hillas import camera_to_shower_coordinates
+from ctapipe.instrument import SubarrayDescription
 from ctapipe_io_lst import OPTICS
 
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -304,10 +304,30 @@ def build_models(filegammas, fileprotons,
     df_proton = pd.read_hdf(fileprotons, key=dl1_params_lstcam_key)
 
     if config['source_dependent']:
-        src_dep_df_gamma = get_srcdep_params(filegammas, 'on')
+        # if source-dependent parameters are already in dl1 data, just read those data
+        # if not, source-dependent parameters are added here
+        if dl1_params_src_dep_lstcam_key in get_dataset_keys(filegammas):
+            src_dep_df_gamma = get_srcdep_params(filegammas, 'on')
+        
+        else:
+            subarray_info = SubarrayDescription.from_hdf(filegammas)
+            tel_id = config["allowed_tels"][0] if "allowed_tels" in config else 1
+            focal_length = subarray_info.tel[tel_id].optics.equivalent_focal_length
+            src_dep_df_gamma =pd.concat(get_source_dependent_parameters(df_gamma, config, focal_length=focal_length), axis=1)
+
         df_gamma = pd.concat([df_gamma, src_dep_df_gamma], axis=1)
 
-        src_dep_df_proton = get_srcdep_params(fileprotons, 'on')
+        # if source-dependent parameters are already in dl1 data, just read those data
+        # if not, source-dependent parameters are added here
+        if dl1_params_src_dep_lstcam_key in get_dataset_keys(fileprotons):
+            src_dep_df_proton = get_srcdep_params(fileprotons, 'on')
+
+        else:
+            subarray_info = SubarrayDescription.from_hdf(fileprotons)
+            tel_id = config["allowed_tels"][0] if "allowed_tels" in config else 1
+            focal_length = subarray_info.tel[tel_id].optics.equivalent_focal_length
+            src_dep_df_proton =pd.concat(get_source_dependent_parameters(df_proton, config, focal_length=focal_length), axis=1)
+
         df_proton = pd.concat([df_proton, src_dep_df_proton], axis=1)
 
     df_gamma = utils.filter_events(df_gamma,

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -20,7 +20,7 @@ from sklearn.model_selection import train_test_split
 
 from . import disp
 from . import utils
-from ..io import standard_config, replace_config
+from ..io import standard_config, replace_config, get_srcdep_index_keys, get_srcdep_params,
 from ..io.io import dl1_params_lstcam_key, dl1_params_src_dep_lstcam_key
 
 from ctapipe.image.hillas import camera_to_shower_coordinates
@@ -304,15 +304,11 @@ def build_models(filegammas, fileprotons,
     df_proton = pd.read_hdf(fileprotons, key=dl1_params_lstcam_key)
 
     if config['source_dependent']:
-        src_dep_df_gamma = pd.read_hdf(filegammas, key=dl1_params_src_dep_lstcam_key)
-        src_dep_df_gamma.columns = pd.MultiIndex.from_tuples(
-            [tuple(col[1:-1].replace('\'', '').replace(' ', '').split(",")) for col in src_dep_df_gamma.columns])
-        df_gamma = pd.concat([df_gamma, src_dep_df_gamma['on']], axis=1)
+        src_dep_df_gamma = get_srcdep_params(filegammas, 'on')
+        df_gamma = pd.concat([df_gamma, src_dep_df_gamma], axis=1)
 
-        src_dep_df_proton = pd.read_hdf(fileprotons, key=dl1_params_src_dep_lstcam_key)
-        src_dep_df_proton.columns = pd.MultiIndex.from_tuples(
-            [tuple(col[1:-1].replace('\'', '').replace(' ', '').split(",")) for col in src_dep_df_proton.columns])
-        df_proton = pd.concat([df_proton, src_dep_df_proton['on']], axis=1)
+        src_dep_df_proton = get_srcdep_params(fileprotons, 'on')
+        df_proton = pd.concat([df_proton, src_dep_df_proton], axis=1)
 
     df_gamma = utils.filter_events(df_gamma,
                                    filters=events_filters,

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -26,7 +26,6 @@ from tables import open_file
 
 from lstchain.io import (
     get_dataset_keys,
-    get_srcdep_index_keys,
     get_srcdep_params,
     global_metadata,
     read_configuration_file,

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -151,9 +151,9 @@ def main():
 
         dl2_srcdep_dict = {}
         srcindep_keys = data.keys()
-        srcdep_index_keys = data_srcdep.columns.levels[0]
+        srcdep_wobble_angles = data_srcdep.columns.levels[0]
 
-        for i, k in enumerate(srcdep_index_keys):
+        for i, k in enumerate(srcdep_wobble_angles):
             data_with_srcdep_param = pd.concat([data, data_srcdep[k]], axis=1)
             data_with_srcdep_param = filter_events(data_with_srcdep_param,
                                                    filters=config["events_filters"],

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -141,13 +141,21 @@ def main():
     # Source-dependent analysis
     if config['source_dependent']:
 
+        # if source-dependent parameters are already in dl1 data, just read those data.
+        if dl1_params_src_dep_lstcam_key in get_dataset_keys(args.input_file):
+            data_srcdep = get_srcdep_params(args.input_file)
+
+        # if not, source-dependent parameters are added now
+        else:
+            data_srcdep = pd.concat(dl1_to_dl2.get_source_dependent_parameters(
+                data, config, focal_length=focal_length), axis=1)
+
         dl2_srcdep_dict = {}
         srcindep_keys = data.keys()
         srcdep_index_keys = get_srcdep_index_keys(args.input_file)
 
         for i, k in enumerate(srcdep_index_keys):
-            data_srcdep = get_srcdep_params(args.input_file, k)
-            data_with_srcdep_param = pd.concat([data, data_srcdep], axis=1)
+            data_with_srcdep_param = pd.concat([data, data_srcdep[k]], axis=1)
             data_with_srcdep_param = filter_events(data_with_srcdep_param,
                                                    filters=config["events_filters"],
                                                    finite_params=config['energy_regression_features']

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -151,9 +151,9 @@ def main():
 
         dl2_srcdep_dict = {}
         srcindep_keys = data.keys()
-        srcdep_wobble_angles = data_srcdep.columns.levels[0]
+        srcdep_assumed_positions = data_srcdep.columns.levels[0]
 
-        for i, k in enumerate(srcdep_wobble_angles):
+        for i, k in enumerate(srcdep_assumed_positions):
             data_with_srcdep_param = pd.concat([data, data_srcdep[k]], axis=1)
             data_with_srcdep_param = filter_events(data_with_srcdep_param,
                                                    filters=config["events_filters"],

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -152,7 +152,7 @@ def main():
 
         dl2_srcdep_dict = {}
         srcindep_keys = data.keys()
-        srcdep_index_keys = get_srcdep_index_keys(args.input_file)
+        srcdep_index_keys = data_srcdep.columns.levels[0]
 
         for i, k in enumerate(srcdep_index_keys):
             data_with_srcdep_param = pd.concat([data, data_srcdep[k]], axis=1)


### PR DESCRIPTION
continued from #704 

This PR makes it possible to add source-dependent parameters during the RF training or DL1_to_dl2 process, so no need to add these parameters by another script explicitly.