### PR TITLE
DL3 energy-dependent alpha cut

### DIFF
--- a/docs/examples/dl3_tool_config.json
+++ b/docs/examples/dl3_tool_config.json
@@ -16,6 +16,7 @@
     "global_alpha_cut": 10,
     "global_theta_cut": 0.2,
     "theta_containment": 0.68,
+    "alpha_containment": 0.68,
     "allowed_tels": [1]
   }
 }

--- a/docs/examples/dl3_tool_config.json
+++ b/docs/examples/dl3_tool_config.json
@@ -23,6 +23,9 @@
     "min_theta_cut": 0.05,
     "max_theta_cut": 0.32,
     "fill_theta_cut": 0.32,
+    "min_alpha_cut": 1,
+    "max_alpha_cut": 45,
+    "fill_alpha_cut": 45,
     "allowed_tels": [1]
   }
 }

--- a/docs/examples/irf_tool_config.json
+++ b/docs/examples/irf_tool_config.json
@@ -16,6 +16,7 @@
     "global_alpha_cut": 10,
     "global_theta_cut": 0.2,
     "theta_containment": 0.68,
+    "alpha_containment": 0.68,
     "allowed_tels": [1]
   },
   "DataBinning": {

--- a/docs/examples/irf_tool_config.json
+++ b/docs/examples/irf_tool_config.json
@@ -23,6 +23,9 @@
     "min_theta_cut": 0.05,
     "max_theta_cut": 0.32,
     "fill_theta_cut": 0.32,
+    "min_alpha_cut": 1,
+    "max_alpha_cut": 45,
+    "fill_alpha_cut": 45,
     "allowed_tels": [1]
   },
   "DataBinning": {

--- a/lstchain/data/lstchain_src_dep_config.json
+++ b/lstchain/data/lstchain_src_dep_config.json
@@ -60,7 +60,7 @@
   },
 
   "random_forest_energy_regressor_args": {
-    "max_depth": 50,
+    "max_depth": 30,
     "min_samples_leaf": 2,
     "n_jobs": 4,
     "n_estimators": 150,
@@ -69,7 +69,7 @@
     "max_features": "auto",
     "max_leaf_nodes": null,
     "min_impurity_decrease": 0.0,
-    "min_samples_split": 2,
+    "min_samples_split": 10,
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
@@ -78,7 +78,7 @@
   },
 
   "random_forest_disp_regressor_args": {
-    "max_depth": 50,
+    "max_depth": 30,
     "min_samples_leaf": 2,
     "n_jobs": 4,
     "n_estimators": 150,
@@ -87,7 +87,7 @@
     "max_features": "auto",
     "max_leaf_nodes": null,
     "min_impurity_decrease": 0.0,
-    "min_samples_split": 2,
+    "min_samples_split": 10,
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
@@ -96,12 +96,12 @@
   },
 
   "random_forest_disp_classifier_args": {
-    "max_depth": 100,
+    "max_depth": 30,
     "min_samples_leaf": 2,
     "n_jobs": 4,
     "n_estimators": 100,
     "criterion": "gini",
-    "min_samples_split": 2,
+    "min_samples_split": 10,
     "min_weight_fraction_leaf": 0.0,
     "max_features": "auto",
     "max_leaf_nodes": null,
@@ -115,12 +115,12 @@
   },
 
   "random_forest_particle_classifier_args": {
-    "max_depth": 100,
+    "max_depth": 30,
     "min_samples_leaf": 2,
     "n_jobs": 4,
     "n_estimators": 100,
     "criterion": "gini",
-    "min_samples_split": 2,
+    "min_samples_split": 10,
     "min_weight_fraction_leaf": 0.0,
     "max_features": "auto",
     "max_leaf_nodes": null,

--- a/lstchain/io/event_selection.py
+++ b/lstchain/io/event_selection.py
@@ -103,6 +103,22 @@ class DL3Cuts(Component):
         default_value=0.2,
     ).tag(config=True)
 
+    min_alpha_cut = Float(
+        help="Minimum alpha cut (deg) in an energy bin",
+        default_value=1,
+    ).tag(config=True)
+
+    max_alpha_cut = Float(
+        help="Maximum alpha cut (deg) in an energy bin",
+        default_value=45,
+    ).tag(config=True)
+
+    fill_alpha_cut = Float(
+        help="Fill value of alpha cut (deg) in an energy bin with fewer " +
+            "than minimum number of events present",
+        default_value=45,
+    ).tag(config=True)
+
     alpha_containment = Float(
         help="Percentage containment region for alpha cuts",
         default=0.68,
@@ -213,8 +229,7 @@ class DL3Cuts(Component):
         return data[data["alpha"].to_value(u.deg) < self.global_alpha_cut]
 
     def energy_dependent_alpha_cuts(
-            self, data, energy_bins, min_value=1 * u.deg,
-            max_value=90 * u.deg, smoothing=None, min_events=10
+            self, data, energy_bins, smoothing=None
     ):
         """
         Evaluating an optimized energy-dependent alpha cuts, in a given
@@ -227,12 +242,12 @@ class DL3Cuts(Component):
             data["alpha"],
             data["reco_energy"],
             bins=energy_bins,
-            min_value=min_value,
-            max_value=max_value,
-            fill_value=data["alpha"].max(),
+            min_value=self.min_alpha_cut * u.deg,
+            max_value=self.max_alpha_cut * u.deg,
+            fill_value=self.fill_alpha_cut * u.deg,
             percentile=100 * self.alpha_containment,
             smoothing=smoothing,
-            min_events=min_events,
+            min_events=self.min_event_p_en_bin,
         )
         return alpha_cuts
         
@@ -246,7 +261,7 @@ class DL3Cuts(Component):
             data["alpha"],
             data["reco_energy"],
             alpha_cuts,
-            operator.le,
+            operator.lt,
         )
         return data[data["selected_alpha"]]
             

--- a/lstchain/io/tests/test_eventselection.py
+++ b/lstchain/io/tests/test_eventselection.py
@@ -43,18 +43,21 @@ def test_dl3_global_cuts():
 
     temp_cuts.global_gh_cut = 0.7
     temp_cuts.global_theta_cut = 0.2
+    temp_cuts.global_alpha_cut = 20
     temp_cuts.allowed_tels = [1, 2]
 
     temp_data = QTable({
         "gh_score": u.Quantity(np.tile(np.arange(0.35, 0.85, 0.05), 3)),
         "reco_energy": np.geomspace(50 * u.GeV, 50 * u.TeV, 30),
         "theta": u.Quantity(np.tile(np.arange(0.05, 0.35, 0.03), 3), unit=u.deg),
+        "alpha": u.Quantity(np.tile(np.arange(5, 85, 8), 3), unit=u.deg),
         "tel_id": u.Quantity(np.repeat([1, 2, 3], 10)),
         "mc_type": u.Quantity(np.repeat([0], 30)),
         })
 
     assert len(temp_cuts.apply_global_gh_cut(temp_data)) == 6
     assert len(temp_cuts.apply_global_theta_cut(temp_data)) == 15
+    assert len(temp_cuts.apply_global_alpha_cut(temp_data)) == 6
     assert len(temp_cuts.allowed_tels_filter(temp_data)) == 20
 
 
@@ -63,12 +66,14 @@ def test_dl3_energy_dependent_cuts():
 
     temp_cuts.gh_max_efficiency = 0.8
     temp_cuts.theta_containment = 0.68
+    temp_cuts.alpha_containment = 0.68
     temp_cuts.min_event_p_en_bin = 2
 
     temp_data = QTable({
         "gh_score": u.Quantity(np.tile(np.arange(0.35, 0.85, 0.05), 3)),
         "reco_energy": np.geomspace(50 * u.GeV, 50 * u.TeV, 30),
         "theta": u.Quantity(np.tile(np.arange(0.05, 0.35, 0.03), 3), unit=u.deg),
+        "alpha": u.Quantity(np.tile(np.arange(5, 85, 8), 3), unit=u.deg),
         "tel_id": u.Quantity(np.repeat([1, 2, 3], 10)),
         "mc_type": u.Quantity(np.repeat([0], 30)),
         })
@@ -82,13 +87,20 @@ def test_dl3_energy_dependent_cuts():
         temp_data, en_range,
     )
 
+    alpha_cut = temp_cuts.energy_dependent_alpha_cuts(
+        temp_data, en_range,
+    )
+
     data_th = temp_cuts.apply_energy_dependent_theta_cuts(temp_data, theta_cut)
     data_gh = temp_cuts.apply_energy_dependent_gh_cuts(temp_data, gh_cut)
+    data_al = temp_cuts.apply_energy_dependent_alpha_cuts(temp_data, alpha_cut)
 
     assert theta_cut["cut"][0] == 0.0908 * u.deg
     assert gh_cut["cut"][1] == 0.3725
+    assert alpha_cut["cut"][0] == 15.88 * u.deg
     assert len(data_th) == 21
     assert len(data_gh) == 26
+    assert len(data_al) == 14
 
 
 def test_data_binning():

--- a/lstchain/tools/lstchain_create_dl3_file.py
+++ b/lstchain/tools/lstchain_create_dl3_file.py
@@ -196,7 +196,7 @@ class DataReductionFITSWriter(Tool):
 
         try:
             with fits.open(self.input_irf) as hdul:
-                self.use_energy_dependent_cuts = (
+                self.use_energy_dependent_gh_cuts = (
                     "GH_CUT" not in hdul["EFFECTIVE AREA"].header
                 )
         except:
@@ -205,11 +205,17 @@ class DataReductionFITSWriter(Tool):
                 " to check for global cut information in the Header value"
             )
 
+        if self.source_dep:
+            with fits.open(self.input_irf) as hdul:
+                self.use_energy_dependent_alpha_cuts = (
+                    "ALPHA_CUT" not in hdul["EFFECTIVE AREA"].header
+                )
+            
     def apply_srcindep_gh_cut(self):
         ''' apply gammaness cut '''
         self.data = self.event_sel.filter_cut(self.data)
 
-        if self.use_energy_dependent_cuts:
+        if self.use_energy_dependent_gh_cuts:
             self.energy_dependent_gh_cuts = QTable.read(
                 self.input_irf, hdu="GH_CUTS"
             )
@@ -238,7 +244,7 @@ class DataReductionFITSWriter(Tool):
 
             data_temp = self.event_sel.filter_cut(data_temp)
             
-            if self.use_energy_dependent_cuts:
+            if self.use_energy_dependent_gh_cuts:
                 self.energy_dependent_gh_cuts = QTable.read(
                     self.input_irf, hdu="GH_CUTS"
                 )
@@ -246,14 +252,30 @@ class DataReductionFITSWriter(Tool):
                 data_temp = self.cuts.apply_energy_dependent_gh_cuts(
                     data_temp, self.energy_dependent_gh_cuts
                 )
+                self.log.info(
+                    "Using gamma efficiency of "
+                    f"{self.energy_dependent_gh_cuts.meta['GH_EFF']}"
+                )
             else:
                 with fits.open(self.input_irf) as hdul:
                     self.cuts.global_gh_cut = hdul[1].header["GH_CUT"]
                 data_temp = self.cuts.apply_global_gh_cut(data_temp)
                     
-            with fits.open(self.input_irf) as hdul:
-                self.cuts.global_alpha_cut = hdul[1].header["AL_CUT"]
-            data_temp = self.cuts.apply_global_alpha_cut(data_temp)
+            if self.use_energy_dependent_alpha_cuts:
+                self.energy_dependent_alpha_cuts = QTable.read(
+                    self.input_irf, hdu="ALPHA_CUTS"
+                )
+                data_temp = self.cuts.apply_energy_dependent_alpha_cuts(
+                    data_temp, self.energy_dependent_alpha_cuts
+                )
+                self.log.info(
+                    "Using alpha containment region of "
+                    f'{self.energy_dependent_alpha_cuts.meta["ALPHA_CONT"]}'
+                )
+            else:
+                with fits.open(self.input_irf) as hdul:
+                    self.cuts.global_alpha_cut = hdul[1].header["AL_CUT"]
+                data_temp = self.cuts.apply_global_alpha_cut(data_temp)
 
             # set expected source positions as reco positions
             set_expected_pos_to_reco_altaz(data_temp)

--- a/lstchain/tools/lstchain_create_dl3_file.py
+++ b/lstchain/tools/lstchain_create_dl3_file.py
@@ -270,7 +270,7 @@ class DataReductionFITSWriter(Tool):
                 )
                 self.log.info(
                     "Using alpha containment region of "
-                    f'{self.energy_dependent_alpha_cuts.meta["ALPHA_CONT"]}'
+                    f'{self.energy_dependent_alpha_cuts.meta["AL_CONT"]}'
                 )
             else:
                 with fits.open(self.input_irf) as hdul:

--- a/lstchain/tools/lstchain_create_dl3_file.py
+++ b/lstchain/tools/lstchain_create_dl3_file.py
@@ -208,7 +208,7 @@ class DataReductionFITSWriter(Tool):
         if self.source_dep:
             with fits.open(self.input_irf) as hdul:
                 self.use_energy_dependent_alpha_cuts = (
-                    "ALPHA_CUT" not in hdul["EFFECTIVE AREA"].header
+                    "AL_CUT" not in hdul["EFFECTIVE AREA"].header
                 )
             
     def apply_srcindep_gh_cut(self):
@@ -263,7 +263,7 @@ class DataReductionFITSWriter(Tool):
                     
             if self.use_energy_dependent_alpha_cuts:
                 self.energy_dependent_alpha_cuts = QTable.read(
-                    self.input_irf, hdu="ALPHA_CUTS"
+                    self.input_irf, hdu="AL_CUTS"
                 )
                 data_temp = self.cuts.apply_energy_dependent_alpha_cuts(
                     data_temp, self.energy_dependent_alpha_cuts

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -243,6 +243,10 @@ class IRFFITSWriter(Tool):
             {"IRFFITSWriter": {"energy_dependent_theta": True}},
             "Uses energy-dependent cuts for theta",
         ),
+        "energy-dependent-alpha": (
+            {"IRFFITSWriter": {"energy_dependent_alpha": True}},
+            "Uses energy-dependent cuts for alpha",
+        ),
     }
 
     def setup(self):

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -509,7 +509,7 @@ class IRFFITSWriter(Tool):
                     )
             else:
                 if self.energy_dependent_alpha:
-                    extra_headers["ALPHA_CONT"] = (
+                    extra_headers["AL_CONT"] = (
                         self.cuts.alpha_containment,
                         "Alpha containment region in percentage"
                     )

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -189,6 +189,11 @@ class IRFFITSWriter(Tool):
         default_value=False,
     ).tag(config=True)
 
+    energy_dependent_alpha = traits.Bool(
+        help="True for applying energy-dependent alpha cuts",
+        default_value=False,
+    ).tag(config=True)
+
     overwrite = traits.Bool(
         help="If True, overwrites existing output file without asking",
         default_value=False,
@@ -211,6 +216,7 @@ class IRFFITSWriter(Tool):
         "gh-efficiency": "DL3Cuts.gh_efficiency",
         "theta-containment": "DL3Cuts.theta_containment",
         "global-theta-cut": "DL3Cuts.global_theta_cut",
+        "alpha-containment": "DL3Cuts.alpha_containment",
         "global-alpha-cut": "DL3Cuts.global_alpha_cut",
         "allowed-tels": "DL3Cuts.allowed_tels",
         "overwrite": "IRFFITSWriter.overwrite",
@@ -377,30 +383,43 @@ class IRFFITSWriter(Tool):
             )
 
         if self.point_like:
-            if self.energy_dependent_theta:
-                self.theta_cuts = self.cuts.energy_dependent_theta_cuts(
-                    gammas, reco_energy_bins,
-                    min_value=0.05 * u.deg, max_value=0.32 * u.deg,
-                )
-                gammas = self.cuts.apply_energy_dependent_theta_cuts(
-                    gammas, self.theta_cuts
-                )
-                self.log.info(
-                    "Using a containment region for theta of "
-                    f"{self.cuts.theta_containment}"
-                )
-            else:
-                if not self.source_dep:
+            if not self.source_dep:
+                if self.energy_dependent_theta:
+                    self.theta_cuts = self.cuts.energy_dependent_theta_cuts(
+                        gammas, reco_energy_bins,
+                        min_value=0.05 * u.deg, max_value=0.32 * u.deg,
+                    )
+                    gammas = self.cuts.apply_energy_dependent_theta_cuts(
+                        gammas, self.theta_cuts
+                    )
+                    self.log.info(
+                        "Using a containment region for theta of "
+                        f"{self.cuts.theta_containment}"
+                    )
+                else:
                     gammas = self.cuts.apply_global_theta_cut(gammas)
                     self.log.info(
                         "Using a global Theta cut of "
                         f"{self.cuts.global_theta_cut} for point-like IRF"
                     )
+            else:
+                if self.energy_dependent_alpha:
+                    self.alpha_cuts = self.cuts.energy_dependent_alpha_cuts(
+                        gammas, reco_energy_bins,
+                        min_value=1 * u.deg, max_value=90 * u.deg,
+                    )
+                    gammas = self.cuts.apply_energy_dependent_alpha_cuts(
+                        gammas, self.alpha_cuts
+                    )
+                    self.log.info(
+                        "Using a containment region for alpha of "
+                        f"{self.cuts.alpha_containment} %"
+                    )
                 else:
                     gammas = self.cuts.apply_global_alpha_cut(gammas)
                     self.log.info(
-                      'Using a global Alpha cut of '
-                      f'{self.cuts.global_alpha_cut} for point like IRF'
+                        'Using a global Alpha cut of '
+                        f'{self.cuts.global_alpha_cut} for point like IRF'
                     )
 
         if self.mc_particle["gamma"]["mc_type"] == "point_like":
@@ -485,11 +504,17 @@ class IRFFITSWriter(Tool):
                         'deg'
                     )
             else:
-                extra_headers["AL_CUT"] = (
-                    self.cuts.global_alpha_cut,
-                    'deg'
-                )
-
+                if self.energy_dependent_alpha:
+                    extra_headers["ALPHA_CONT"] = (
+                        self.cuts.alpha_containment,
+                        "Alpha containment region in percentage"
+                    )
+                else:
+                    extra_headers["AL_CUT"] = (
+                        self.cuts.global_alpha_cut,
+                        'deg'
+                    )
+                    
         # Write HDUs
         self.hdus = [fits.PrimaryHDU(), ]
 
@@ -612,6 +637,22 @@ class IRFFITSWriter(Tool):
                     )
                 )
                 self.log.info("RAD MAX HDU added")
+
+        if self.energy_dependent_alpha and self.source_dep:
+            # Create a separate temporary header
+            alpha_header = fits.Header()
+            alpha_header["CREATOR"] = f"lstchain v{__version__}"
+            alpha_header["DATE"] = Time.now().utc.iso
+            
+            for k, v in extra_headers.items():
+                alpha_header[k] = v
+                
+            self.hdus.append(
+                fits.BinTableHDU(
+                    self.alpha_cuts, header=gh_header, name="ALPHA_CUTS"
+                )
+            )
+            self.log.info("ALPHA CUTS HDU added")
 
     def finish(self):
 

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -211,6 +211,7 @@ class IRFFITSWriter(Tool):
         "gh-efficiency": "DL3Cuts.gh_efficiency",
         "theta-containment": "DL3Cuts.theta_containment",
         "global-theta-cut": "DL3Cuts.global_theta_cut",
+        "global-alpha-cut": "DL3Cuts.global_alpha_cut",
         "allowed-tels": "DL3Cuts.allowed_tels",
         "overwrite": "IRFFITSWriter.overwrite",
     }

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -653,7 +653,7 @@ class IRFFITSWriter(Tool):
                 
             self.hdus.append(
                 fits.BinTableHDU(
-                    self.alpha_cuts, header=gh_header, name="ALPHA_CUTS"
+                    self.alpha_cuts, header=gh_header, name="AL_CUTS"
                 )
             )
             self.log.info("ALPHA CUTS HDU added")

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -409,7 +409,6 @@ class IRFFITSWriter(Tool):
                 if self.energy_dependent_alpha:
                     self.alpha_cuts = self.cuts.energy_dependent_alpha_cuts(
                         gammas, reco_energy_bins,
-                        min_value=1 * u.deg, max_value=90 * u.deg,
                     )
                     gammas = self.cuts.apply_energy_dependent_alpha_cuts(
                         gammas, self.alpha_cuts

--- a/lstchain/tools/tests/test_tools.py
+++ b/lstchain/tools/tests/test_tools.py
@@ -181,7 +181,7 @@ def test_create_irf_point_like_srcdep_energy_dependent_cuts(
     assert isinstance(gh_cuts.meta["GH_EFF"], float)
     
     al_cuts = QTable.read(irf_file, hdu="AL_CUTS")
-    assert isinstance(al_cuts.meta["ALPHA_CONT"], float)
+    assert isinstance(al_cuts.meta["AL_CONT"], float)
     
 @pytest.mark.private_data
 def test_create_dl3_energy_dependent_cuts(

--- a/lstchain/tools/tests/test_tools.py
+++ b/lstchain/tools/tests/test_tools.py
@@ -323,7 +323,6 @@ def test_create_srcdep_dl3_energy_dependent_cuts(
     using energy-dependent cuts
     """
     from lstchain.tools.lstchain_create_dl3_file import DataReductionFITSWriter
-    from lstchain.paths import dl2_to_dl3_filename 
 
     irf_file = temp_dir_observed_srcdep_files / "irf_edep.fits.gz"
 

--- a/lstchain/tools/tests/test_tools.py
+++ b/lstchain/tools/tests/test_tools.py
@@ -148,7 +148,41 @@ def test_create_irf_point_like_energy_dependent_cuts(
 
     assert RadMax2D.read(irf_file, hdu="RAD_MAX")
 
+def test_create_irf_point_like_srcdep_energy_dependent_cuts(
+    temp_dir_observed_srcdep_files, simulated_srcdep_dl2_file
+):
+    """
+    Generating point-like source-dependent IRF file from a test DL2 files,
+    using energy-dependent cuts
+    """
+    from lstchain.tools.lstchain_create_irf_files import IRFFITSWriter
+    from astropy.table import QTable
 
+    irf_file = temp_dir_observed_srcdep_files / "irf_edep.fits.gz"
+    
+    assert (
+        run_tool(
+            IRFFITSWriter(),
+            argv=[
+                f"--input-gamma-dl2={simulated_srcdep_dl2_file}",
+                f"--output-irf-file={irf_file}",
+                "--point-like",
+                "--source-dep",
+                "--energy-dependent-gh",
+                "--energy-dependent-alpha",
+                "--overwrite",
+            ],
+            cwd=temp_dir_observed_srcdep_files,
+       )
+       == 0
+    )
+    
+    gh_cuts = QTable.read(irf_file, hdu="GH_CUTS")
+    assert isinstance(gh_cuts.meta["GH_EFF"], float)
+    
+    al_cuts = QTable.read(irf_file, hdu="AL_CUTS")
+    assert isinstance(al_cuts.meta["ALPHA_CONT"], float)
+    
 @pytest.mark.private_data
 def test_create_dl3_energy_dependent_cuts(
     temp_dir_observed_files, observed_dl2_file
@@ -244,7 +278,9 @@ def test_create_dl3_with_config(temp_dir_observed_files, observed_dl2_file):
 
 
 @pytest.mark.private_data
-def test_create_srcdep_dl3(temp_dir_observed_srcdep_files, observed_srcdep_dl2_file, simulated_srcdep_irf_file):
+def test_create_srcdep_dl3(
+        temp_dir_observed_srcdep_files, observed_srcdep_dl2_file, simulated_srcdep_irf_file
+):
     """
     Generating a source-dependent DL3 file from a test DL2 files and test IRF file
     """
@@ -277,6 +313,38 @@ def test_create_srcdep_dl3(temp_dir_observed_srcdep_files, observed_srcdep_dl2_f
 
     np.testing.assert_allclose(ra, 83.63, atol=1e-2)
     np.testing.assert_allclose(dec, 22.01, atol=1e-2)
+
+@pytest.mark.private_data
+def test_create_srcdep_dl3_energy_dependent_cuts(
+        temp_dir_observed_srcdep_files, observed_srcdep_dl2_file
+):
+    """
+    Generating a source-dependent DL3 file from a test DL2 files and test IRF file,
+    using energy-dependent cuts
+    """
+    from lstchain.tools.lstchain_create_dl3_file import DataReductionFITSWriter
+    from lstchain.paths import dl2_to_dl3_filename 
+
+    irf_file = temp_dir_observed_srcdep_files / "irf_edep.fits.gz"
+
+    assert (
+        run_tool(
+            DataReductionFITSWriter(),
+            argv=[
+                f"--input-dl2={observed_srcdep_dl2_file}",
+                f"--output-dl3-path={temp_dir_observed_srcdep_files}",
+                f"--input-irf={irf_file}",
+                "--source-name=Crab",
+                "--source-ra=83.633deg",
+                "--source-dec=22.01deg",
+                "--source-dep",
+                "--overwrite",
+            ],
+            cwd=temp_dir_observed_srcdep_files,
+        )
+        == 0
+    )
+
 
 @pytest.mark.private_data
 def test_index_dl3_files(temp_dir_observed_files):


### PR DESCRIPTION
This PR implements energy-dependent alpha cut for the IRF/DL3 production.
The same solution as energy-dependent g/h cuts is basically used for the energy-dependent alpha cut.
(create a separate temporary header to save energy-dependent alpha cuts in IRF)
Since the alpha cut is already applied to observational DL3 data, there is no need to modify gammapy.