### PR TITLE
Use setup-miniconda in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Prepare conda installation
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          # fix mamba error that the directory does not exist
+          mkdir -p ~/conda_pkgs_dir/cache
+          # setup correct python version
+          sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
+
+      - name: Conda setup
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          auto-update-conda: true
+          activate-environment: "lst-dev"
+          environment-file: environment.yml
 
       - name: Install dependencies
         env:
@@ -55,15 +67,7 @@ jobs:
           CTAPIPE_VERSION: ${{ matrix.ctapipe-version }}
 
         run: |
-          . $CONDA/etc/profile.d/conda.sh
-          conda config --set always_yes yes --set changeps1 no
-          sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
-
-          echo "Creating conda env"
-          conda install -c conda-forge mamba
-          mamba env create -n ci -f environment.yml
-          conda activate ci
-
+          python --version
           echo "Installing additional pip packages"
           # we install ctapipe using pip to be able to select any commit, e.g. the current master
           pip install \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
   tests:
     needs: pyflakes
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
     strategy:
       matrix:
         # we currently only support python 3.7 since traitlets 5 requires 3.7
@@ -86,10 +91,6 @@ jobs:
 
       - name: Tests
         run: |
-          # github actions starts a new shell for each "step", so we need to
-          # activate our env again
-          source $CONDA/etc/profile.d/conda.sh
-          conda activate ci
           pytest -n auto --dist loadscope --cov --cov-report=xml -m 'private_data or not private_data' lstchain
 
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
@chaimain reported a strange error with mamba in the CI.

Switch to using the `setup-miniconda` github action to see if that works better (as we did recently for ctapipe)