### PR TITLE
Remove hard-coded arguments in the energy-dependent cuts functions

### DIFF
--- a/docs/examples/dl3_tool_config.json
+++ b/docs/examples/dl3_tool_config.json
@@ -1,21 +1,27 @@
 {
   "EventSelector": {
     "filters": {
-      "intensity": [100, Infinity],
+      "intensity": [0, Infinity],
       "width": [0, Infinity],
       "length": [0, Infinity],
       "r": [0, 1],
-      "wl": [0.1, 1],
-      "leakage_intensity_width_2": [0, 0.2],
+      "wl": [0.01, 1],
+      "leakage_intensity_width_2": [0, 1],
       "event_type": [32, 32]
     }
   },
   "DL3Cuts": {
+    "min_event_p_en_bin": 100,
     "global_gh_cut": 0.7,
     "gh_efficiency": 0.9,
+    "min_gh_cut": 0.1,
+    "max_gh_cut": 0.95,
     "global_alpha_cut": 10,
     "global_theta_cut": 0.2,
     "theta_containment": 0.68,
+    "min_theta_cut": 0.05,
+    "max_theta_cut": 0.32,
+    "fill_theta_cut": 0.32,
     "allowed_tels": [1]
   }
 }

--- a/docs/examples/irf_tool_config.json
+++ b/docs/examples/irf_tool_config.json
@@ -1,21 +1,27 @@
 {
   "EventSelector": {
     "filters": {
-      "intensity": [100, Infinity],
+      "intensity": [0, Infinity],
       "width": [0, Infinity],
       "length": [0, Infinity],
       "r": [0, 1],
-      "wl": [0.1, 1],
-      "leakage_intensity_width_2": [0, 0.2],
+      "wl": [0.01, 1],
+      "leakage_intensity_width_2": [0, 1],
       "event_type": [32, 32]
     }
   },
   "DL3Cuts": {
+    "min_event_p_en_bin": 100,
     "global_gh_cut": 0.7,
     "gh_efficiency": 0.9,
+    "min_gh_cut": 0.1,
+    "max_gh_cut": 0.95,
     "global_alpha_cut": 10,
     "global_theta_cut": 0.2,
     "theta_containment": 0.68,
+    "min_theta_cut": 0.05,
+    "max_theta_cut": 0.32,
+    "fill_theta_cut": 0.32,
     "allowed_tels": [1]
   },
   "DataBinning": {

--- a/lstchain/io/tests/test_eventselection.py
+++ b/lstchain/io/tests/test_eventselection.py
@@ -63,6 +63,7 @@ def test_dl3_energy_dependent_cuts():
 
     temp_cuts.gh_max_efficiency = 0.8
     temp_cuts.theta_containment = 0.68
+    temp_cuts.min_event_p_en_bin = 2
 
     temp_data = QTable({
         "gh_score": u.Quantity(np.tile(np.arange(0.35, 0.85, 0.05), 3)),
@@ -74,11 +75,11 @@ def test_dl3_energy_dependent_cuts():
     en_range = u.Quantity([0.01, 0.1, 1, 10, 100, np.inf], unit=u.TeV)
 
     theta_cut = temp_cuts.energy_dependent_theta_cuts(
-        temp_data, en_range, min_events=2
+        temp_data, en_range,
     )
 
     gh_cut = temp_cuts.energy_dependent_gh_cuts(
-        temp_data, en_range, min_events=2
+        temp_data, en_range,
     )
 
     data_th = temp_cuts.apply_energy_dependent_theta_cuts(temp_data, theta_cut)

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -128,9 +128,9 @@ class IRFFITSWriter(Tool):
 
     Or generate source-dependent IRFs
     > lstchain_create_irf_files
-        -g /path/to/DL2_MC_gamma_file.h5 
+        -g /path/to/DL2_MC_gamma_file.h5
         -o /path/to/irf.fits.gz
-        --point-like 
+        --point-like
         --global-gh-cut 0.9
         --global-alpha-cut 10
         --source-dep
@@ -360,7 +360,7 @@ class IRFFITSWriter(Tool):
 
         if self.energy_dependent_gh:
             self.gh_cuts_gamma = self.cuts.energy_dependent_gh_cuts(
-                gammas, reco_energy_bins, min_value=0.1, max_value=0.95
+                gammas, reco_energy_bins
             )
             gammas = self.cuts.apply_energy_dependent_gh_cuts(
                 gammas, self.gh_cuts_gamma
@@ -379,7 +379,6 @@ class IRFFITSWriter(Tool):
             if self.energy_dependent_theta:
                 self.theta_cuts = self.cuts.energy_dependent_theta_cuts(
                     gammas, reco_energy_bins,
-                    min_value=0.05 * u.deg, max_value=0.32 * u.deg,
                 )
                 gammas = self.cuts.apply_energy_dependent_theta_cuts(
                     gammas, self.theta_cuts
@@ -477,7 +476,7 @@ class IRFFITSWriter(Tool):
                     extra_headers["TH_CONT"] = (
                         self.cuts.theta_containment,
                         "Theta containment region in percentage"
-                    )               
+                    )
                 else:
                     extra_headers["RAD_MAX"] = (
                         self.cuts.global_theta_cut,


### PR DESCRIPTION
Makes the following new traits - 
- `min_event_p_en_bin`: minimum number of events to check, in each energy bin. I have changed the default value to 100, instead of the earlier 10, which was too low to be meaningful with the standard bins we provide. Needs to be fixed after some more tests.
- `min/max_gh/theta_cut`: Minimum and maximum cut values of gh_score (gammaness) and theta, while evaluating the percentile cuts.
- `fill_theta_cut`: Fill value of theta cut, when the number of events is below the minimum value, in each energy bin. For gh_score cut, I use the maximum value of 1, as it is fixed.

Also fixes the issue of #954 here to be more consistent PR, rather than #943. #942 can also follow this new change.

The example configs have been updated accordingly.

This will also help in fixing the error seen in running some tests in #961 
 