### PR TITLE
Update ctapipe_io_lst requirement to 0.15.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,6 @@ dependencies:
   - pymongo
   - seaborn
   - pip:
-      - ctapipe_io_lst~=0.14.0
+      - ctapipe_io_lst~=0.15.0
       - ctaplot~=0.5.5
       - pyirf~=0.6.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'astropy~=4.2',
         'bokeh~=1.0',
         'ctapipe~=0.12.0',
-        'ctapipe_io_lst~=0.14.0',
+        'ctapipe_io_lst~=0.15.0',
         'ctaplot~=0.5.5',
         'eventio>=1.5.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=0.19.0',


### PR DESCRIPTION
Contains the fix to the case for ext devices (TIB / UCTS) failing mid of a subrun