### PR TITLE
Apply interleaved calibration factors in dl1ab step

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -64,6 +64,7 @@
     "threshold": 267,
     "fraction_cleaning_intensity": 0.03
   },
+  "apply_interleaved_cal": true,
 
   "random_forest_energy_regressor_args": {
     "max_depth": 30,

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -269,7 +269,7 @@ def main():
                     
                     if params['calibration_id'] == ORIGINAL_CALIBRATION_ID:
                         flag_selected_gain = np.array(
-                            [selected_gain_channel == HIGHG_AIN, 
+                            [selected_gain_channel == HIGH_GAIN, 
                              selected_gain_channel == LOW_GAIN],
                             dtype=bool
                         ) 


### PR DESCRIPTION
The calculation of calibration factors and identification of bad pixels can be done using interleaved pedestal and calibration laser events. However, such information is not applied to the data analysis chain (subrun-wise r0 to dl1 step) since 100,000 laser events are required to update calibration factors in the standard configuration file. Thus, the analysis chain uses the calibration factors computed using the standard ped+cal run taken at the beginning of the night shift for all of the runs.
 
 This PR enables to recalibrate pixel charge and peak time in dl1ab step with calibration factors computed using interleaved ped+cal events. This process is applied to events with `calibration_id`=0 (for now all events have `calibration_id`= 0). Since `dc_to_pe` of `unusable_pixels` is zero, pixels defined unusable by interleaved calibration events have zero charge after this recalibration. So it would be better to treat those bad pixels using interpolation or something (#716 which will be updated soon). In addition, more robust definition of bad pixels in calibration codes is needed using #969 or #971 

@FrancaCassol What do you think?
 