### PR TITLE
Fix link logic in create_pro_symlink, make link replacement atomic

### DIFF
--- a/lstchain/onsite.py
+++ b/lstchain/onsite.py
@@ -6,17 +6,21 @@ def create_symlink_overwrite(link, target):
     '''
     Create a symlink from link to target, replacing an existing link atomically.
     '''
+    target = target.resolve()
+
     if not link.exists():
         link.symlink_to(target)
         return
 
-    if link.resolve() == target.resolve():
+    if link.resolve() == target:
         # nothing to do
         return
 
     # create the symlink in a tempfile, then replace the original one
     # in one step to avoid race conditions
-    tmp = Path(tempfile.mktemp(prefix='tmp_symlink'))
+    tmp = tempfile.NamedTemporaryFile(prefix='tmp_symlink_', delete=True)
+    tmp.close()
+    tmp = Path(tmp.name)
     tmp.symlink_to(target)
     tmp.replace(link)
 

--- a/lstchain/scripts/onsite/onsite_create_calibration_file.py
+++ b/lstchain/scripts/onsite/onsite_create_calibration_file.py
@@ -137,7 +137,7 @@ def main():
 
     if pro_symlink:
         pro = "pro"
-        create_pro_symlink(output_dir, prod_id)
+        create_pro_symlink(output_dir)
     else:
         pro = prod_id
 

--- a/lstchain/scripts/onsite/onsite_create_drs4_pedestal_file.py
+++ b/lstchain/scripts/onsite/onsite_create_drs4_pedestal_file.py
@@ -80,7 +80,7 @@ def main():
 
     # update the default production directory
     if pro_symlink:
-        create_pro_symlink(output_dir, prod_id)
+        create_pro_symlink(output_dir)
 
     # make log dir
     log_dir = f"{output_dir}/log"

--- a/lstchain/scripts/onsite/onsite_create_drs4_time_file.py
+++ b/lstchain/scripts/onsite/onsite_create_drs4_time_file.py
@@ -98,7 +98,7 @@ def main():
     # update the default production directory
     if pro_symlink:
         pro = "pro"
-        create_pro_symlink(output_dir, prod_id)
+        create_pro_symlink(output_dir)
     else:
         pro = prod_id
 

--- a/lstchain/scripts/onsite/onsite_create_ffactor_systematics_file.py
+++ b/lstchain/scripts/onsite/onsite_create_ffactor_systematics_file.py
@@ -70,7 +70,7 @@ def main():
 
     if pro_symlink:
         pro = "pro"
-        create_pro_symlink(output_dir, prod_id)
+        create_pro_symlink(output_dir)
     else:
         pro = prod_id
 

--- a/lstchain/tests/test_onsite.py
+++ b/lstchain/tests/test_onsite.py
@@ -1,0 +1,24 @@
+from lstchain.onsite import create_symlink_overwrite
+
+
+def test_create_symlink_overwrite(tmp_path):
+    target1 = tmp_path / 'target1'
+    target1.open('w').close()
+
+    target2 = tmp_path / 'target2'
+    target2.open('w').close()
+
+    # link not yet existing case
+    link = tmp_path / 'link'
+    create_symlink_overwrite(link, target1)
+    assert link.resolve() == target1.resolve()
+
+    # link points to the wrong target, recreate
+    create_symlink_overwrite(link, target2)
+    assert link.resolve() == target2.resolve()
+
+
+    # link exists, points already to the target, this should be a no-op
+    # but I didn't find a good way to verify that it really is one
+    create_symlink_overwrite(link, target2)
+    assert link.resolve() == target2.resolve()


### PR DESCRIPTION
@FrancaCassol reported problems with the filter scan jobs that might be due to our LDAP problems or due to a race condition when the symlink is replaced.

Due to a wrong comparison (`is not` instead of `!=`) the link was always recreated, which might lead to problems if something tries to read from it while another job is recreating it.

Here I make the check properly that no action is performed if the link is already correct and for the case it really needs to be modified, the change happens atomically by first creating a temporary link and then replacing the existing one for the temporary link.