### PR TITLE
Dealing with configs in a better way

### DIFF
--- a/lstchain/data/lstchain_dl1ab_tune_MC_to_Crab_config.json
+++ b/lstchain/data/lstchain_dl1ab_tune_MC_to_Crab_config.json
@@ -1,4 +1,15 @@
 {
+  "LocalPeakWindowSum":{
+    "window_shift": 4,
+    "window_width": 8,
+    "apply_integration_correction": true
+  },
+  "GlobalPeakWindowSum":{
+    "window_shift": 4,
+    "window_width": 8,
+    "apply_integration_correction": true
+  },
+
   "image_modifier": {
     "increase_nsb": true,
     "extra_noise_in_dim_pixels": 1.2,

--- a/lstchain/data/lstchain_mc_config.json
+++ b/lstchain/data/lstchain_mc_config.json
@@ -1,0 +1,12 @@
+{
+  "LocalPeakWindowSum":{
+    "window_shift": 4,
+    "window_width": 8,
+    "apply_integration_correction": true
+  },
+  "GlobalPeakWindowSum":{
+    "window_shift": 4,
+    "window_width": 8,
+    "apply_integration_correction": true
+  }
+}

--- a/lstchain/data/lstchain_src_dep_config.json
+++ b/lstchain/data/lstchain_src_dep_config.json
@@ -1,139 +1,4 @@
 {
-  "source_config" : {
-    "EventSource": {
-      "allowed_tels": [1],
-      "max_events": null
-    },
-    "LSTEventSource": {
-      "default_trigger_type": "ucts",
-      "allowed_tels": [1],
-      "min_flatfield_adc": 3000,
-      "min_flatfield_pixel_fraction": 0.8,
-      "calibrate_flatfields_and_pedestals": false,
-      "EventTimeCalculator": {
-        "dragon_reference_counter": null,
-        "dragon_reference_time": null
-      },
-      "PointingSource":{
-        "drive_report_path": null
-      },
-      "LSTR0Corrections":{
-        "calib_scale_high_gain":1.088,
-        "calib_scale_low_gain":1.004,
-        "drs4_pedestal_path": null,
-        "calibration_path": null,
-        "drs4_time_calibration_path": null
-      }
-    }
-  },
-
-  "events_filters": {
-    "intensity": [0, Infinity],
-    "width": [0, Infinity],
-    "length": [0, Infinity],
-    "wl": [0, Infinity],
-    "r": [0, Infinity],
-    "leakage_intensity_width_2": [0, Infinity]
-  },
-
-  "tailcut": {
-    "picture_thresh":8,
-    "boundary_thresh":4,
-    "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":2,
-    "use_only_main_island":false,
-    "delta_time": 2
-  },
-  "tailcuts_clean_with_pedestal_threshold": {
-    "picture_thresh":8,
-    "boundary_thresh":4,
-    "sigma":2.5,
-    "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":2,
-    "use_only_main_island":false,
-    "delta_time": 2
-  },
-  "dynamic_cleaning": {
-    "apply": true,
-    "threshold": 267,
-    "fraction_cleaning_intensity": 0.03
-  },
-
-  "random_forest_energy_regressor_args": {
-    "max_depth": 30,
-    "min_samples_leaf": 2,
-    "n_jobs": 4,
-    "n_estimators": 150,
-    "bootstrap": true,
-    "criterion": "squared_error",
-    "max_features": "auto",
-    "max_leaf_nodes": null,
-    "min_impurity_decrease": 0.0,
-    "min_samples_split": 10,
-    "min_weight_fraction_leaf": 0.0,
-    "oob_score": false,
-    "random_state": 42,
-    "verbose": 0,
-    "warm_start": false
-  },
-
-  "random_forest_disp_regressor_args": {
-    "max_depth": 30,
-    "min_samples_leaf": 2,
-    "n_jobs": 4,
-    "n_estimators": 150,
-    "bootstrap": true,
-    "criterion": "squared_error",
-    "max_features": "auto",
-    "max_leaf_nodes": null,
-    "min_impurity_decrease": 0.0,
-    "min_samples_split": 10,
-    "min_weight_fraction_leaf": 0.0,
-    "oob_score": false,
-    "random_state": 42,
-    "verbose": 0,
-    "warm_start": false
-  },
-
-  "random_forest_disp_classifier_args": {
-    "max_depth": 30,
-    "min_samples_leaf": 2,
-    "n_jobs": 4,
-    "n_estimators": 100,
-    "criterion": "gini",
-    "min_samples_split": 10,
-    "min_weight_fraction_leaf": 0.0,
-    "max_features": "auto",
-    "max_leaf_nodes": null,
-    "min_impurity_decrease": 0.0,
-    "bootstrap": true,
-    "oob_score": false,
-    "random_state": 42,
-    "verbose": 0.0,
-    "warm_start": false,
-    "class_weight": null
-  },
-
-  "random_forest_particle_classifier_args": {
-    "max_depth": 30,
-    "min_samples_leaf": 2,
-    "n_jobs": 4,
-    "n_estimators": 100,
-    "criterion": "gini",
-    "min_samples_split": 10,
-    "min_weight_fraction_leaf": 0.0,
-    "max_features": "auto",
-    "max_leaf_nodes": null,
-    "min_impurity_decrease": 0.0,
-    "bootstrap": true,
-    "oob_score": false,
-    "random_state": 42,
-    "verbose": 0.0,
-    "warm_start": false,
-    "class_weight": null
-  },
-
-
   "energy_regression_features": [
     "log_intensity",
     "width",
@@ -145,9 +10,7 @@
     "leakage_intensity_width_2",
     "dist"
   ],
-
   "disp_method": "disp_norm_sign",
-
   "disp_regression_features": [
     "log_intensity",
     "width",
@@ -159,7 +22,6 @@
     "leakage_intensity_width_2",
     "dist"
   ],
-
   "disp_classification_features": [
     "log_intensity",
     "width",
@@ -171,7 +33,6 @@
     "leakage_intensity_width_2",
     "dist"
   ],
-
   "particle_classification_features": [
     "log_intensity",
     "width",
@@ -185,29 +46,10 @@
     "dist"
   ],
 
-  "allowed_tels": [1, 2, 3, 4],
-  "write_pe_image": false,
-  "mc_image_scaling_factor": 1,
-  "image_extractor": "LocalPeakWindowSum",
-  "image_extractor_for_muons": "GlobalPeakWindowSum",
-  "CameraCalibrator": {
-    "apply_waveform_time_shift": false
-  },
-  "time_sampling_correction_path": "default",
-  "LocalPeakWindowSum":{
-    "window_shift": 4,
-    "window_width": 8,
-    "apply_integration_correction": false
-  },
-  "GlobalPeakWindowSum":{
-    "window_shift": 4,
-    "window_width": 8,
-    "apply_integration_correction": false
-  },
-  "timestamps_pointing":"ucts",
-
-  "train_gamma_src_r_deg": [0, Infinity],
-
+  "train_gamma_src_r_deg": [
+    0,
+    Infinity
+  ],
   "source_dependent": true,
   "mc_nominal_source_x_deg": 0.4,
   "mc_nominal_source_y_deg": 0.0,
@@ -215,55 +57,6 @@
   "observation_mode": "wobble",
   "n_off_wobble": 1,
   "source_name": "Crab Nebula",
-  "source_ra":83.63308333,
-  "source_dec":22.0145,
-
-  "volume_reducer":{
-    "algorithm": null,
-    "parameters": {
-    }
-  },
-  "calibration_product": "LSTCalibrationCalculator",
-
-  "LSTCalibrationCalculator":{
-    "systematic_correction_path": null,
-    "squared_excess_noise_factor": 1.222,
-    "flatfield_product": "FlasherFlatFieldCalculator",
-    "pedestal_product": "PedestalIntegrator",
-    "PedestalIntegrator":{
-      "sample_size": 10000,
-      "sample_duration":100000,
-      "tel_id":1,
-      "time_sampling_correction_path": null,
-      "charge_median_cut_outliers": [-10,10],
-      "charge_std_cut_outliers": [-10,10],
-      "charge_product":"FixedWindowSum",
-      "FixedWindowSum":{
-        "window_shift": 6,
-        "window_width":12,
-        "peak_index": 18,
-        "apply_integration_correction": false
-      }
-    },
-    "FlasherFlatFieldCalculator":{
-      "sample_size": 10000,
-      "sample_duration":100000,
-      "tel_id":1,
-      "time_sampling_correction_path": null,
-      "charge_product":"LocalPeakWindowSum",
-      "charge_median_cut_outliers": [-0.5,0.5],
-      "charge_std_cut_outliers": [-10,10],
-      "time_cut_outliers": [2,38],
-      "LocalPeakWindowSum":{
-        "window_shift": 5,
-        "window_width":12,
-        "apply_integration_correction": false
-      }
-    }
-  },
-  "waveform_nsb_tuning":{
-    "nsb_tuning": false,
-    "nsb_tuning_ratio": 0.52,
-    "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
-  }
+  "source_ra": 83.63308333,
+  "source_dec": 22.0145
 }

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -67,8 +67,8 @@
 
   "random_forest_energy_regressor_args": {
     "max_depth": 30,
-    "min_samples_leaf": 2,
-    "n_jobs": 4,
+    "min_samples_leaf": 10,
+    "n_jobs": -1,
     "n_estimators": 150,
     "bootstrap": true,
     "criterion": "squared_error",
@@ -85,8 +85,8 @@
 
   "random_forest_disp_regressor_args": {
     "max_depth": 30,
-    "min_samples_leaf": 2,
-    "n_jobs": 4,
+    "min_samples_leaf": 10,
+    "n_jobs": -1,
     "n_estimators": 150,
     "bootstrap": true,
     "criterion": "squared_error",
@@ -103,8 +103,8 @@
 
   "random_forest_disp_classifier_args": {
     "max_depth": 30,
-    "min_samples_leaf": 2,
-    "n_jobs": 4,
+    "min_samples_leaf": 10,
+    "n_jobs": -1,
     "n_estimators": 100,
     "criterion": "gini",
     "min_samples_split": 10,
@@ -122,8 +122,8 @@
 
   "random_forest_particle_classifier_args": {
     "max_depth": 30,
-    "min_samples_leaf": 2,
-    "n_jobs": 4,
+    "min_samples_leaf": 10,
+    "n_jobs": -1,
     "n_estimators": 100,
     "criterion": "gini",
     "min_samples_split": 10,
@@ -193,7 +193,7 @@
     "reco_disp_sign"
   ],
 
-  "allowed_tels": [1, 2, 3, 4],
+  "allowed_tels": [1],
   "write_pe_image": false,
   "mc_image_scaling_factor": 1,
   "image_extractor": "LocalPeakWindowSum",

--- a/lstchain/io/config.py
+++ b/lstchain/io/config.py
@@ -1,5 +1,5 @@
 import json
-import os
+from pathlib import Path
 from copy import copy
 
 __all__ = [
@@ -23,7 +23,8 @@ def read_configuration_file(config_filename):
     -------
     Dictionnary
     """
-    assert os.path.exists(config_filename)
+    if not Path(config_filename).exists():
+        raise FileNotFoundError(f"config file {config_filename} does not exist")
 
     with open(config_filename) as json_file:
         data = json.load(json_file)
@@ -39,11 +40,39 @@ def get_standard_config():
     -------
     dict
     """
-    standard_config_file = os.path.join(os.path.dirname(__file__), "../data/lstchain_standard_config.json")
+    standard_config_file = Path(__file__).parent.joinpath("../data/lstchain_standard_config.json")
     return read_configuration_file(standard_config_file)
 
 
-def get_srcdep_config():
+def get_mc_config():
+    """
+    Load the config from the file 'data/lstchain_mc_config.json'
+
+    Returns
+    -------
+    dict
+    """
+    std_cfg = get_standard_config()
+    mc_cfg = read_configuration_file(Path(__file__).parent.joinpath("../data/lstchain_mc_config.json"))
+    std_cfg.update(mc_cfg)
+    return std_cfg
+
+
+def get_src_dep_config():
+    """
+    Load the config from the file 'data/lstchain_src_dep_config.json'
+
+    Returns
+    -------
+    dict
+    """
+    std_cfg = get_standard_config()
+    src_dep_cfg = read_configuration_file(Path(__file__).parent.joinpath("../data/lstchain_src_dep_config.json"))
+    std_cfg.update(src_dep_cfg)
+    return std_cfg
+
+
+def get_src_dep_config():
     """
     Load the config for source-dependent analysis from the file 'data/lstchain_src_dep_config.json'
 
@@ -51,8 +80,8 @@ def get_srcdep_config():
     -------
     dict
     """
-    srcdep_config_file = os.path.join(os.path.dirname(__file__), "../data/lstchain_src_dep_config.json")
-    return read_configuration_file(srcdep_config_file)
+    src_dep_config_file = Path(__file__).parent.joinpath("../data/lstchain_src_dep_config.json")
+    return read_configuration_file(src_dep_config_file)
 
 
 def replace_config(base_config, new_config):
@@ -69,7 +98,6 @@ def replace_config(base_config, new_config):
     dict
     """
     config = copy(base_config)
-
     for k in new_config.keys():
         config[k] = new_config[k]
 
@@ -95,3 +123,18 @@ def get_cleaning_parameters(config, clean_method_name):
     min_n_picture_neighbors = config[clean_method_name]['min_number_picture_neighbors']
     return picture_th, boundary_th, isolated_pixels, min_n_picture_neighbors
 
+
+def dump_config(config, filename, overwrite=False):
+    """
+    Dump config to a json file
+
+    Parameters
+    ----------
+    config: dict
+    filename: Path
+    overwrite: bool
+    """
+    if Path(filename).exists() and not overwrite:
+        raise FileExistsError(f"File {filename} exists, use overwrite=True")
+    with open(filename, 'w') as file:
+        json.dump(config, file, indent=2)

--- a/lstchain/io/config.py
+++ b/lstchain/io/config.py
@@ -58,9 +58,9 @@ def get_mc_config():
     return std_cfg
 
 
-def get_src_dep_config():
+def get_srcdep_config():
     """
-    Load the config from the file 'data/lstchain_src_dep_config.json'
+    Load the config for source-dependent analysis from the file 'data/lstchain_src_dep_config.json'
 
     Returns
     -------
@@ -70,18 +70,6 @@ def get_src_dep_config():
     src_dep_cfg = read_configuration_file(Path(__file__).parent.joinpath("../data/lstchain_src_dep_config.json"))
     std_cfg.update(src_dep_cfg)
     return std_cfg
-
-
-def get_src_dep_config():
-    """
-    Load the config for source-dependent analysis from the file 'data/lstchain_src_dep_config.json'
-
-    Returns
-    -------
-    dict
-    """
-    src_dep_config_file = Path(__file__).parent.joinpath("../data/lstchain_src_dep_config.json")
-    return read_configuration_file(src_dep_config_file)
 
 
 def replace_config(base_config, new_config):

--- a/lstchain/io/tests/test_config.py
+++ b/lstchain/io/tests/test_config.py
@@ -1,15 +1,29 @@
 from lstchain.io import config
 from lstchain.io.config import get_cleaning_parameters
+import tempfile
+from pathlib import Path
 
 def test_get_standard_config():
-    config.get_standard_config()
+    std_cfg = config.get_standard_config()
+    assert 'source_config' in std_cfg
+    assert 'tailcut' in std_cfg
+
 
 def test_get_srcdep_config():
     srcdep_config = config.get_srcdep_config()
-    assert srcdep_config['source_dependent'] == True
+    assert 'tailcut' in srcdep_config
+    assert srcdep_config['source_dependent']
     assert srcdep_config['mc_nominal_source_x_deg'] == 0.4
     assert srcdep_config['observation_mode'] == 'wobble'
     assert srcdep_config['n_off_wobble'] == 1
+
+
+def test_get_mc_config():
+    mc_cfg = config.get_mc_config()
+    assert 'tailcut' in mc_cfg
+    assert mc_cfg['LocalPeakWindowSum']['apply_integration_correction']
+    assert mc_cfg['GlobalPeakWindowSum']['apply_integration_correction']
+
 
 def test_replace_config():
     a = dict(toto=1, tata=2)
@@ -19,6 +33,7 @@ def test_replace_config():
     assert c["tata"] == 3
     assert c["tutu"] == 4
 
+
 def test_get_cleaning_parameters():
     std_config = config.get_standard_config()
     cleaning_params = get_cleaning_parameters(std_config, 'tailcut')
@@ -27,3 +42,11 @@ def test_get_cleaning_parameters():
     assert std_config['tailcut']['boundary_thresh'] == boundary_th
     assert std_config['tailcut']['keep_isolated_pixels'] == isolated_pixels
     assert std_config['tailcut']['min_number_picture_neighbors'] == min_n_neighbors
+
+def test_dump_config():
+    cfg = {'myconf': 1}
+    with tempfile.NamedTemporaryFile() as file:
+        config.dump_config(cfg, file.name)
+        assert Path(file.name).exists()
+        read_cfg = config.read_configuration_file(file.name)
+        assert read_cfg['myconf'] == 1

--- a/lstchain/io/tests/test_config.py
+++ b/lstchain/io/tests/test_config.py
@@ -1,7 +1,7 @@
 from lstchain.io import config
 from lstchain.io.config import get_cleaning_parameters
 import tempfile
-from pathlib import Path
+
 
 def test_get_standard_config():
     std_cfg = config.get_standard_config()
@@ -43,10 +43,10 @@ def test_get_cleaning_parameters():
     assert std_config['tailcut']['keep_isolated_pixels'] == isolated_pixels
     assert std_config['tailcut']['min_number_picture_neighbors'] == min_n_neighbors
 
+
 def test_dump_config():
     cfg = {'myconf': 1}
     with tempfile.NamedTemporaryFile() as file:
-        config.dump_config(cfg, file.name)
-        assert Path(file.name).exists()
+        config.dump_config(cfg, file.name, overwrite=True)
         read_cfg = config.read_configuration_file(file.name)
         assert read_cfg['myconf'] == 1

--- a/lstchain/scripts/lstchain_dump_config.py
+++ b/lstchain/scripts/lstchain_dump_config.py
@@ -9,7 +9,7 @@ import logging
 from pathlib import Path
 
 from lstchain.io.config import (read_configuration_file, dump_config,
-                                get_standard_config, get_mc_config, get_src_dep_config
+                                get_standard_config, get_mc_config, get_srcdep_config
                                 )
 
 
@@ -22,7 +22,7 @@ def update_std_config(new_config):
     return std_config
 
 
-def main():
+def build_parser():
     parser = argparse.ArgumentParser(description="Dump lstchain config in a file.")
 
     # Required arguments
@@ -50,7 +50,12 @@ def main():
                         help='Overwrite existing output file',
                         )
 
-    args = parser.parse_args()
+    return parser
+
+
+def main():
+
+    args = build_parser.parse_args()
 
     if args.mc and args.src_dep:
         raise ValueError("--mc and --src-dep can't be used at the same time")
@@ -58,7 +63,7 @@ def main():
     if args.mc:
         config = get_mc_config()
     elif args.src_dep:
-        config = get_src_dep_config()
+        config = get_srcdep_config()
     else:
         config = get_standard_config()
 
@@ -67,7 +72,6 @@ def main():
             raise FileNotFoundError(f"Config file {args.update_with} does not exist")
         extra_config = read_configuration_file(args.update_with)
         config.update(extra_config)
-
 
     dump_config(config, args.output_file, overwrite=args.overwrite)
 

--- a/lstchain/scripts/lstchain_dump_config.py
+++ b/lstchain/scripts/lstchain_dump_config.py
@@ -63,7 +63,7 @@ def main():
         config = get_standard_config()
 
     if args.update_with:
-        if not args.update_with.exists():
+        if not args.update_with.is_file():
             raise FileNotFoundError(f"Config file {args.update_with} does not exist")
         extra_config = read_configuration_file(args.update_with)
         config.update(extra_config)

--- a/lstchain/scripts/lstchain_dump_config.py
+++ b/lstchain/scripts/lstchain_dump_config.py
@@ -55,7 +55,7 @@ def build_parser():
 
 def main():
 
-    args = build_parser.parse_args()
+    args = build_parser().parse_args()
 
     if args.mc and args.src_dep:
         raise ValueError("--mc and --src-dep can't be used at the same time")

--- a/lstchain/scripts/lstchain_dump_config.py
+++ b/lstchain/scripts/lstchain_dump_config.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+"""
+
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+from lstchain.io.config import (read_configuration_file, dump_config,
+                                get_standard_config, get_mc_config, get_src_dep_config
+                                )
+
+
+log = logging.getLogger(__name__)
+
+
+def update_std_config(new_config):
+    std_config = get_standard_config()
+    std_config.update(new_config)
+    return std_config
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Dump lstchain config in a file.")
+
+    # Required arguments
+    parser.add_argument('-o', '--output-file',
+                        help='path to the output file containing the config',
+                        default='lstchain_config.json',
+                        type=Path,
+                        )
+
+    parser.add_argument('--update-with',
+                        help='Path to a partial config to update the full config with',
+                        type=Path
+                        )
+
+    parser.add_argument('--mc',
+                        action='store_true',
+                        help='Use to dump a modified standard configuration for Monte-Carlo analysis')
+
+    parser.add_argument('--src-dep',
+                        action='store_true',
+                        help='Use to dump a modified standard configuration for source dependent analysis')
+
+    parser.add_argument('--overwrite',
+                        action='store_true',
+                        help='Overwrite existing output file',
+                        )
+
+    args = parser.parse_args()
+
+    if args.mc and args.src_dep:
+        raise ValueError("--mc and --src-dep can't be used at the same time")
+
+    if args.mc:
+        config = get_mc_config()
+    elif args.src_dep:
+        config = get_src_dep_config()
+    else:
+        config = get_standard_config()
+
+    if args.update_with:
+        if not args.update_with.exists():
+            raise FileNotFoundError(f"Config file {args.update_with} does not exist")
+        extra_config = read_configuration_file(args.update_with)
+        config.update(extra_config)
+
+
+    dump_config(config, args.output_file, overwrite=args.overwrite)
+
+    log.info(f"Config dumped in {args.output_file}")
+
+
+if __name__ == '__main__':
+    main()

--- a/lstchain/scripts/lstchain_tune_nsb.py
+++ b/lstchain/scripts/lstchain_tune_nsb.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 
 from lstchain.image.modifier import calculate_noise_parameters
+from lstchain.io.config import dump_config, read_configuration_file
 
 log = logging.getLogger(__name__)
 
@@ -32,16 +33,30 @@ parser.add_argument(
          'one used for calibration and DL1 creation)',
     required=True,
 )
+
 parser.add_argument(
     '--input-mc', type=Path,
     help='Path to a simtel file of the production (must include the true '
          'p.e. images)',
     required=True,
 )
+
 parser.add_argument(
     '--input-data', type=Path,
     help='Path to a data DL1 file of the production (must include DL1a)',
     required=True,
+)
+
+parser.add_argument(
+    '--output-file', '-o',
+    type=Path,
+    help='Path to a output file where to dump the update config',
+)
+
+parser.add_argument(
+    '--overwrite',
+    action='store_true',
+    help='Use to overwrite output-file',
 )
 
 
@@ -76,7 +91,10 @@ def main():
     log.info(json.dumps(dict_nsb, indent=2))
     log.info('\n')
 
-    return
+    if args.output_file:
+        cfg = read_configuration_file(args.config)
+        cfg['image_modifier'].update(dict_nsb)
+        dump_config(cfg, args.output_file, overwrite=args.overwrite)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I think this should solve #924 (implementing solution B discussed there) #208 and improve the way we deal with configs.

- MC now gets its own config file so we stop forgetting about `apply_integration_correction`
- Users can still work with a limited config file (e.g. containing only an updated `tailcut` config different from the standard one)
- Users can then use the `--update-with` to dump a full configuration from that limited config


@SeiyaNozaki could you have a look at the update srcdep config please?



Fixes #924 
Fixes #208 
