### PR TITLE
Update the event binning for true/reco energy and source offset

### DIFF
--- a/docs/examples/irf_tool_config.json
+++ b/docs/examples/irf_tool_config.json
@@ -40,8 +40,8 @@
     "bkg_fov_offset_min": 0,
     "bkg_fov_offset_max": 10,
     "bkg_fov_offset_n_edges": 21,
-    "source_offset_min": 0.0001,
-    "source_offset_max": 1.0001,
+    "source_offset_min": 0.001,
+    "source_offset_max": 1.001,
     "source_offset_n_edges": 100
   }
 }

--- a/docs/examples/irf_tool_config.json
+++ b/docs/examples/irf_tool_config.json
@@ -25,11 +25,11 @@
     "allowed_tels": [1]
   },
   "DataBinning": {
-    "true_energy_min": 0.01,
-    "true_energy_max": 100,
+    "true_energy_min": 0.005,
+    "true_energy_max": 200,
     "true_energy_n_bins_per_decade": 5,
-    "reco_energy_min": 0.01,
-    "reco_energy_max": 100,
+    "reco_energy_min": 0.005,
+    "reco_energy_max": 200,
     "reco_energy_n_bins_per_decade": 5,
     "energy_migration_min": 0.2,
     "energy_migration_max": 5,
@@ -42,6 +42,6 @@
     "bkg_fov_offset_n_edges": 21,
     "source_offset_min": 0.0001,
     "source_offset_max": 1.0001,
-    "source_offset_n_edges": 1000
+    "source_offset_n_edges": 100
   }
 }

--- a/docs/examples/irf_tool_config.json
+++ b/docs/examples/irf_tool_config.json
@@ -40,8 +40,8 @@
     "bkg_fov_offset_min": 0,
     "bkg_fov_offset_max": 10,
     "bkg_fov_offset_n_edges": 21,
-    "source_offset_min": 0.001,
-    "source_offset_max": 1.001,
-    "source_offset_n_edges": 100
+    "source_offset_min": 0,
+    "source_offset_max": 1,
+    "source_offset_n_edges": 101
   }
 }

--- a/lstchain/io/event_selection.py
+++ b/lstchain/io/event_selection.py
@@ -299,17 +299,17 @@ class DataBinning(Component):
 
     source_offset_min = Float(
         help="Minimum value for Source offset for PSF IRF",
-        default_value=0.001,
+        default_value=0,
     ).tag(config=True)
 
     source_offset_max = Float(
         help="Maximum value for Source offset for PSF IRF",
-        default_value=1.001,
+        default_value=1,
     ).tag(config=True)
 
     source_offset_n_edges = Int(
         help="Number of edges for Source offset for PSF IRF",
-        default_value=100,
+        default_value=101,
     ).tag(config=True)
 
     def true_energy_bins(self):

--- a/lstchain/io/event_selection.py
+++ b/lstchain/io/event_selection.py
@@ -299,12 +299,12 @@ class DataBinning(Component):
 
     source_offset_min = Float(
         help="Minimum value for Source offset for PSF IRF",
-        default_value=0.0001,
+        default_value=0.001,
     ).tag(config=True)
 
     source_offset_max = Float(
         help="Maximum value for Source offset for PSF IRF",
-        default_value=1.0001,
+        default_value=1.001,
     ).tag(config=True)
 
     source_offset_n_edges = Int(

--- a/lstchain/io/event_selection.py
+++ b/lstchain/io/event_selection.py
@@ -224,12 +224,12 @@ class DataBinning(Component):
 
     true_energy_min = Float(
         help="Minimum value for True Energy bins in TeV units",
-        default_value=0.01,
+        default_value=0.005,
     ).tag(config=True)
 
     true_energy_max = Float(
         help="Maximum value for True Energy bins in TeV units",
-        default_value=100,
+        default_value=200,
     ).tag(config=True)
 
     true_energy_n_bins_per_decade = Float(
@@ -239,12 +239,12 @@ class DataBinning(Component):
 
     reco_energy_min = Float(
         help="Minimum value for Reco Energy bins in TeV units",
-        default_value=0.01,
+        default_value=0.005,
     ).tag(config=True)
 
     reco_energy_max = Float(
         help="Maximum value for Reco Energy bins in TeV units",
-        default_value=100,
+        default_value=200,
     ).tag(config=True)
 
     reco_energy_n_bins_per_decade = Float(
@@ -309,7 +309,7 @@ class DataBinning(Component):
 
     source_offset_n_edges = Int(
         help="Number of edges for Source offset for PSF IRF",
-        default_value=1000,
+        default_value=100,
     ).tag(config=True)
 
     def true_energy_bins(self):


### PR DESCRIPTION
Resolves #729 and also adds support for binning different MC nodes, with varying true energy range, into IRFs. Will be also useful for #711.
If there any other defaults to be modified, please let me know here.