### PR TITLE
set joblib compress to 3

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -431,19 +431,19 @@ def build_models(filegammas, fileprotons,
         os.makedirs(path_models, exist_ok=True)
 
         file_reg_energy = path_models + "/reg_energy.sav"
-        joblib.dump(reg_energy, file_reg_energy)
+        joblib.dump(reg_energy, file_reg_energy, compress=3)
 
         if config['disp_method'] == 'disp_vector':
             file_reg_disp_vector = path_models + "/reg_disp_vector.sav"
-            joblib.dump(reg_disp_vector, file_reg_disp_vector)
+            joblib.dump(reg_disp_vector, file_reg_disp_vector, compress=3)
         elif config['disp_method'] == 'disp_norm_sign':
             file_reg_disp_norm = os.path.join(path_models, 'reg_disp_norm.sav')
             file_cls_disp_sign = os.path.join(path_models, 'cls_disp_sign.sav')
-            joblib.dump(reg_disp_norm, file_reg_disp_norm)
-            joblib.dump(cls_disp_sign, file_cls_disp_sign)
+            joblib.dump(reg_disp_norm, file_reg_disp_norm, compress=3)
+            joblib.dump(cls_disp_sign, file_cls_disp_sign, compress=3)
 
         file_cls_gh = path_models + "/cls_gh.sav"
-        joblib.dump(cls_gh, file_cls_gh)
+        joblib.dump(cls_gh, file_cls_gh, compress=3)
 
     if config['disp_method'] == 'disp_vector':
         return reg_energy, reg_disp_vector, cls_gh

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -163,10 +163,10 @@ def test_build_models(simulated_dl1_file, rf_models):
 
     import joblib
 
-    joblib.dump(reg_energy, rf_models["energy"])
-    joblib.dump(cls_gh, rf_models["gh_sep"])
-    joblib.dump(reg_disp_norm, rf_models["disp_norm"])
-    joblib.dump(cls_disp_sign, rf_models["disp_sign"])
+    joblib.dump(reg_energy, rf_models["energy"], compress=3)
+    joblib.dump(cls_gh, rf_models["gh_sep"], compress=3)
+    joblib.dump(reg_disp_norm, rf_models["disp_norm"], compress=3)
+    joblib.dump(cls_disp_sign, rf_models["disp_sign"], compress=3)
 
 
 def test_apply_models(simulated_dl1_file, simulated_dl2_file, rf_models):

--- a/notebooks/rf-performance.ipynb
+++ b/notebooks/rf-performance.ipynb
@@ -442,9 +442,9 @@
     "fileE = \"RFreg_Energy.sav\"                                                           \n",
     "fileD = \"RFreg_Disp.sav\"                                                             \n",
     "fileH = \"RFcls_GH.sav\"                                                               \n",
-    "joblib.dump(RFreg_Energy, fileE)                                                                      \n",
-    "joblib.dump(RFreg_Disp, fileD)                                                                        \n",
-    "joblib.dump(RFcls_GH, fileH)"
+    "joblib.dump(RFreg_Energy, fileE, compress=3)\n",
+    "joblib.dump(RFreg_Disp, fileD, compress=3)\n",
+    "joblib.dump(RFcls_GH, fileH, compress=3)"
    ]
   },
   {


### PR DESCRIPTION
We don't use any compression for the RF dump on disk.

I picked `compress=3` from a quick study (see below) that seems to give a good compromise: `1.2s --> 12.1s` to dump, `1.5-->3.8s` to read, `788MB-->179MB` on disk


Study:
```
In [13]: for i in range(9):
    ...:     print(i)
    ...:     %time joblib.dump(disp_sign,f'disp_sign_{i}.sav', compress=i)
    ...: 
0
CPU times: user 339 ms, sys: 890 ms, total: 1.23 s
Wall time: 1.41 s
1
CPU times: user 8.62 s, sys: 967 ms, total: 9.58 s
Wall time: 9.59 s
2
CPU times: user 9.11 s, sys: 599 ms, total: 9.71 s
Wall time: 9.72 s
3
CPU times: user 11.6 s, sys: 530 ms, total: 12.1 s
Wall time: 12.1 s
4
CPU times: user 12.7 s, sys: 504 ms, total: 13.2 s
Wall time: 13.2 s
5
CPU times: user 16.8 s, sys: 469 ms, total: 17.3 s
Wall time: 17.3 s
6
CPU times: user 28 s, sys: 517 ms, total: 28.5 s
Wall time: 28.5 s
7
CPU times: user 41.3 s, sys: 604 ms, total: 41.9 s
Wall time: 41.9 s
8
CPU times: user 2min 12s, sys: 839 ms, total: 2min 13s
Wall time: 2min 13s
```

```
In [15]: for i in range(9):
    ...:     print(i)
    ...:     %time joblib.load(f'disp_sign_{i}.sav')
    ...: 
0
CPU times: user 639 ms, sys: 894 ms, total: 1.53 s
Wall time: 1.53 s
1
CPU times: user 3.62 s, sys: 631 ms, total: 4.25 s
Wall time: 4.26 s
2
CPU times: user 3.39 s, sys: 475 ms, total: 3.87 s
Wall time: 3.87 s
3
CPU times: user 3.28 s, sys: 488 ms, total: 3.77 s
Wall time: 3.77 s
4
CPU times: user 3.35 s, sys: 496 ms, total: 3.85 s
Wall time: 3.85 s
5
CPU times: user 3.24 s, sys: 461 ms, total: 3.7 s
Wall time: 3.7 s
6
CPU times: user 3.12 s, sys: 507 ms, total: 3.62 s
Wall time: 3.62 s
7
CPU times: user 3.14 s, sys: 474 ms, total: 3.62 s
Wall time: 3.62 s
8
CPU times: user 3.09 s, sys: 452 ms, total: 3.55 s
Wall time: 3.55 s
```

```
In [17]: ls -sh disp_sign*.sav
788M disp_sign_0.sav  
198M disp_sign_1.sav
187M disp_sign_2.sav 
179M disp_sign_3.sav 
181M disp_sign_4.sav
172M disp_sign_5.sav
167M disp_sign_6.sav 
166M disp_sign_7.sav
162M disp_sign_8.sav
```
