### PR TITLE
Update lstchain_dl1ab_tune_MC_to_Crab_config.json

### DIFF
--- a/lstchain/data/lstchain_dl1ab_tune_MC_to_Crab_config.json
+++ b/lstchain/data/lstchain_dl1ab_tune_MC_to_Crab_config.json
@@ -12,12 +12,12 @@
 
   "image_modifier": {
     "increase_nsb": true,
-    "extra_noise_in_dim_pixels": 1.2,
-    "extra_bias_in_dim_pixels": 0.5,
+    "extra_noise_in_dim_pixels": 1.27,
+    "extra_bias_in_dim_pixels": 0.665,
     "transition_charge": 8,
-    "extra_noise_in_bright_pixels": 1.2,
-    "increase_psf": true,
-    "smeared_light_fraction": 0.125
+    "extra_noise_in_bright_pixels": 2.08,
+    "increase_psf": false,
+    "smeared_light_fraction": 0
   },
 
   "tailcut": {


### PR DESCRIPTION
To avoid confusions, set here as default the values currently used (with the LST-Prod2 MC) to tune the simulations to Crab data. 

The NSB increase is higher than before because in this simulation we use mirror_degraded_fraction (instead of telescope_transmission) to adjust in sim_telarray the light collection efficiency (by a factor 0.784). This will scale the NSB down, so we have to increase the value in the tuning applied in DL1ab. 

As for PSF, we are not tuning it now based on muons: we have now a better PSF in the simulation (based on star images on the star imaging screen), which seems ok to match the Width distributions f gammas,  plus we have now doubts that the muon ring width info is accurate enough to allow fine tuning of the psf.