### PR TITLE
Correct the R0 baseline subtraction in case of simulation events

### DIFF
--- a/lstchain/tools/lstchain_create_calibration_file.py
+++ b/lstchain/tools/lstchain_create_calibration_file.py
@@ -151,10 +151,10 @@ class CalibrationHDF5Writer(Tool):
 
                 # if simulation use not calibrated and not gain selected R0 waveform
                 if self.simulation:
-                    event.r1.tel[tel_id].waveform = (
-                            event.r0.tel[tel_id].waveform.astype(np.float32)
-                            -np.median(event.mon.tel[tel_id].calibration.pedestal_per_sample, axis=1)[...,np.newaxis, np.newaxis]
-                    )
+                    # estimate offset of each channel from the camera median pedestal value
+                    offset = np.median(event.mon.tel[tel_id].calibration.pedestal_per_sample, axis=1).round()
+                    event.r1.tel[tel_id].waveform = event.r0.tel[tel_id].waveform.astype(np.float32) - offset[:, np.newaxis, np.newaxis]
+                    
 
                 if count % 1000 == 0 and count> self.events_to_skip:
                     self.log.debug(f"Event {count}")

--- a/lstchain/tools/lstchain_create_calibration_file.py
+++ b/lstchain/tools/lstchain_create_calibration_file.py
@@ -152,7 +152,7 @@ class CalibrationHDF5Writer(Tool):
                 # if simulation use not calibrated and not gain selected R0 waveform
                 if self.simulation:
                     event.r1.tel[tel_id].waveform = (
-                            event.r0.tel[tel_id].waveform.astype(float)
+                            event.r0.tel[tel_id].waveform.astype(np.float32)
                             -np.median(event.mon.tel[tel_id].calibration.pedestal_per_sample, axis=1)[...,np.newaxis, np.newaxis]
                     )
 

--- a/lstchain/tools/lstchain_create_calibration_file.py
+++ b/lstchain/tools/lstchain_create_calibration_file.py
@@ -153,7 +153,7 @@ class CalibrationHDF5Writer(Tool):
                 if self.simulation:
                     event.r1.tel[tel_id].waveform = (
                             event.r0.tel[tel_id].waveform.astype(float)
-                            - event.mon.tel[tel_id].calibration.pedestal_per_sample[..., np.newaxis]
+                            -np.median(event.mon.tel[tel_id].calibration.pedestal_per_sample, axis=1)[...,np.newaxis, np.newaxis]
                     )
 
                 if count % 1000 == 0 and count> self.events_to_skip:


### PR DESCRIPTION
At present we subtract the sim_tel calibration pedestals (pixel per pixel) in order to obtain the uncalibrated R1 with baseline = 0 but the sim_tel calibration pedestals are affected by sim_tel calibration errors (supposed errors on the calibration values) that are then propagated to the waveform. In this PR the camera median pedestals are subtracted instead, which are around the orginal pedestal shift,  since the calibration errors are gaussian. In future releases, we could think to use the meta sim_tel information to directly subtracted the shift