### PR TITLE
Add dummy RAD_MAX for source-dependent analysis

### DIFF
--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -504,7 +504,7 @@ class IRFFITSWriter(Tool):
                         'deg'
                     )
             else:
-
+                # add dummy "RAD_MAX" to adapt to 1D analysis with gammapy>0.20.1
                 extra_headers["RAD_MAX"] = (
                     0.1,
                     'deg'

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -504,6 +504,12 @@ class IRFFITSWriter(Tool):
                         'deg'
                     )
             else:
+
+                extra_headers["RAD_MAX"] = (
+                    0.1,
+                    'deg'
+                )
+
                 if self.energy_dependent_alpha:
                     extra_headers["AL_CONT"] = (
                         self.cuts.alpha_containment,


### PR DESCRIPTION
The latest version of gammapy (>0.20.1) always requires `RAD_MAX` to extract the ON/OFF region (e.g. `WobbleRegionsFinder`). This PR adds "dummy" RAD_MAX to adapt to the latest gammapy codes for source-dependent analysis. 