### PR TITLE
Add new function to check mc type

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1135,10 +1135,10 @@ def extract_simulation_nsb(filename):
 
 def check_mc_type(filename):
     """
-    Check MC type ('point_like', 'diffuse', 'ring_wobble') using DL1/DL2 MC file
+    Check MC type ('point_like', 'diffuse', 'ring_wobble') based on the viewcone setting
     Parameters
     ----------
-    filename: path
+    filename:path (DL1/DL2 hdf file)
     Returns
     -------
     string
@@ -1155,26 +1155,11 @@ def check_mc_type(filename):
     elif min_viewcone == 0.0:
         mc_type = 'diffuse'
         
+    elif (max_viewcone - min_viewcone) < 0.1:
+        mc_type = 'ring_wobble'
+
     else:
-        # check if mc_type is 'ring_wobble' or not
-        dataset_keys = get_dataset_keys(filename)
-
-        if dl1_params_lstcam_key in dataset_keys:
-            df = pd.read_hdf(filename, key=dl1_params_lstcam_key)
-        if dl2_params_lstcam_key in dataset_keys:
-            df = pd.read_hdf(filename, key=dl2_params_lstcam_key)
-
-        
-        src_r_m = np.sqrt(df['src_x']**2 + df['src_y']**2)
-        foclen = OPTICS.equivalent_focal_length.value
-        src_r_deg = np.rad2deg(np.arctan(src_r_m / foclen))
-
-        if  np.allclose(src_r_deg, min_viewcone, atol=0.1
-        ) and np.allclose(src_r_deg, max_viewcone, atol=0.1):
-            mc_type = 'ring_wobble'
-
-        else:
-            raise ValueError('mc type cannot be identified')
+        raise ValueError('mc type cannot be identified')
 
     return mc_type
             

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -42,7 +42,7 @@ __all__ = [
     'auto_merge_h5files',
     'check_mcheader',
     'check_metadata',
-    'check_mc_type'
+    'check_mc_type',
     'check_thrown_events_histogram',
     'copy_h5_nodes',
     'extract_simulation_nsb',

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -30,8 +30,6 @@ from .lstcontainers import (
     ThrownEventsHistogram,
 )
 
-from ctapipe_io_lst import OPTICS
-
 log = logging.getLogger(__name__)
 
 __all__ = [

--- a/lstchain/io/tests/test_io.py
+++ b/lstchain/io/tests/test_io.py
@@ -146,3 +146,9 @@ def test_extract_simulation_nsb(mc_gamma_testfile):
     assert np.isclose(nsb[0], 0.317, rtol=0.1)
     assert np.isclose(nsb[1], 0.276, rtol=0.1)
 
+
+def test_check_mc_type(simulated_dl1_file):
+    from lstchain.io.io import check_mc_type
+
+    mc_type = check_mc_type(simulated_dl1_file)
+    assert mc_type == 'diffuse'

--- a/lstchain/io/tests/test_io.py
+++ b/lstchain/io/tests/test_io.py
@@ -145,3 +145,4 @@ def test_extract_simulation_nsb(mc_gamma_testfile):
     nsb = extract_simulation_nsb(mc_gamma_testfile)
     assert np.isclose(nsb[0], 0.317, rtol=0.1)
     assert np.isclose(nsb[1], 0.276, rtol=0.1)
+

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -76,6 +76,7 @@ from lstchain.io import (
     EventSelector,
 )
 from lstchain.io import read_mc_dl2_to_QTable
+from lstchain.io.io import check_mc_type
 from lstchain.__init__ import __version__
 
 __all__ = ["IRFFITSWriter"]
@@ -301,10 +302,7 @@ class IRFFITSWriter(Tool):
             self.log.info(f"Simulated {particle_type.title()} Events:")
             p["events"], p["simulation_info"] = read_mc_dl2_to_QTable(p["file"])
 
-            if p["simulation_info"].viewcone.value == 0.0:
-                p["mc_type"] = "point_like"
-            else:
-                p["mc_type"] = "diffuse"
+            p["mc_type"] = check_mc_type(p["file"])
 
             self.log.debug(
                 f"Simulated {p['mc_type']} {particle_type.title()} Events:"
@@ -402,7 +400,7 @@ class IRFFITSWriter(Tool):
                       f'{self.cuts.global_alpha_cut} for point like IRF'
                     )
 
-        if self.mc_particle["gamma"]["mc_type"] == "point_like":
+        if self.mc_particle["gamma"]["mc_type"] in ["point_like", "ring_wobble"]:
             mean_fov_offset = round(
                 gammas["true_source_fov_offset"].mean().to_value(), 1
             )
@@ -493,7 +491,7 @@ class IRFFITSWriter(Tool):
         self.hdus = [fits.PrimaryHDU(), ]
 
         with np.errstate(invalid="ignore", divide="ignore"):
-            if self.mc_particle["gamma"]["mc_type"] == "point_like":
+            if self.mc_particle["gamma"]["mc_type"] in ["point_like", "ring_wobble"]:
                 self.effective_area = effective_area_per_energy(
                     gammas,
                     self.mc_particle["gamma"]["simulation_info"],


### PR DESCRIPTION
continued from https://github.com/cta-observatory/cta-lstchain/pull/962

I implemented a new function to check mc_type (`point_like`, `diffuse`, `ring_wobble`) based on the suggestion in https://github.com/cta-observatory/pyirf/issues/176
This PR makes it possible to generate point-like IRF with ring-wobble MC properly (especially for source-dependent analysis).