### PR TITLE
replace only first occurrence on dl2 output filename

### DIFF
--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -166,7 +166,7 @@ def main():
                 dl2_srcindep = dl2_df[srcindep_keys]
 
     os.makedirs(args.output_dir, exist_ok=True)
-    output_file = os.path.join(args.output_dir, os.path.basename(args.input_file).replace('dl1', 'dl2'))
+    output_file = os.path.join(args.output_dir, os.path.basename(args.input_file).replace('dl1', 'dl2', 1))
 
     if os.path.exists(output_file):
         raise IOError(output_file + ' exists, exiting.')


### PR DESCRIPTION
If the string `dl1` appears more than once on the dl2 filename, all occurrences will be replaced.

For example, in a file named `dl1_electron_20deg_180deg_dl1ab_tune_MC_to_Crab_testing.h5` both `dl1` strings will be replaced.

Another option could be using a regular expression, but I think this solution is much easier and straight forward