### PR TITLE
Correct config of interleaved event processing

### DIFF
--- a/lstchain/calib/camera/calibration_calculator.py
+++ b/lstchain/calib/camera/calibration_calculator.py
@@ -123,7 +123,6 @@ class CalibrationCalculator(Component):
 
             except:
                 raise IOError(f"Problem in reading quadratic term file {self.systematic_correction_path}")
-
         self.log.debug(f"{self.pedestal}")
         self.log.debug(f"{self.flatfield}")
 

--- a/lstchain/calib/camera/flatfield.py
+++ b/lstchain/calib/camera/flatfield.py
@@ -278,9 +278,9 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
                                              pixel_median > self.time_cut_outliers[1])
 
         return {
-            'sample_time': (time_start +(trigger_time - time_start) / 2).unix,
-            'sample_time_min': time_start.unix,
-            'sample_time_max': trigger_time.unix,
+            'sample_time': (time_start +(trigger_time - time_start) / 2).unix*u.s,
+            'sample_time_min': time_start.unix*u.s,
+            'sample_time_max': trigger_time.unix*u.s,
             'time_mean': np.ma.getdata(pixel_mean)*u.ns,
             'time_median': np.ma.getdata(pixel_median)*u.ns,
             'time_std': np.ma.getdata(pixel_std)*u.ns,

--- a/lstchain/calib/camera/flatfield.py
+++ b/lstchain/calib/camera/flatfield.py
@@ -92,7 +92,6 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
             self.charge_product, parent=self, subarray=subarray
         )
 
-
     def _extract_charge(self, event):
         """
         Extract the charge and the time from a calibration event
@@ -120,8 +119,6 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
         peak_pos = 0
         if self.extractor:
             charge, peak_pos = self.extractor(waveforms, self.tel_id, no_gain_selection)
-
-
 
         # shift the time if time shift is already defined
         # (e.g. drs4 waveform time shifts for LST)

--- a/lstchain/calib/camera/flatfield.py
+++ b/lstchain/calib/camera/flatfield.py
@@ -278,7 +278,7 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
                                              pixel_median > self.time_cut_outliers[1])
 
         return {
-            'sample_time': (trigger_time + time_start).value / 2 *u.s,
+            'sample_time': (time_start +(trigger_time - time_start) / 2).value *u.s,
             'sample_time_min': time_start.value*u.s,
             'sample_time_max': trigger_time.value*u.s,
             'time_mean': np.ma.getdata(pixel_mean)*u.ns,

--- a/lstchain/calib/camera/flatfield.py
+++ b/lstchain/calib/camera/flatfield.py
@@ -278,9 +278,9 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
                                              pixel_median > self.time_cut_outliers[1])
 
         return {
-            'sample_time': (time_start +(trigger_time - time_start) / 2).value *u.s,
-            'sample_time_min': time_start.value*u.s,
-            'sample_time_max': trigger_time.value*u.s,
+            'sample_time': (time_start +(trigger_time - time_start) / 2).unix,
+            'sample_time_min': time_start.unix,
+            'sample_time_max': trigger_time.unix,
             'time_mean': np.ma.getdata(pixel_mean)*u.ns,
             'time_median': np.ma.getdata(pixel_median)*u.ns,
             'time_std': np.ma.getdata(pixel_std)*u.ns,

--- a/lstchain/calib/camera/flatfield.py
+++ b/lstchain/calib/camera/flatfield.py
@@ -278,7 +278,7 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
                                              pixel_median > self.time_cut_outliers[1])
 
         return {
-            'sample_time': (trigger_time - time_start).value / 2 *u.s,
+            'sample_time': (trigger_time + time_start).value / 2 *u.s,
             'sample_time_min': time_start.value*u.s,
             'sample_time_max': trigger_time.value*u.s,
             'time_mean': np.ma.getdata(pixel_mean)*u.ns,

--- a/lstchain/calib/camera/pedestals.py
+++ b/lstchain/calib/camera/pedestals.py
@@ -241,7 +241,7 @@ def calculate_time_results(
 ):
     """Calculate and return the sample time"""
     return {
-        'sample_time': (trigger_time - time_start).value / 2 *u.s,
+        'sample_time': (trigger_time + time_start).value / 2 *u.s,
         'sample_time_min': time_start.value*u.s,
         'sample_time_max': trigger_time.value*u.s,
     }

--- a/lstchain/calib/camera/pedestals.py
+++ b/lstchain/calib/camera/pedestals.py
@@ -4,6 +4,7 @@ Factory for the estimation of the flat field coefficients
 
 
 import numpy as np
+from astropy import units as u
 from ctapipe.calib.camera.pedestals import PedestalCalculator
 from ctapipe.core.traits import List, Path
 from lstchain.calib.camera.time_sampling_correction import TimeSamplingCorrection
@@ -240,9 +241,9 @@ def calculate_time_results(
 ):
     """Calculate and return the sample time"""
     return {
-        'sample_time': (time_start + (trigger_time - time_start) / 2).unix,
-        'sample_time_min': time_start.unix,
-        'sample_time_max': trigger_time.unix,
+        'sample_time': (time_start + (trigger_time - time_start) / 2).unix*u.s,
+        'sample_time_min': time_start.unix*u.s,
+        'sample_time_max': trigger_time.unix*u.s,
     }
 
 

--- a/lstchain/calib/camera/pedestals.py
+++ b/lstchain/calib/camera/pedestals.py
@@ -4,7 +4,6 @@ Factory for the estimation of the flat field coefficients
 
 
 import numpy as np
-from astropy import units as u
 from ctapipe.calib.camera.pedestals import PedestalCalculator
 from ctapipe.core.traits import List, Path
 from lstchain.calib.camera.time_sampling_correction import TimeSamplingCorrection

--- a/lstchain/calib/camera/pedestals.py
+++ b/lstchain/calib/camera/pedestals.py
@@ -241,9 +241,9 @@ def calculate_time_results(
 ):
     """Calculate and return the sample time"""
     return {
-        'sample_time': (time_start + (trigger_time - time_start) / 2).value *u.s,
-        'sample_time_min': time_start.value*u.s,
-        'sample_time_max': trigger_time.value*u.s,
+        'sample_time': (time_start + (trigger_time - time_start) / 2).unix,
+        'sample_time_min': time_start.unix,
+        'sample_time_max': trigger_time.unix,
     }
 
 

--- a/lstchain/calib/camera/pedestals.py
+++ b/lstchain/calib/camera/pedestals.py
@@ -86,7 +86,6 @@ class PedestalIntegrator(PedestalCalculator):
         else:
             self.time_sampling_corrector = None
 
-
         # fix for broken extractor setup in ctapipe baseclass
         self.extractor = ImageExtractor.from_name(
             self.charge_product, parent=self, subarray=subarray

--- a/lstchain/calib/camera/pedestals.py
+++ b/lstchain/calib/camera/pedestals.py
@@ -241,7 +241,7 @@ def calculate_time_results(
 ):
     """Calculate and return the sample time"""
     return {
-        'sample_time': (trigger_time + time_start).value / 2 *u.s,
+        'sample_time': (time_start + (trigger_time - time_start) / 2).value *u.s,
         'sample_time_min': time_start.value*u.s,
         'sample_time_max': trigger_time.value*u.s,
     }

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -261,5 +261,11 @@
     "nsb_tuning": false,
     "nsb_tuning_ratio": 0.52,
     "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
-  }
+  },
+  "FixedWindowSum":{
+      "window_shift": 6,
+      "window_width":12,
+      "peak_index": 18,
+      "apply_integration_correction": false
+    }
 }

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -261,11 +261,5 @@
     "nsb_tuning": false,
     "nsb_tuning_ratio": 0.52,
     "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
-  },
-  "FixedWindowSum":{
-      "window_shift": 6,
-      "window_width":12,
-      "peak_index": 18,
-      "apply_integration_correction": false
-    }
+  }
 }

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -222,6 +222,7 @@
   "calibration_product": "LSTCalibrationCalculator",
 
   "LSTCalibrationCalculator":{
+    "systematic_correction_path": null,
     "squared_excess_noise_factor": 1.222,
     "flatfield_product": "FlasherFlatFieldCalculator",
     "pedestal_product": "PedestalIntegrator",
@@ -232,7 +233,13 @@
       "time_sampling_correction_path": null,
       "charge_median_cut_outliers": [-10,10],
       "charge_std_cut_outliers": [-10,10],
-      "charge_product":"FixedWindowSum"
+      "charge_product":"FixedWindowSum",
+      "FixedWindowSum":{
+      "window_shift": 6,
+      "window_width":12,
+      "peak_index": 18,
+      "apply_integration_correction": false
+    }
     },
     "FlasherFlatFieldCalculator":{
       "sample_size": 10000,
@@ -242,18 +249,12 @@
       "charge_product":"LocalPeakWindowSum",
       "charge_median_cut_outliers": [-0.5,0.5],
       "charge_std_cut_outliers": [-10,10],
-      "time_cut_outliers": [2,38]
-    },
-    "LocalPeakWindowSum":{
-      "window_shift": 5,
-      "window_width":12,
-      "apply_integration_correction": false
-    },
-    "FixedWindowSum":{
-      "window_shift": 6,
-      "window_width":12,
-      "peak_index": 18,
-      "apply_integration_correction": false
+      "time_cut_outliers": [2,38],
+      "LocalPeakWindowSum":{
+        "window_shift": 5,
+        "window_width":12,
+        "apply_integration_correction": false
+      }
     }
   },
   "waveform_nsb_tuning":{

--- a/lstchain/data/onsite_camera_calibration_param.json
+++ b/lstchain/data/onsite_camera_calibration_param.json
@@ -14,6 +14,18 @@
             "console"
           ]
         },
+        "ctapipe.core.provenance":{
+          "level": "INFO",
+          "handlers": [
+            "console"
+          ]
+        },
+        "ctapipe.core.traits":{
+          "level": "INFO",
+          "handlers": [
+            "console"
+          ]
+        },
         "ctapipe.io.hdf5tableio.HDF5TableWriter": {
           "level": "INFO",
           "handlers": [

--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -276,15 +276,17 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     ped_config = config['LSTCalibrationCalculator']['PedestalIntegrator']
     tel_id = ped_config['tel_id']
     # Obtain the (unbiased) extractor used for pedestal calculations:
+    pedestal_extractor_type = ped_config['charge_product']
     pedestal_calibrator = CameraCalibrator(
-        image_extractor_type=ped_config['charge_product'],
-        config=Config(config['LSTCalibrationCalculator']),
+        image_extractor_type=pedestal_extractor_type,
+        config=ped_config,
         subarray=mc_reader.subarray)
 
     # Obtain the (usually biased) extractor used for shower images:
     shower_extractor_type = config['image_extractor']
     shower_calibrator = CameraCalibrator(
-        image_extractor_type=shower_extractor_type, config=Config(config),
+        image_extractor_type=shower_extractor_type,
+        config=Config(config),
         subarray=mc_reader.subarray)
 
     # Since these extractors are now for use on MC, we have to apply the pulse
@@ -301,8 +303,7 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     shower_extractor_window_width = config[config['image_extractor']]['window_width']
 
     # Pulse integration window width for the pedestal estimation:
-    pedestal_extractor_window_width = config['LSTCalibrationCalculator']\
-        ['FixedWindowSum']['window_width']
+    pedestal_extractor_window_width = ped_config[pedestal_extractor_type]['window_width']
 
     # MC pedestals integrated with the unbiased pedestal extractor
     mc_ped_charges = []

--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -279,7 +279,7 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     pedestal_extractor_type = ped_config['charge_product']
     pedestal_calibrator = CameraCalibrator(
         image_extractor_type=pedestal_extractor_type,
-        config=ped_config,
+        config=Config(ped_config),
         subarray=mc_reader.subarray)
 
     # Obtain the (usually biased) extractor used for shower images:

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -338,8 +338,7 @@ def r0_to_dl1(
                                                             config=Config(config),subarray = subarray)
 
         # Component to process interleaved pedestal and flat-fields
-        calib_config = Config(config[config['calibration_product']])
-
+        calib_config = Config({config['calibration_product']: config[config['calibration_product']]})
         calibration_calculator = CalibrationCalculator.from_name(
             config['calibration_product'],
             config=calib_config,

--- a/lstchain/scripts/lstchain_data_r0_to_dl1.py
+++ b/lstchain/scripts/lstchain_data_r0_to_dl1.py
@@ -68,6 +68,11 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    '--systematic-correction-file', '--systematics', type=Path,
+    help='Path to the file with the calibration systematics corrections'
+)
+
+parser.add_argument(
     '--config', '-c', type=Path,
     dest='config_file',
     help='Path to a configuration file. If none is given, a standard configuration is applied',
@@ -188,6 +193,10 @@ def main():
         lst_r0_corrections['calibration_path'] = args.calibration_file
     if args.time_calibration_file is not None:
         lst_r0_corrections['drs4_time_calibration_path'] = args.time_calibration_file
+
+    calib_config = config[config['calibration_product']]
+    if args.systematic_correction_file is not None:
+        calib_config['systematic_correction_path'] = args.systematic_correction_file
 
     r0_to_dl1.r0_to_dl1(
         args.input_file,


### PR DESCRIPTION
The config was not successfully read but the Components, therefore the interleaved events were processed with default trailet values (e.g. charge integration over only 7 samples, which explains the difference on the number of pe with respect to the beginning of night calibration). Also the f-factor systematic correction trailet was not included in the config file