### PR TITLE
IERS B (instead of IERS A) & smarter data filter.

### DIFF
--- a/notebooks/data_selection.ipynb
+++ b/notebooks/data_selection.ipynb
@@ -25,6 +25,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# IERS A downloading is somewhat buggy: \n",
+    "# see https://github.com/astropy/astropy/issues/13007\n",
+    "# The next two lines disable IERS A, using lower precision / pre-downloaded IERS B instead."
+    "from astropy.utils import iers\n",
+    "iers.conf.auto_download = False  \n",
+    "\n",
     "import glob\n",
     "import tables\n",
     "from ctapipe.io import read_table\n",
@@ -41,6 +47,37 @@
     "from datetime import datetime\n",
     "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb308415",
+   "metadata": {},
+   "source": [
+    "### Outlier robust filter\n",
+    "\n",
+    "mean and std dev are affected by outliers. Therefore [mean-N*std,mean+N*std] is not a reliable filter definition if outliers are present. Using percentiles (i.e. defining IQR-based cuts) allows to concentrate in the central part of the distribution and ignore how far the outliers are."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51d2fcc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def outlier_resistant_filter(x,nstd=2,hard_lo_cut=-np.inf,hard_hi_cut=np.inf):\n",
+    "    # mean and std are affected by outliers, therefore use use median and IQR (less affected)\n",
+    "    # IQR = interquantile range \n",
+    "    # 1 sigma <-> 0.32 - 0.68 in gaussian distributions. \n",
+    "    # \n",
+    "    q32, q68 = np.percentile(x, [32 ,68])\n",
+    "    sigma_neg = np.median(x)-q32\n",
+    "    sigma_pos = q68-np.median(x)\n",
+    "    \n",
+    "    # define the filter\n",
+    "    filt = (x>np.median(x)-sigma_neg*nstd) & (x>hard_lo_cut) & (x<np.median(x)+sigma_pos*nstd) & (x<hard_hi_cut)\n",
+    "    return(filt)"
    ]
   },
   {
@@ -299,14 +336,14 @@
    "id": "4d435ae3",
    "metadata": {},
    "source": [
-    "### Selection of zenith angle range\n",
+    "### Selection of zenith angle range\n",
     "Define here the desired zenith angle range, e.g. for selecting runs that can be analyzed with an MC set with a given pointing"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "617dc170",
+   "id": "13b581a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,16 +352,7 @@
     "zenith_mask =  ((90 - np.rad2deg(dcheck_runsummary['min_altitude']) < max_zenith) &\n",
     "                (90 - np.rad2deg(dcheck_runsummary['min_altitude']) > min_zenith))\n",
     "\n",
-    "print(f'With {min_zenith} < zenith < {max_zenith} degrees:')\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40cf6c15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "print(f'With {min_zenith} < zenith < {max_zenith} degrees:')\n",
     "print_runs(dcheck_runsummary, source_mask & zenith_mask & ped_ok_mask, by_date=True)"
    ]
   },
@@ -359,6 +387,7 @@
     "mask = source_mask & zenith_mask & ped_ok_mask\n",
     "\n",
     "plt.figure(figsize=(15,4))\n",
+    "#location = EarthLocation.of_site('Roque de los Muchachos')\n",
     "\n",
     "sun_gcrs = get_sun(Time(utctime))\n",
     "altaz = AltAz(obstime=utctime, location=location)\n",
@@ -405,6 +434,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7e12fb37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy\n",
+    "astropy.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "58c7ea17",
    "metadata": {
     "scrolled": true
@@ -424,7 +464,8 @@
     "plt.show()\n",
     "\n",
     "# Moon below the horizon:\n",
-    "no_moon = moon_altaz.alt.to_value(u.deg) < 0"
+    "no_moon  = moon_altaz.alt.to_value(u.deg) < 0\n",
+    "low_moon = (moon_altaz.alt.to_value(u.deg) < 5) & (moon_altaz.alt.to_value(u.deg) >= 0)"
    ]
   },
   {
@@ -475,6 +516,9 @@
     "mask = source_mask & zenith_mask & ped_ok_mask & ~no_moon\n",
     "plt.scatter(dcheck_runsummary['runnumber'][mask], dcheck_runsummary['ped_charge_stddev'][mask], \n",
     "            label='Moon above horizon', s=5)\n",
+    "mask = source_mask & zenith_mask & ped_ok_mask & low_moon\n",
+    "plt.scatter(dcheck_runsummary['runnumber'][mask], dcheck_runsummary['ped_charge_stddev'][mask], \n",
+    "            label='Moon above but near horizon', s=5)\n",
     "plt.grid()\n",
     "plt.legend()\n",
     "plt.xlabel('Run number')\n",
@@ -522,14 +566,21 @@
    },
    "outputs": [],
    "source": [
-    "mask = source_mask & zenith_mask & ped_ok_mask & ped_std_cut\n",
-    "\n",
     "rate_cosmics = dcheck_runsummary['num_cosmics'] / dcheck_runsummary['elapsed_time']\n",
+    "filt_cosmics = outlier_resistant_filter(rate_cosmics,3,2e3,2e4)\n",
+    "\n",
     "plt.figure(figsize=(15,4))\n",
-    "plt.scatter(90 - np.rad2deg(dcheck_runsummary['mean_altitude'][mask]), rate_cosmics[mask])\n",
+    "\n",
+    "mask = source_mask & zenith_mask & ped_ok_mask & ped_std_cut & filt_cosmics\n",
+    "plt.scatter(90 - np.rad2deg(dcheck_runsummary['mean_altitude'][mask]), rate_cosmics[mask], label='Survived')\n",
+    "\n",
+    "mask = source_mask & zenith_mask & ped_ok_mask & ped_std_cut & ~filt_cosmics\n",
+    "plt.scatter(90 - np.rad2deg(dcheck_runsummary['mean_altitude'][mask]), rate_cosmics[mask], label='Removed')\n",
+    "\n",
     "plt.ylabel('Cosmics rate (/s)')\n",
     "plt.xlabel('Zenith angle (deg)')\n",
     "plt.ylim(0, 15000)\n",
+    "plt.legend()\n",
     "plt.grid()\n",
     "plt.show()"
    ]
@@ -543,13 +594,20 @@
    "source": [
     "# Now the cosmics rate vs. run number\n",
     "\n",
-    "mask = source_mask & zenith_mask & ped_ok_mask & ped_std_cut\n",
-    "\n",
     "rate_cosmics = dcheck_runsummary['num_cosmics'] / dcheck_runsummary['elapsed_time']\n",
+    "filt_cosmics = outlier_resistant_filter(rate_cosmics,3,2e3,2e4)\n",
+    "\n",
     "plt.figure(figsize=(15,4))\n",
-    "plt.scatter(dcheck_runsummary['runnumber'][mask], rate_cosmics[mask])\n",
+    "\n",
+    "mask = source_mask & zenith_mask & ped_ok_mask & ped_std_cut & filt_cosmics\n",
+    "plt.scatter(dcheck_runsummary['runnumber'][mask], rate_cosmics[mask],label='survived')\n",
+    "\n",
+    "mask = source_mask & zenith_mask & ped_ok_mask & ped_std_cut & ~filt_cosmics\n",
+    "plt.scatter(dcheck_runsummary['runnumber'][mask], rate_cosmics[mask],label='removed')\n",
+    "\n",
     "plt.ylabel('Cosmics rate (/s)')\n",
     "plt.xlabel('Run number')\n",
+    "plt.legend()\n",
     "plt.grid()\n",
     "plt.show()"
    ]
@@ -572,7 +630,9 @@
    },
    "outputs": [],
    "source": [
-    "rate_mask = rate_cosmics > 3000\n",
+    "#rate_mask = rate_cosmics > 3000\n",
+    "rate_mask = outlier_resistant_filter(rate_cosmics,3,2e3,2e4)\n",
+    "\n",
     "print_runs(dcheck_runsummary, source_mask & zenith_mask & ped_ok_mask & ped_std_cut & rate_mask)"
    ]
   },
@@ -692,18 +752,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "56294cfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rate_pulse10 = (dcheck_runsummary[f'cosmics_fraction_pulses_above10'] * \n",
+    "                dcheck_runsummary['num_cosmics'] / \n",
+    "                dcheck_runsummary['elapsed_time'])\n",
+    "rate_pulse30 = (dcheck_runsummary[f'cosmics_fraction_pulses_above30'] * \n",
+    "                dcheck_runsummary['num_cosmics'] / \n",
+    "                dcheck_runsummary['elapsed_time'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "068fadd0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "rate10_mask = (dcheck_runsummary[f'cosmics_fraction_pulses_above10'] * \n",
-    "               dcheck_runsummary['num_cosmics'] / \n",
-    "               dcheck_runsummary['elapsed_time']) > 25\n",
-    "rate30_mask = (dcheck_runsummary[f'cosmics_fraction_pulses_above30'] * \n",
-    "               dcheck_runsummary['num_cosmics'] / \n",
-    "               dcheck_runsummary['elapsed_time']) > 4.5\n",
+    "mask = source_mask & zenith_mask & ped_ok_mask & ped_std_cut & rate_mask\n",
     "\n",
-    "pix_rate_mask = rate10_mask & rate30_mask"
+    "rate10_mask = outlier_resistant_filter(rate_pulse10,3,10,120)\n",
+    "rate30_mask = outlier_resistant_filter(rate_pulse30,3,1,120)\n",
+    "\n",
+    "print(f'Number of selected runs for pulse > 10 p.e. filter: {np.sum(rate10_mask[mask])}/{len(rate10_mask[mask])}')\n",
+    "print(f'Number of selected runs for pulse > 30 p.e. filter: {np.sum(rate30_mask[mask])}/{len(rate30_mask[mask])}')\n",
+    "\n",
+    "pix_rate_mask = rate10_mask & rate30_mask\n",
+    "\n",
+    "print(f'Number of selected runs for pix_rate_mask: {np.sum(pix_rate_mask[mask])}/{len(pix_rate_mask[mask])}')\n"
    ]
   },
   {
@@ -1049,7 +1127,7 @@
    "outputs": [],
    "source": [
     "# We might a cut of < 0.2  on the std dev of the rate of >30 pulses\n",
-    "# Perhaps this anomaly is produced by car flashes, or the MAGIC LIDAR...\n",
+    "# Perhaps this anomaly is produced by car flashes, or the MAGIC LIDAR...\n",
     "\n",
     "# Create a mask that can be applied to the dcheck_runsummary table:\n",
     "\n",
@@ -1062,6 +1140,48 @@
     "        continue    \n",
     "    pulse30_std_cut[dcheck_runsummary['runnumber']==run] = False\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a25cf9b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_runs(dcheck_runsummary, source_mask & zenith_mask & ped_ok_mask & ped_std_cut & rate_mask & pix_rate_mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "811bc73c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dccbbfeb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47a8d930",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9da3ce86",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Two suggested improvements:

* Use astropy-blunded IERS B (lower precision, but allows to skip the need for the buggy IERS A downloading, https://github.com/astropy/astropy/issues/13007 )
* Use less outlier-affected filtering of data distributions, based on the 32-50-68 percentiles instead of hardcoding the cuts or using std deviation.

Tested with Crab Nebula and M87.