### PR TITLE
Fix comparison of timestamps in calibration code

### DIFF
--- a/lstchain/calib/camera/flatfield.py
+++ b/lstchain/calib/camera/flatfield.py
@@ -168,8 +168,7 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
 
         self.collect_sample(charge, pixel_mask, arrival_time)
 
-        sample_age = self.trigger_time - self.time_start
-
+        sample_age = (self.trigger_time - self.time_start).to_value(u.s)
         # check if to create a calibration event
         if (self.num_events_seen > 0 and
                 (sample_age > self.sample_duration or

--- a/lstchain/calib/camera/pedestals.py
+++ b/lstchain/calib/camera/pedestals.py
@@ -162,9 +162,7 @@ class PedestalIntegrator(PedestalCalculator):
 
         self.collect_sample(charge, pixel_mask)
 
-        sample_age = self.trigger_time - self.time_start
-
-
+        sample_age = (self.trigger_time - self.time_start).to_value(u.s)
         # check if to create a calibration event
         if (self.num_events_seen > 0 and
                 (sample_age > self.sample_duration or


### PR DESCRIPTION
This code was comparing an astropy `TimeDelta` object to a plain number,
which was supposed to be in seconds. However, astropy treats plain
numbers as days, not seconds. Since astropy 5.1, this creates a warning
and made me find this bug. See
astropy/astropy#12887.

This means that in when calculating calibration coefficients, the condition for the sample duration was never met, only the number of events condition was used effectively.

I don't know if that has any consequences, since we right now analyze subrun by subrun and these are shorter than the  default 60s sample duration value.