### PR TITLE
Allow only LST1 in standard config

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -1,7 +1,7 @@
 {
   "source_config" : {
     "EventSource": {
-      "allowed_tels": [1, 2, 3, 4],
+      "allowed_tels": [1],
       "max_events": null
     },
     "LSTEventSource": {


### PR DESCRIPTION
I think we always process LST1 alone with the "new" MC, so that should be standard.