### PR TITLE
Add pytest for source-dependent analysis

### DIFF
--- a/lstchain/conftest.py
+++ b/lstchain/conftest.py
@@ -54,6 +54,13 @@ def temp_dir_observed_files(tmp_path_factory):
     return tmp_path_factory.mktemp("observed_files")
 
 
+@pytest.mark.private_data
+@pytest.fixture(scope="session")
+def temp_dir_observed_srcdep_files(tmp_path_factory):
+    """Temporal common directory for processing observed data."""
+    return tmp_path_factory.mktemp("observed_srcdep_files")
+
+
 @pytest.fixture(scope="session")
 def mc_gamma_testfile():
     """Get a simulated test file."""
@@ -305,6 +312,26 @@ def observed_dl2_file(temp_dir_observed_files, observed_dl1_files, rf_models):
         temp_dir_observed_files
     )
     return real_data_dl2_file
+
+
+@pytest.fixture(scope="session")
+@pytest.mark.private_data
+def observed_srcdep_dl2_file(temp_dir_observed_srcdep_files, observed_dl1_files, rf_models_srcdep):
+    """Produce a source-dependent dl2 file from an observed dl1 file."""
+    real_data_srcdep_dl2_file = temp_dir_observed_srcdep_files / (observed_dl1_files["dl1_file1"].name.replace("dl1", "dl2"))
+    srcdep_config_file = config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
+    run_program(
+        "lstchain_dl1_to_dl2",
+        "--input-file",
+        observed_dl1_files["dl1_file1"],
+        "--path-models",
+        rf_models_srcdep["path"],
+        "--output-dir",
+        temp_dir_observed_srcdep_files,
+        "--config",
+        srcdep_config_file,
+    )
+    return real_data_srcdep_dl2_file
 
 
 @pytest.fixture(scope="session")

--- a/lstchain/conftest.py
+++ b/lstchain/conftest.py
@@ -211,7 +211,7 @@ def simulated_srcdep_dl2_file(temp_dir_simulated_srcdep_files, simulated_dl1_fil
     using the random forest test models.
     """
     srcdep_dl2_file = temp_dir_simulated_srcdep_files / "dl2_gamma_test_large.h5"
-    srcdep_config_file = config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
+    srcdep_config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
     run_program(
         "lstchain_dl1_to_dl2",
         "--input-file",
@@ -276,7 +276,7 @@ def rf_models_srcdep(temp_dir_simulated_srcdep_files, simulated_dl1_file):
     file_model_gh_sep_srcdep = models_srcdep_path / "cls_gh.sav"
     file_model_disp_norm_srcdep = models_srcdep_path / "reg_disp_norm.sav"
     file_model_disp_sign_srcdep = models_srcdep_path / "cls_disp_sign.sav"
-    srcdep_config_file = config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
+    srcdep_config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
 
     run_program(
         "lstchain_mc_trainpipe",
@@ -319,7 +319,7 @@ def observed_dl2_file(temp_dir_observed_files, observed_dl1_files, rf_models):
 def observed_srcdep_dl2_file(temp_dir_observed_srcdep_files, observed_dl1_files, rf_models_srcdep):
     """Produce a source-dependent dl2 file from an observed dl1 file."""
     real_data_srcdep_dl2_file = temp_dir_observed_srcdep_files / (observed_dl1_files["dl1_file1"].name.replace("dl1", "dl2"))
-    srcdep_config_file = config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
+    srcdep_config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
     run_program(
         "lstchain_dl1_to_dl2",
         "--input-file",

--- a/lstchain/conftest.py
+++ b/lstchain/conftest.py
@@ -198,6 +198,27 @@ def simulated_dl2_file(temp_dir_simulated_files, simulated_dl1_file, rf_models):
 
 
 @pytest.fixture(scope="session")
+def simulated_srcdep_dl2_file(temp_dir_simulated_srcdep_files, simulated_dl1_file, rf_models_srcdep):
+    """
+    Produce the test source-dependent dl2 file from the simulated dl1 test file
+    using the random forest test models.
+    """
+    srcdep_dl2_file = temp_dir_simulated_srcdep_files / "dl2_gamma_test_large.h5"
+    srcdep_config_file = config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
+    run_program(
+        "lstchain_dl1_to_dl2",
+        "--input-file",
+        simulated_dl1_file,
+        "--path-models",
+        rf_models_srcdep["path"],
+        "--output-dir",
+        temp_dir_simulated_srcdep_files,
+        "--config",
+        srcdep_config_file,
+    )
+    return srcdep_dl2_file
+
+@pytest.fixture(scope="session")
 def fake_dl1_proton_file(temp_dir_simulated_files, simulated_dl1_file):
     """
     Produce a fake dl1 proton file by copying the dl2 gamma test file

--- a/lstchain/io/__init__.py
+++ b/lstchain/io/__init__.py
@@ -1,4 +1,9 @@
-from .config import get_standard_config, replace_config, read_configuration_file
+from .config import (
+    get_standard_config,
+    get_srcdep_config,
+    replace_config, 
+    read_configuration_file,
+)
 from .lstcontainers import (
     DL1ParametersContainer,
     DispContainer,
@@ -27,6 +32,7 @@ from .io import (
 )
 
 standard_config = get_standard_config()
+srcdep_config = get_srcdep_config()
 
 __all__ = [
     'replace_config',

--- a/lstchain/io/config.py
+++ b/lstchain/io/config.py
@@ -5,6 +5,7 @@ from copy import copy
 __all__ = [
     'get_cleaning_parameters',
     'get_standard_config',
+    'get_srcdep_config',
     'read_configuration_file',
     'replace_config',
 ]
@@ -41,6 +42,16 @@ def get_standard_config():
     standard_config_file = os.path.join(os.path.dirname(__file__), "../data/lstchain_standard_config.json")
     return read_configuration_file(standard_config_file)
 
+def get_srcdep_config():
+    """
+    Load the config for source-dependent analysis from the file 'data/lstchain_src_dep_config.json'
+
+    Returns
+    -------
+    dict
+    """
+    srcdep_config_file = os.path.join(os.path.dirname(__file__), "../data/lstchain_src_dep_config.json")
+    return read_configuration_file(srcdep_config_file)
 
 def replace_config(base_config, new_config):
     """

--- a/lstchain/io/tests/test_config.py
+++ b/lstchain/io/tests/test_config.py
@@ -4,6 +4,9 @@ from lstchain.io.config import get_cleaning_parameters
 def test_get_standard_config():
     config.get_standard_config()
 
+def test_get_srcdep_config():
+    config.get_srcdep_config()
+
 def test_replace_config():
     a = dict(toto=1, tata=2)
     b = dict(tata=3, tutu=4)

--- a/lstchain/io/tests/test_config.py
+++ b/lstchain/io/tests/test_config.py
@@ -5,7 +5,11 @@ def test_get_standard_config():
     config.get_standard_config()
 
 def test_get_srcdep_config():
-    config.get_srcdep_config()
+    srcdep_config = config.get_srcdep_config()
+    assert srcdep_config['source_dependent'] == True
+    assert srcdep_config['mc_nominal_source_x_deg'] == 0.4
+    assert srcdep_config['observation_mode'] == 'wobble'
+    assert srcdep_config['n_off_wobble'] == 3
 
 def test_replace_config():
     a = dict(toto=1, tata=2)

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -313,20 +313,20 @@ def build_models(filegammas, fileprotons,
         # if source-dependent parameters are already in dl1 data, just read those data
         # if not, source-dependent parameters are added here
         if dl1_params_src_dep_lstcam_key in get_dataset_keys(filegammas):
-            src_dep_df_gamma = get_srcdep_params(filegammas, 'on')
-        
+            src_dep_df_gamma = get_srcdep_params(filegammas)
+         
         else:
             subarray_info = SubarrayDescription.from_hdf(filegammas)
             tel_id = config["allowed_tels"][0] if "allowed_tels" in config else 1
             focal_length = subarray_info.tel[tel_id].optics.equivalent_focal_length
             src_dep_df_gamma = get_source_dependent_parameters(df_gamma, config, focal_length=focal_length)
-            
+
         df_gamma = pd.concat([df_gamma, src_dep_df_gamma['on']], axis=1)
 
         # if source-dependent parameters are already in dl1 data, just read those data
         # if not, source-dependent parameters are added here
         if dl1_params_src_dep_lstcam_key in get_dataset_keys(fileprotons):
-            src_dep_df_proton = get_srcdep_params(fileprotons, 'on')
+            src_dep_df_proton = get_srcdep_params(fileprotons)
 
         else:
             subarray_info = SubarrayDescription.from_hdf(fileprotons)

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -297,6 +297,7 @@ def test_lstchain_dl1_to_dl2(simulated_dl2_file):
     assert "reco_src_x" in dl2_df.columns
     assert "reco_src_y" in dl2_df.columns
 
+
 def test_lstchain_dl1_to_dl2_srcdep(simulated_srcdep_dl2_file):
     assert simulated_srcdep_dl2_file.is_file()
     dl2_srcdep_df = get_srcdep_params(simulated_srcdep_dl2_file)
@@ -312,7 +313,8 @@ def test_lstchain_dl1_to_dl2_srcdep(simulated_srcdep_dl2_file):
     assert "reco_disp_dx" in dl2_srcdep_df['on'].columns
     assert "reco_disp_dy" in dl2_srcdep_df['on'].columns
     assert "reco_src_x" in dl2_srcdep_df['on'].columns
-    assert "reco_src_y" in dl2_srcdep_df['on'].columns
+    assert "reco_src_y" in dl2_srcdep_df['on'].columns    
+
 
 @pytest.mark.private_data
 def test_lstchain_find_pedestals(temp_dir_observed_files, observed_dl1_files):
@@ -341,6 +343,32 @@ def test_lstchain_observed_dl1_to_dl2(observed_dl2_file):
     assert "reco_src_y" in dl2_df.columns
     assert "reco_disp_dx" in dl2_df.columns
     assert "reco_disp_dy" in dl2_df.columns
+
+
+@pytest.mark.private_data
+def test_lstchain_observed_dl1_to_dl2_srcdep(observed_srcdep_dl2_file):
+    assert observed_srcdep_dl2_file.is_file()
+    dl2_srcdep_df = get_srcdep_params(observed_srcdep_dl2_file)
+    srcdep_assumed_positions = ['on', 'off_090', 'off_180', 'off_270']
+    srcdep_dl2_params = [
+        'expected_src_x',
+        'expected_src_y',
+        'dist',
+        'alpha',
+        'time_gradient_from_source',
+        'skewness_from_source',
+        'gammaness',
+        'reco_type',
+        'reco_energy',
+        'reco_disp_dx',
+        'reco_disp_dy',
+        'reco_src_x',
+        'reco_src_y'
+    ]
+
+    for srcdep_assumed_position in srcdep_assumed_positions:
+        for srcdep_dl2_param in srcdep_dl2_params:
+            assert srcdep_dl2_param in dl2_srcdep_df[srcdep_assumed_position].columns
 
 
 def test_dl1ab(simulated_dl1ab):

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -184,6 +184,13 @@ def test_lstchain_mc_trainpipe(rf_models):
     assert rf_models["gh_sep"].is_file()
 
 
+def test_lstchain_mc_trainpipe_srcdep(rf_models_srcdep):
+    assert rf_models_srcdep["energy"].is_file()
+    assert rf_models_srcdep["disp_norm"].is_file()
+    assert rf_models_srcdep["disp_sign"].is_file()
+    assert rf_models_srcdep["gh_sep"].is_file()
+
+
 def test_lstchain_mc_rfperformance(tmp_path, simulated_dl1_file, fake_dl1_proton_file):
     gamma_file = simulated_dl1_file
     proton_file = fake_dl1_proton_file

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -21,7 +21,6 @@ from lstchain.io.io import (
     dl1_params_tel_mon_ped_key,
     dl1_params_tel_mon_cal_key,
     dl1_params_tel_mon_flat_key,
-    dl1_params_src_dep_lstcam_key,
 )
 
 from lstchain.io.config import get_standard_config

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -297,6 +297,23 @@ def test_lstchain_dl1_to_dl2(simulated_dl2_file):
     assert "reco_src_x" in dl2_df.columns
     assert "reco_src_y" in dl2_df.columns
 
+def test_lstchain_dl1_to_dl2_srcdep(simulated_srcdep_dl2_file):
+    assert simulated_srcdep_dl2_file.is_file()
+    dl2_srcdep_df = get_srcdep_params(simulated_srcdep_dl2_file)
+    assert "expected_src_x" in dl2_srcdep_df['on'].columns
+    assert "expected_src_y" in dl2_srcdep_df['on'].columns
+    assert "dist" in dl2_srcdep_df['on'].columns
+    assert "alpha" in dl2_srcdep_df['on'].columns
+    assert "time_gradient_from_source" in dl2_srcdep_df['on'].columns
+    assert "skewness_from_source" in dl2_srcdep_df['on'].columns
+    assert "gammaness" in dl2_srcdep_df['on'].columns
+    assert "reco_type" in dl2_srcdep_df['on'].columns
+    assert "reco_energy" in dl2_srcdep_df['on'].columns
+    assert "reco_disp_dx" in dl2_srcdep_df['on'].columns
+    assert "reco_disp_dy" in dl2_srcdep_df['on'].columns
+    assert "reco_src_x" in dl2_srcdep_df['on'].columns
+    assert "reco_src_y" in dl2_srcdep_df['on'].columns
+
 @pytest.mark.private_data
 def test_lstchain_find_pedestals(temp_dir_observed_files, observed_dl1_files):
     run_program(

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -17,6 +17,7 @@ from lstchain.io.io import (
     dl2_params_lstcam_key,
     dl1_images_lstcam_key,
     get_dataset_keys,
+    get_srcdep_params,
     dl1_params_tel_mon_ped_key,
     dl1_params_tel_mon_cal_key,
     dl1_params_tel_mon_flat_key,
@@ -24,6 +25,7 @@ from lstchain.io.io import (
 )
 
 from lstchain.io.config import get_standard_config
+
 import json
 
 
@@ -65,20 +67,16 @@ def simulated_dl1ab(temp_dir_simulated_files, simulated_dl1_file):
     run_program("lstchain_dl1ab", "-f", simulated_dl1_file, "-o", output_file)
     return output_file
 
+def test_add_source_dependent_parameters(temp_dir_simulated_srcdep_files, simulated_dl1_file):
+    shutil.copy(simulated_dl1_file, temp_dir_simulated_srcdep_files / "dl1_copy.h5")
+    dl1_file = temp_dir_simulated_srcdep_files / "dl1_copy.h5"
+    run_program("lstchain_add_source_dependent_parameters", "-f", dl1_file)
+    dl1_params_src_dep = get_srcdep_params(dl1_file)
 
-def test_add_source_dependent_parameters(simulated_dl1_file):
-    run_program("lstchain_add_source_dependent_parameters", "-f", simulated_dl1_file)
-    dl1_params_src_dep = pd.read_hdf(
-        simulated_dl1_file, key=dl1_params_src_dep_lstcam_key
-    )
-    dl1_params_src_dep.columns = pd.MultiIndex.from_tuples(
-        [
-            tuple(col[1:-1].replace("'", "").replace(" ", "").split(","))
-            for col in dl1_params_src_dep.columns
-        ]
-    )
-    assert "alpha" in dl1_params_src_dep["on"].columns
-
+    assert 'alpha' in dl1_params_src_dep['on'].columns
+    assert 'dist' in dl1_params_src_dep['on'].columns
+    assert 'time_gradient_from_source' in dl1_params_src_dep['on'].columns
+    assert 'skewness_from_source' in dl1_params_src_dep['on'].columns
 
 @pytest.fixture(scope="session")
 def merged_simulated_dl1_file(simulated_dl1_file, temp_dir_simulated_files):

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -90,7 +90,7 @@ def test_content_dl1(simulated_dl1_file):
         assert 'obs_id' in params_table.colnames
 
 
-def test_get_source_dependent_parameters(simulated_dl1_file):
+def test_get_source_dependent_parameters_mc(simulated_dl1_file):
     from lstchain.reco.dl1_to_dl2 import get_source_dependent_parameters
 
     # for gamma MC
@@ -109,11 +109,46 @@ def test_get_source_dependent_parameters(simulated_dl1_file):
     assert (src_dep_df_gamma['on']['expected_src_y'] == dl1_params['src_y']).all()
 
     np.testing.assert_allclose(
-        src_dep_df_proton['on']['expected_src_x'], 0.195, rtol=1e-2
+        src_dep_df_proton['on']['expected_src_x'], 0.195, atol=1e-2
     )
     np.testing.assert_allclose(
         src_dep_df_proton['on']['expected_src_y'], 0., atol=1e-2
     )
+
+@pytest.mark.private_data
+def test_get_source_dependent_parameters_observed(observed_dl1_files):
+    from lstchain.reco.dl1_to_dl2 import get_source_dependent_parameters
+
+    # on observation data
+    srcdep_config['observation_mode']='on'
+    dl1_params = pd.read_hdf(observed_dl1_files["dl1_file1"], key=dl1_params_lstcam_key)
+    src_dep_df_on = get_source_dependent_parameters(dl1_params, srcdep_config)
+
+    # wobble observation data
+    srcdep_config['observation_mode']='wobble'
+    dl1_params['alt_tel'] += np.deg2rad(0.4) 
+    src_dep_df_wobble = get_source_dependent_parameters(dl1_params, srcdep_config)
+
+    assert 'alpha' in src_dep_df_on['on'].columns
+    assert 'dist' in src_dep_df_on['on'].columns
+    assert 'time_gradient_from_source' in src_dep_df_on['on'].columns
+    assert 'skewness_from_source' in src_dep_df_on['on'].columns
+    assert (src_dep_df_on['on']['expected_src_x'] == 0).all()
+    assert (src_dep_df_on['on']['expected_src_y'] == 0).all()
+
+    np.testing.assert_allclose(
+        src_dep_df_wobble['on']['expected_src_x'], -0.195, atol=1e-2
+    )
+    np.testing.assert_allclose(
+        src_dep_df_wobble['on']['expected_src_y'], 0., atol=1e-2
+    )
+    np.testing.assert_allclose(
+        src_dep_df_wobble['off_180']['expected_src_x'], 0.195, atol=1e-2
+    )
+    np.testing.assert_allclose(
+        src_dep_df_wobble['off_180']['expected_src_y'], 0., atol=1e-2
+    )
+
 
 def test_build_models(simulated_dl1_file, rf_models):
     from lstchain.reco.dl1_to_dl2 import build_models

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 import tables
 
-from lstchain.io import standard_config
+from lstchain.io import standard_config, srcdep_config
 from lstchain.io.io import dl1_params_lstcam_key, dl2_params_lstcam_key, dl1_images_lstcam_key
 from lstchain.reco.utils import filter_events
 
@@ -93,10 +93,27 @@ def test_content_dl1(simulated_dl1_file):
 def test_get_source_dependent_parameters(simulated_dl1_file):
     from lstchain.reco.dl1_to_dl2 import get_source_dependent_parameters
 
+    # for gamma MC
     dl1_params = pd.read_hdf(simulated_dl1_file, key=dl1_params_lstcam_key)
-    src_dep_df = get_source_dependent_parameters(dl1_params, standard_config)
-    assert "alpha" in src_dep_df['on'].columns
+    src_dep_df_gamma = get_source_dependent_parameters(dl1_params, srcdep_config)
 
+    # for proton MC
+    dl1_params.mc_type = 101
+    src_dep_df_proton = get_source_dependent_parameters(dl1_params, srcdep_config)
+
+    assert 'alpha' in src_dep_df_gamma['on'].columns
+    assert 'dist' in src_dep_df_gamma['on'].columns
+    assert 'time_gradient_from_source' in src_dep_df_gamma['on'].columns
+    assert 'skewness_from_source' in src_dep_df_gamma['on'].columns
+    assert (src_dep_df_gamma['on']['expected_src_x'] == dl1_params['src_x']).all()
+    assert (src_dep_df_gamma['on']['expected_src_y'] == dl1_params['src_y']).all()
+
+    np.testing.assert_allclose(
+        src_dep_df_proton['on']['expected_src_x'], 0.195, rtol=1e-2
+    )
+    np.testing.assert_allclose(
+        src_dep_df_proton['on']['expected_src_y'], 0., atol=1e-2
+    )
 
 def test_build_models(simulated_dl1_file, rf_models):
     from lstchain.reco.dl1_to_dl2 import build_models


### PR DESCRIPTION
This PR implemented pytest codes for source-dependent analysis (MC and real data).
I'd like to implement it before #875 , then I can also add additional pytest for source-dependent DL3 production.