### PR TITLE
Remove hard coded parameters in analysis_muon_event and make it usable with any telescope id.

### DIFF
--- a/lstchain/image/muon/muon_analysis.py
+++ b/lstchain/image/muon/muon_analysis.py
@@ -62,7 +62,7 @@ def pixel_coords_to_telescope(geom, equivalent_focal_length):
 
 def update_parameters(config, n_pixels):
     """
-    Create the parameters used to select good muon ring and perfor the image cleaning.
+    Create the parameters used to select good muon rings and perform the muon analysis.
     Parameters
     ----------
     config: `dict` or None

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -610,10 +610,10 @@ def r0_to_dl1(
                             mean_pixel_charge_around_ring,\
                             muonpars = \
                                 analyze_muon_event(subarray,
-                                                   event.index.event_id,
+                                                   tel_id, event.index.event_id,
                                                    image, geom, focal_length,
-                                                   mirror_area, False, '')
-                            #                      mirror_area, True, './')
+                                                   mirror_area, None, False, '')
+                            #                      mirror_area, None, True, './')
                             #           (test) plot muon rings as png files
 
                             # Now we want to obtain the waveform sample (in HG & LG) at which the ring light peaks:

--- a/lstchain/scripts/lstchain_dl1_muon_analysis.py
+++ b/lstchain/scripts/lstchain_dl1_muon_analysis.py
@@ -156,8 +156,8 @@ def main():
                 muonringparam, good_ring, radial_distribution,
                 mean_pixel_charge_around_ring, muonparameters
             ) = analyze_muon_event(subarray,
-                                   event_id, image, geom, equivalent_focal_length,
-                                   mirror_area, args.plot_rings, args.plots_path
+                                   lst1_tel_id, event_id, image, geom, equivalent_focal_length,
+                                   mirror_area, None, args.plot_rings, args.plots_path
                                    )
 
             if good_ring:


### PR DESCRIPTION
Add the possibility to update previously hard coded values in analysis_muon_event from a config file and pass the telescope id.

Implementation contains current LST-1 based values as defaults.