### PR TITLE
Corrected missleading comment from previous code version

### DIFF
--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -532,7 +532,7 @@ def calculate_required_additional_nsb(simtel_filename, data_dl1_filename, config
     mc_unbiased_std_ped_pe = np.std(mc_ped_charges)
 
     # Find the additional noise (in data w.r.t. MC) for the unbiased extractor
-    # The idea is that pedestal std scales with NSB (But better correction with sqrt(variance ratio-1) observed)
+    # The idea is that pedestal variance scales with NSB
 
     data_ped_variance = data_median_std_ped_pe ** 2
     mc_ped_variance = mc_unbiased_std_ped_pe ** 2


### PR DESCRIPTION
Correct a comment reflecting the implementation of the code before a correction (commit [ddff326](https://github.com/cta-observatory/cta-lstchain/pull/821/commits/ddff326554619dbf26cd437f26ad2790263e0215)) and currently wrong.