### PR TITLE
Improve DL1 check treatment of problematic data

### DIFF
--- a/lstchain/datachecks/dl1_checker.py
+++ b/lstchain/datachecks/dl1_checker.py
@@ -1234,8 +1234,7 @@ def merge_dl1datacheck_files(file_list):
                 else:
                     table.append(file.root.dl1datacheck['tablename'][:])
             else:
-                logger.warning('Table', tablename, 'is missing in file ' +
-                               str(filename))
+                logger.warning(f'Table {tablename} is missing in file {filename}')
         file.close()
 
     merged_file.close()

--- a/lstchain/datachecks/dl1_checker.py
+++ b/lstchain/datachecks/dl1_checker.py
@@ -1227,7 +1227,7 @@ def merge_dl1datacheck_files(file_list):
 
         for table, tablename in zip([pedestals, flatfield, cosmics],
                                     ['pedestals', 'flatfield', 'cosmics']):
-            if '/dl1datacheck/'+tablename in file.root.datacheck:
+            if tablename in file.root.dl1datacheck:
                 if table is None:
                     table = file.copy_node('/dl1datacheck', name=tablename,
                                            newparent=merged_file.root.dl1datacheck)

--- a/lstchain/datachecks/dl1_checker.py
+++ b/lstchain/datachecks/dl1_checker.py
@@ -1212,49 +1212,30 @@ def merge_dl1datacheck_files(file_list):
     merged_file.create_group('/', 'dl1datacheck')
     merged_file.create_group('/', 'instrument')
 
-    # The tables in the merged file will be copied from the first file. If a
-    # table is missing in the first file (e.g. pedestals) it will be left
-    # empty in the whole merged file.
-
-    if '/dl1datacheck/pedestals' in first_file.root.dl1datacheck:
-        pedestals = \
-            first_file.copy_node('/dl1datacheck', name='pedestals',
-                                 newparent=merged_file.root.dl1datacheck)
-    else:
-        pedestals = None
-
-    if '/dl1datacheck/flatfield' in first_file.root.dl1datacheck:
-        flatfield = \
-            first_file.copy_node('/dl1datacheck', name='flatfield',
-                                 newparent=merged_file.root.dl1datacheck)
-    else:
-        flatfield = None
-
-    # the ones below are compulsory, an exception will be raised if not present:
-    cosmics = first_file.copy_node('/dl1datacheck', name='cosmics',
-                                   newparent=merged_file.root.dl1datacheck)
+    # The tables below are the same in all merged files, so they are just
+    # copied from the first file:
     first_file.copy_node('/dl1datacheck', name='histogram_binning',
                          newparent=merged_file.root.dl1datacheck)
     first_file.copy_node('/dl1datacheck', name='used_trigger_tag',
                          newparent=merged_file.root.dl1datacheck)
     first_file.close()
 
-    for filename in file_list[1:]:
+    # Now merge the rest of the other tables for all files:
+    pedestals = flatfield = cosmics = None
+    for filename in file_list:
         file = tables.open_file(filename)
-        if pedestals is not None:
-            if '/dl1datacheck/pedestals' in file.root.dl1datacheck:
-                pedestals.append(file.root.dl1datacheck.pedestals[:])
-            else:
-                logger.warning('Table pedestals is missing in file ' +
-                               str(filename))
-        if flatfield is not None:
-            if '/dl1datacheck/flatfield' in file.root.dl1datacheck:
-                flatfield.append(file.root.dl1datacheck.flatfield[:])
-            else:
-                logger.warning('Table flatfield is missing in file ' +
-                               str(filename))
 
-        cosmics.append(file.root.dl1datacheck.cosmics[:])
+        for table, tablename in zip([pedestals, flatfield, cosmics],
+                                    ['pedestals', 'flatfield', 'cosmics']):
+            if '/dl1datacheck/'+tablename in file.root.datacheck:
+                if table is None:
+                    table = file.copy_node('/dl1datacheck', name=tablename,
+                                           newparent=merged_file.root.dl1datacheck)
+                else:
+                    table.append(file.root.dl1datacheck['tablename'][:])
+            else:
+                logger.warning('Table', tablename, 'is missing in file ' +
+                               str(filename))
         file.close()
 
     merged_file.close()

--- a/lstchain/datachecks/dl1_checker.py
+++ b/lstchain/datachecks/dl1_checker.py
@@ -1221,18 +1221,20 @@ def merge_dl1datacheck_files(file_list):
     first_file.close()
 
     # Now merge the rest of the other tables for all files:
-    pedestals = flatfield = cosmics = None
+    newtables = {}
+
     for filename in file_list:
         file = tables.open_file(filename)
-
-        for table, tablename in zip([pedestals, flatfield, cosmics],
-                                    ['pedestals', 'flatfield', 'cosmics']):
+        for tablename in ['pedestals', 'flatfield', 'cosmics']:
             if tablename in file.root.dl1datacheck:
-                if table is None:
-                    table = file.copy_node('/dl1datacheck', name=tablename,
-                                           newparent=merged_file.root.dl1datacheck)
+                if tablename in newtables:
+                    newtables[tablename].append(file.root.dl1datacheck[
+                                              tablename][:])
                 else:
-                    table.append(file.root.dl1datacheck['tablename'][:])
+                    newtables[tablename] = file.copy_node(
+                            '/dl1datacheck',
+                            name=tablename,
+                            newparent=merged_file.root.dl1datacheck)
             else:
                 logger.warning(f'Table {tablename} is missing in file {filename}')
         file.close()


### PR DESCRIPTION
Now the lack of interleaved pedestal or flatfield events in the first subrun no longer implies that the corresponding type of events is ignored in the rest of the subruns. 