### PR TITLE
Fix timestamps in DL3 files, fixes #986

### DIFF
--- a/lstchain/high_level/hdu_table.py
+++ b/lstchain/high_level/hdu_table.py
@@ -432,15 +432,18 @@ def create_event_list(
     ev_header["TIME-OBS"] = time_params["time_obs"]
     ev_header["DATE-END"] = time_params["date_end"]
     ev_header["TIME-END"] = time_params["time_end"]
-    ev_header["TSTART"] = time_params["t_start"]
-    ev_header["TSTOP"] = time_params["t_stop"]
+    ev_header["TSTART"] = (time_params["t_start"].value, time_params["t_start"].unit)
+    ev_header["TSTOP"] = (time_params["t_stop"].value, time_params["t_stop"].unit)
     ev_header["MJDREFI"] = time_params["MJDREFI"]
     ev_header["MJDREFF"] = time_params["MJDREFF"]
     ev_header["TIMEUNIT"] = "s"
     ev_header["TIMESYS"] = "UTC"
     ev_header["TIMEREF"] = "TOPOCENTER"
     ev_header["ONTIME"] = elapsed_time
-    ev_header["TELAPSE"] = (time_params["t_stop"] - time_params["t_start"]).to(u.s)
+    ev_header["TELAPSE"] = (
+        (time_params["t_stop"] - time_params["t_start"]).to_value(u.s),
+        u.s
+    )
     ev_header["DEADC"] = effective_time / elapsed_time
     ev_header["LIVETIME"] = effective_time
 

--- a/lstchain/high_level/tests/test_hdus.py
+++ b/lstchain/high_level/tests/test_hdus.py
@@ -88,7 +88,7 @@ def test_get_timing_params():
 
     params = get_timing_params(data)
 
-    # Converting to a single mjd number looses precision but should be better than 0.1 us
+    # Converting to a single mjd number loses precision but should be better than 0.1 us
     epoch = Time(params["MJDREFI"], params["MJDREFF"], format="mjd")
     assert (epoch + params['t_start']).isclose(t[0], atol=0.1 * u.us)
     assert (epoch + params['t_stop']).isclose(t[-1], atol=0.1 * u.us)


### PR DESCRIPTION
Timestamps were wrong by amount of UTC leap seconds before.