### PR TITLE
Reduce size of random forests in standard config

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -60,7 +60,7 @@
   },
 
   "random_forest_energy_regressor_args": {
-    "max_depth": 50,
+    "max_depth": 30,
     "min_samples_leaf": 2,
     "n_jobs": 4,
     "n_estimators": 150,
@@ -69,7 +69,7 @@
     "max_features": "auto",
     "max_leaf_nodes": null,
     "min_impurity_decrease": 0.0,
-    "min_samples_split": 2,
+    "min_samples_split": 10,
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
@@ -78,7 +78,7 @@
   },
 
   "random_forest_disp_regressor_args": {
-    "max_depth": 50,
+    "max_depth": 30,
     "min_samples_leaf": 2,
     "n_jobs": 4,
     "n_estimators": 150,
@@ -87,7 +87,7 @@
     "max_features": "auto",
     "max_leaf_nodes": null,
     "min_impurity_decrease": 0.0,
-    "min_samples_split": 2,
+    "min_samples_split": 10,
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
@@ -96,12 +96,12 @@
   },
 
   "random_forest_disp_classifier_args": {
-    "max_depth": 100,
+    "max_depth": 30,
     "min_samples_leaf": 2,
     "n_jobs": 4,
     "n_estimators": 100,
     "criterion": "gini",
-    "min_samples_split": 2,
+    "min_samples_split": 10,
     "min_weight_fraction_leaf": 0.0,
     "max_features": "auto",
     "max_leaf_nodes": null,
@@ -115,12 +115,12 @@
   },
 
   "random_forest_particle_classifier_args": {
-    "max_depth": 100,
+    "max_depth": 30,
     "min_samples_leaf": 2,
     "n_jobs": 4,
     "n_estimators": 100,
     "criterion": "gini",
-    "min_samples_split": 2,
+    "min_samples_split": 10,
     "min_weight_fraction_leaf": 0.0,
     "max_features": "auto",
     "max_leaf_nodes": null,

--- a/lstchain/tools/tests/test_tools.py
+++ b/lstchain/tools/tests/test_tools.py
@@ -139,7 +139,9 @@ def test_create_irf_point_like_energy_dependent_cuts(
                 "--overwrite",
                 "--energy-dependent-gh",
                 "--point-like",
-                "--energy-dependent-theta"
+                "--energy-dependent-theta",
+                "--DL3Cuts.max_theta_cut=1",
+                "--DL3Cuts.fill_theta_cut=1"
             ],
             cwd=temp_dir_observed_files,
         )


### PR DESCRIPTION
Based on https://indico.cta-observatory.org/event/3992/

and cross-check on real-data from @SeiyaNozaki showing no diff in Crab spectra between the two configs.