### PR TITLE
Add an option to disable disp reconstruction

### DIFF
--- a/lstchain/conftest.py
+++ b/lstchain/conftest.py
@@ -274,8 +274,6 @@ def rf_models_srcdep(temp_dir_simulated_srcdep_files, simulated_dl1_file):
     models_srcdep_path = temp_dir_simulated_srcdep_files
     file_model_energy_srcdep = models_srcdep_path / "reg_energy.sav"
     file_model_gh_sep_srcdep = models_srcdep_path / "cls_gh.sav"
-    file_model_disp_norm_srcdep = models_srcdep_path / "reg_disp_norm.sav"
-    file_model_disp_sign_srcdep = models_srcdep_path / "cls_disp_sign.sav"
     srcdep_config_file = os.path.join(os.getcwd(), "./lstchain/data/lstchain_src_dep_config.json")
 
     run_program(
@@ -293,8 +291,6 @@ def rf_models_srcdep(temp_dir_simulated_srcdep_files, simulated_dl1_file):
         "energy": file_model_energy_srcdep,
         "gh_sep": file_model_gh_sep_srcdep,
         "path": models_srcdep_path,
-        "disp_norm": file_model_disp_norm_srcdep,
-        "disp_sign": file_model_disp_sign_srcdep,
     }
 
 @pytest.fixture(scope="session")

--- a/lstchain/data/lstchain_src_dep_config.json
+++ b/lstchain/data/lstchain_src_dep_config.json
@@ -10,7 +10,7 @@
     "leakage_intensity_width_2",
     "dist"
   ],
-  "disp_method": "disp_norm_sign",
+  "disp_method": null,
   "disp_regression_features": [
     "log_intensity",
     "width",

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -900,6 +900,10 @@ def read_mc_dl2_to_QTable(filename):
         events_srcdep = get_srcdep_params(filename, 'on')
         events = pd.concat([events, events_srcdep], axis=1)
 
+        for k in ['reco_alt', 'reco_az']:
+            if not k in events.keys():
+                del unit_mapping[k]
+
     events = events.rename(columns=name_mapping)
 
     events = QTable.from_pandas(events)
@@ -949,6 +953,10 @@ def read_data_dl2_to_QTable(filename, srcdep_pos=None):
     if srcdep_flag:
         data_srcdep = get_srcdep_params(filename, srcdep_pos)
         data = pd.concat([data, data_srcdep], axis=1)
+        
+        for k in ['reco_alt', 'reco_az']:
+            if not k in data.keys():
+                del unit_mapping[k]
 
     data = data.rename(columns=name_mapping)
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -597,26 +597,26 @@ def apply_models(dl1,
         # Defined on the major image axis; sign is such that it is typically positive for gammas:    
         dl2['signed_skewness'] = -1 * np.sign(longi) * dl2['skewness']
         
-    if 'mc_alt_tel' in dl2.columns:
-        alt_tel = dl2['mc_alt_tel'].values
-        az_tel = dl2['mc_az_tel'].values
-    elif 'alt_tel' in dl2.columns:
-        alt_tel = dl2['alt_tel'].values
-        az_tel = dl2['az_tel'].values
-    else:
-        alt_tel = - np.pi / 2. * np.ones(len(dl2))
-        az_tel = - np.pi / 2. * np.ones(len(dl2))
+        if 'mc_alt_tel' in dl2.columns:
+            alt_tel = dl2['mc_alt_tel'].values
+            az_tel = dl2['mc_az_tel'].values
+        elif 'alt_tel' in dl2.columns:
+            alt_tel = dl2['alt_tel'].values
+            az_tel = dl2['az_tel'].values
+        else:
+            alt_tel = - np.pi / 2. * np.ones(len(dl2))
+            az_tel = - np.pi / 2. * np.ones(len(dl2))
+            
+        src_pos_reco = utils.reco_source_position_sky(dl2.x.values * u.m,
+                                                      dl2.y.values * u.m,
+                                                      dl2.reco_disp_dx.values * u.m,
+                                                      dl2.reco_disp_dy.values * u.m,
+                                                      focal_length,
+                                                      alt_tel * u.rad,
+                                                      az_tel * u.rad)
 
-    src_pos_reco = utils.reco_source_position_sky(dl2.x.values * u.m,
-                                                  dl2.y.values * u.m,
-                                                  dl2.reco_disp_dx.values * u.m,
-                                                  dl2.reco_disp_dy.values * u.m,
-                                                  focal_length,
-                                                  alt_tel * u.rad,
-                                                  az_tel * u.rad)
-
-    dl2['reco_alt'] = src_pos_reco.alt.rad
-    dl2['reco_az'] = src_pos_reco.az.rad
+        dl2['reco_alt'] = src_pos_reco.alt.rad
+        dl2['reco_az'] = src_pos_reco.az.rad
 
     dl2['reco_type'] = classifier.predict(dl2[classification_features]).astype(int)
     probs = classifier.predict_proba(dl2[classification_features])

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -155,26 +155,28 @@ def main():
 
         for i, k in enumerate(srcdep_assumed_positions):
             data_with_srcdep_param = pd.concat([data, data_srcdep[k]], axis=1)
+
             data_with_srcdep_param = filter_events(data_with_srcdep_param,
                                                    filters=config["events_filters"],
                                                    finite_params=config['energy_regression_features']
-                                                                 + config['disp_regression_features']
-                                                                 + config['particle_classification_features']
-                                                                 + config['disp_classification_features'],
-                                                   )
+                                                   + config['disp_regression_features']
+                                                   + config['particle_classification_features']
+                                                   + config['disp_classification_features'],
+                                               )
 
-            if config['disp_method'] == 'disp_vector':
+            if config['disp_method'] is not None:                
+                if config['disp_method'] == 'disp_vector':
+                    dl2_df = dl1_to_dl2.apply_models(data_with_srcdep_param, cls_gh, reg_energy,
+                                                     reg_disp_vector=reg_disp_vector,
+                                                     focal_length=focal_length, custom_config=config)
+                elif config['disp_method'] == 'disp_norm_sign':
+                    dl2_df = dl1_to_dl2.apply_models(data_with_srcdep_param, cls_gh, reg_energy,
+                                                     reg_disp_norm=reg_disp_norm,
+                                                     cls_disp_sign=cls_disp_sign, focal_length=focal_length,
+                                                     custom_config=config)
+            else:
                 dl2_df = dl1_to_dl2.apply_models(data_with_srcdep_param, cls_gh, reg_energy,
-                                                 reg_disp_vector=reg_disp_vector,
                                                  focal_length=focal_length, custom_config=config)
-            elif config['disp_method'] == 'disp_norm_sign':
-                dl2_df = dl1_to_dl2.apply_models(data_with_srcdep_param, cls_gh, reg_energy,
-                                                 reg_disp_norm=reg_disp_norm,
-                                                 cls_disp_sign=cls_disp_sign, focal_length=focal_length,
-                                                 custom_config=config)
-            elif config['disp_method'] is None:
-                dl2 = dl1_to_dl2.apply_models(data, cls_gh, reg_energy,
-                                              focal_length=focal_length, custom_config=config)
 
 
             dl2_srcdep = dl2_df.drop(srcindep_keys, axis=1)

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -172,6 +172,10 @@ def main():
                                                  reg_disp_norm=reg_disp_norm,
                                                  cls_disp_sign=cls_disp_sign, focal_length=focal_length,
                                                  custom_config=config)
+            elif config['disp_method'] is None:
+                dl2 = dl1_to_dl2.apply_models(data, cls_gh, reg_energy,
+                                              focal_length=focal_length, custom_config=config)
+
 
             dl2_srcdep = dl2_df.drop(srcindep_keys, axis=1)
             dl2_srcdep_dict[k] = dl2_srcdep

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -182,8 +182,6 @@ def test_lstchain_mc_trainpipe(rf_models):
 
 def test_lstchain_mc_trainpipe_srcdep(rf_models_srcdep):
     assert rf_models_srcdep["energy"].is_file()
-    assert rf_models_srcdep["disp_norm"].is_file()
-    assert rf_models_srcdep["disp_sign"].is_file()
     assert rf_models_srcdep["gh_sep"].is_file()
 
 
@@ -308,10 +306,6 @@ def test_lstchain_dl1_to_dl2_srcdep(simulated_srcdep_dl2_file):
     assert "gammaness" in dl2_srcdep_df['on'].columns
     assert "reco_type" in dl2_srcdep_df['on'].columns
     assert "reco_energy" in dl2_srcdep_df['on'].columns
-    assert "reco_disp_dx" in dl2_srcdep_df['on'].columns
-    assert "reco_disp_dy" in dl2_srcdep_df['on'].columns
-    assert "reco_src_x" in dl2_srcdep_df['on'].columns
-    assert "reco_src_y" in dl2_srcdep_df['on'].columns    
 
 
 @pytest.mark.private_data
@@ -363,11 +357,7 @@ def test_lstchain_observed_dl1_to_dl2_srcdep(observed_srcdep_dl2_file):
         'skewness_from_source',
         'gammaness',
         'reco_type',
-        'reco_energy',
-        'reco_disp_dx',
-        'reco_disp_dy',
-        'reco_src_x',
-        'reco_src_y'
+        'reco_energy'
     ]
 
     for srcdep_assumed_position in srcdep_assumed_positions:


### PR DESCRIPTION
This PR enables to disable disp reconstruction for source-dependent analysis. 
It can be switched on/off through a configuration file.