### PR TITLE
Refactoring: Create LST Cleaning Component

### DIFF
--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -180,9 +180,9 @@ def find_safe_threshold_from_dl1_file(dl1_path, config_file=None,
     else:
         config = std_config
 
-    image_cleaner = "TailcutsImageCleaner"
-    picture_th, _, _, _ = get_cleaning_parameters(config, image_cleaner)
-    sigma = config["pedestal_cleaning"]["sigma"]
+    cleaner = "LSTImageCleaner"
+    picture_th, _, _, _ = get_cleaning_parameters(config, cleaner)
+    sigma = config[cleaner]["sigma"]
 
     # Obtain the picture thresholds of pixels based on the "clean with
     # pedestal threshold" method:

--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -139,9 +139,9 @@ def find_safe_threshold_from_dl1_file(dl1_path, config_file=None,
     else:
         config = std_config
 
-    cleaning_method = 'tailcuts_clean_with_pedestal_threshold'
-    picture_th, _, _, _ = get_cleaning_parameters(config, cleaning_method)
-    sigma = config[cleaning_method]['sigma']
+    image_cleaner = "TailcutsImageCleaner"
+    picture_th, _, _, _ = get_cleaning_parameters(config, image_cleaner)
+    sigma = config["pedestal_cleaning"]["sigma"]
 
     # Obtain the picture thresholds of pixels based on the "clean with
     # pedestal threshold" method:

--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -11,12 +11,32 @@ ORIGINAL_CALIBRATION_ID = 0
 INTERLEAVED_CALIBRATION_ID = 1
 
 def get_ped_thresh(tel_id, event, sigma):
+    """
+    Does the same as `get_threshold_from_dl1_file`, but instead of extracting the 
+    interleaved pedestal values directly with pytables, it uses the event loop.
+
+    Parameters
+    ----------
+    tel_id: int
+        Telescope id
+    event: ctapipe.containers.ArrayEventContainer
+        Top-level container for all event information. 
+    sigma: float
+        cleaning level parameter
+
+    Returns
+    -------
+    picture_thresh: np.ndarray
+        picture threshold calculated using interleaved pedestal events
+    """
+    # `get_bias_and_std`
     ped_charge_mean = event.mon.tel[tel_id].pedestal.charge_mean
     ped_charge_std = event.mon.tel[tel_id].pedestal.charge_std
     dc_to_pe = event.mon.tel[tel_id].calibration.dc_to_pe[ORIGINAL_CALIBRATION_ID]
     ped_charge_mean_pe = ped_charge_mean * dc_to_pe
     ped_charge_std_pe = ped_charge_std * dc_to_pe
 
+    # `get_threshold_from_dl1_file`
     if ped_charge_std_pe.shape[0] > 1:
         pedestal_id = INTERLEAVED_CALIBRATION_ID
     else:

--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -10,7 +10,7 @@ from lstchain.io.config import get_cleaning_parameters
 ORIGINAL_CALIBRATION_ID = 0
 INTERLEAVED_CALIBRATION_ID = 1
 
-def get_ped_thresh(tel_id, event, sigma):
+def get_ped_thresh(tel_id, event, sigma_clean):
     """
     Does the same as `get_threshold_from_dl1_file`, but instead of extracting the 
     interleaved pedestal values directly with pytables, it uses the event loop.
@@ -42,7 +42,7 @@ def get_ped_thresh(tel_id, event, sigma):
     else:
         pedestal_id = ORIGINAL_CALIBRATION_ID
 
-    threshold_clean_pe = ped_charge_mean_pe + sigma * ped_charge_std_pe
+    threshold_clean_pe = ped_charge_mean_pe + sigma_clean * ped_charge_std_pe
 
     unusable_pixels = event.mon.tel[tel_id].calibration.unusable_pixels
 

--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -21,7 +21,7 @@ def get_ped_thresh(tel_id, event, sigma_clean):
         Telescope id
     event: ctapipe.containers.ArrayEventContainer
         Top-level container for all event information. 
-    sigma: float
+    sigma_clean: float
         cleaning level parameter
 
     Returns

--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -10,9 +10,10 @@ from lstchain.io.config import get_cleaning_parameters
 ORIGINAL_CALIBRATION_ID = 0
 INTERLEAVED_CALIBRATION_ID = 1
 
+
 def get_ped_thresh(tel_id, event, sigma_clean):
     """
-    Does the same as `get_threshold_from_dl1_file`, but instead of extracting the 
+    Does the same as `get_threshold_from_dl1_file`, but instead of extracting the
     interleaved pedestal values directly with pytables, it uses the event loop.
 
     Parameters
@@ -20,7 +21,7 @@ def get_ped_thresh(tel_id, event, sigma_clean):
     tel_id: int
         Telescope id
     event: ctapipe.containers.ArrayEventContainer
-        Top-level container for all event information. 
+        Top-level container for all event information.
     sigma_clean: float
         cleaning level parameter
 
@@ -46,10 +47,12 @@ def get_ped_thresh(tel_id, event, sigma_clean):
 
     unusable_pixels = event.mon.tel[tel_id].calibration.unusable_pixels
 
-    threshold_clean_pe[pedestal_id, HIGH_GAIN, unusable_pixels] = \
-        max(threshold_clean_pe[pedestal_id, HIGH_GAIN, :])
-    
+    threshold_clean_pe[pedestal_id, HIGH_GAIN, unusable_pixels] = max(
+        threshold_clean_pe[pedestal_id, HIGH_GAIN, :]
+    )
+
     return threshold_clean_pe[pedestal_id, HIGH_GAIN, :]
+
 
 def get_bias_and_std(dl1_file):
     """
@@ -73,6 +76,7 @@ def get_bias_and_std(dl1_file):
         ped_charge_std_pe = ped_charge_std * dc_to_pe
 
     return ped_charge_mean_pe, ped_charge_std_pe
+
 
 def get_threshold_from_dl1_file(dl1_path, sigma_clean):
     """
@@ -106,28 +110,33 @@ def get_threshold_from_dl1_file(dl1_path, sigma_clean):
         pedestal_id = INTERLEAVED_CALIBRATION_ID
     else:
         pedestal_id = ORIGINAL_CALIBRATION_ID
-    threshold_clean_pe = ped_mean_pe + sigma_clean*ped_std_pe
+    threshold_clean_pe = ped_mean_pe + sigma_clean * ped_std_pe
     # find pixels with std = 0 and mean = 0 <=> dead pixels in interleaved
     # pedestal event likely due to stars
     unusable_pixels = get_unusable_pixels(dl1_path, pedestal_id)
     # for dead pixels set max value of threshold
-    threshold_clean_pe[pedestal_id, HIGH_GAIN, unusable_pixels] = \
-        max(threshold_clean_pe[pedestal_id, HIGH_GAIN, :])
+    threshold_clean_pe[pedestal_id, HIGH_GAIN, unusable_pixels] = max(
+        threshold_clean_pe[pedestal_id, HIGH_GAIN, :]
+    )
     # return pedestal interleaved threshold from data run for high gain
     return threshold_clean_pe[pedestal_id, HIGH_GAIN, :]
 
+
 def get_unusable_pixels(dl1_path, pedestal_id):
     with tables.open_file(dl1_path) as f:
-        calibration_id = f.root.dl1.event.telescope.monitoring.pedestal.col('calibration_id')
-        unusable_pixels = np.where(f.root[dl1_params_tel_mon_cal_key].col(
-                                   'unusable_pixels')[calibration_id[pedestal_id],
-                                                      HIGH_GAIN,
-                                                      :] == True)
+        calibration_id = f.root.dl1.event.telescope.monitoring.pedestal.col(
+            "calibration_id"
+        )
+        unusable_pixels = np.where(
+            f.root[dl1_params_tel_mon_cal_key].col("unusable_pixels")[
+                calibration_id[pedestal_id], HIGH_GAIN, :
+            ]
+            == True
+        )
     return unusable_pixels
 
 
-def find_safe_threshold_from_dl1_file(dl1_path, config_file=None,
-                                      max_fraction=0.04):
+def find_safe_threshold_from_dl1_file(dl1_path, config_file=None, max_fraction=0.04):
     """
     Function to obtain an integer value for the picture threshold such that
     at most a fraction max_fraction of pixels have a higher value resulting
@@ -175,8 +184,7 @@ def find_safe_threshold_from_dl1_file(dl1_path, config_file=None,
     """
     std_config = get_standard_config()
     if config_file is not None:
-        config = replace_config(std_config,
-                                read_configuration_file(config_file))
+        config = replace_config(std_config, read_configuration_file(config_file))
     else:
         config = std_config
 

--- a/lstchain/calib/camera/tests/test_pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/tests/test_pixel_threshold_estimation.py
@@ -1,6 +1,6 @@
 import numpy as np
-from ctapipe.containers import ArrayEventContainer
 import pytest
+from ctapipe.containers import ArrayEventContainer
 
 def test_get_ped_thresh():
     from ..pixel_threshold_estimation import get_ped_thresh
@@ -36,9 +36,9 @@ def test_get_threshold_from_dl1_file(observed_dl1_files):
     file = observed_dl1_files["dl1_file1"]
     sigma = 2.5
     ped_thresh = get_threshold_from_dl1_file(file, sigma_clean=sigma)
-
+    
     assert (ped_thresh.shape == (1855,))
-    assert (ped_thresh[ped_thresh>0].sum() == 1855)
+    assert (np.max(ped_thresh) > 0)
 
 
 @pytest.mark.private_data
@@ -47,6 +47,6 @@ def test_get_unusable_pixels(observed_dl1_files):
 
     file = observed_dl1_files["dl1_file1"]
     unusable_pixels = get_unusable_pixels(file, pedestal_id=0)
-
-    assert (unusable_pixels.shape == (1855,))
+    
+    assert (len(unusable_pixels[0]) == 2)
 

--- a/lstchain/calib/camera/tests/test_pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/tests/test_pixel_threshold_estimation.py
@@ -1,0 +1,52 @@
+import numpy as np
+from ctapipe.containers import ArrayEventContainer
+import pytest
+
+def test_get_ped_thresh():
+    from ..pixel_threshold_estimation import get_ped_thresh
+
+    tel_id = 1
+    sigma = 2
+    event = ArrayEventContainer()
+    event.mon.tel[tel_id].pedestal.charge_mean = np.full((2, 2, 1855), 4, dtype='int')
+    event.mon.tel[tel_id].pedestal.charge_std = np.full((2, 2, 1855), 3, dtype='int')
+    event.mon.tel[tel_id].calibration.dc_to_pe = np.full((2, 2, 1855), 2, dtype='int')
+    event.mon.tel[tel_id].calibration.unusable_pixels = np.full((1855,), False, dtype='bool')
+
+    ped_thresh = get_ped_thresh(tel_id=tel_id, event=event, sigma_clean=sigma)
+    ped_thresh_real = np.full((1855,), 20, dtype='int')
+
+    assert (ped_thresh.all() == ped_thresh_real.all())
+
+@pytest.mark.private_data
+def test_get_bias_and_std(observed_dl1_files):
+    from ..pixel_threshold_estimation import get_bias_and_std
+
+    file = observed_dl1_files["dl1_file1"]
+    ped_charge_mean_pe, ped_charge_std_pe = get_bias_and_std(file)
+
+    assert (ped_charge_mean_pe.shape[2] == 1855)
+    assert (ped_charge_std_pe.shape[2] == 1855)
+
+
+@pytest.mark.private_data
+def test_get_threshold_from_dl1_file(observed_dl1_files):
+    from ..pixel_threshold_estimation import get_threshold_from_dl1_file
+
+    file = observed_dl1_files["dl1_file1"]
+    sigma = 2.5
+    ped_thresh = get_threshold_from_dl1_file(file, sigma_clean=sigma)
+
+    assert (ped_thresh.shape == (1855,))
+    assert (ped_thresh[ped_thresh>0].sum() == 1855)
+
+
+@pytest.mark.private_data
+def test_get_unusable_pixels(observed_dl1_files):
+    from ..pixel_threshold_estimation import get_unusable_pixels
+
+    file = observed_dl1_files["dl1_file1"]
+    unusable_pixels = get_unusable_pixels(file, pedestal_id=0)
+
+    assert (unusable_pixels.shape == (1855,))
+

--- a/lstchain/calib/camera/tests/test_pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/tests/test_pixel_threshold_estimation.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+
 def test_get_ped_thresh():
     from ..pixel_threshold_estimation import get_ped_thresh
     from ctapipe.containers import ArrayEventContainer
@@ -8,15 +9,18 @@ def test_get_ped_thresh():
     tel_id = 1
     sigma = 2
     event = ArrayEventContainer()
-    event.mon.tel[tel_id].pedestal.charge_mean = np.full((2, 2, 1855), 4, dtype='int')
-    event.mon.tel[tel_id].pedestal.charge_std = np.full((2, 2, 1855), 3, dtype='int')
-    event.mon.tel[tel_id].calibration.dc_to_pe = np.full((2, 2, 1855), 2, dtype='int')
-    event.mon.tel[tel_id].calibration.unusable_pixels = np.full((1855,), False, dtype='bool')
+    event.mon.tel[tel_id].pedestal.charge_mean = np.full((2, 2, 1855), 4, dtype="int")
+    event.mon.tel[tel_id].pedestal.charge_std = np.full((2, 2, 1855), 3, dtype="int")
+    event.mon.tel[tel_id].calibration.dc_to_pe = np.full((2, 2, 1855), 2, dtype="int")
+    event.mon.tel[tel_id].calibration.unusable_pixels = np.full(
+        (1855,), False, dtype="bool"
+    )
 
     ped_thresh = get_ped_thresh(tel_id=tel_id, event=event, sigma_clean=sigma)
-    ped_thresh_real = np.full((1855,), 20, dtype='int')
+    ped_thresh_real = np.full((1855,), 20, dtype="int")
 
-    assert (ped_thresh.all() == ped_thresh_real.all())
+    assert ped_thresh.all() == ped_thresh_real.all()
+
 
 @pytest.mark.private_data
 def test_get_bias_and_std(observed_dl1_files):
@@ -25,8 +29,8 @@ def test_get_bias_and_std(observed_dl1_files):
     file = observed_dl1_files["dl1_file1"]
     ped_charge_mean_pe, ped_charge_std_pe = get_bias_and_std(file)
 
-    assert (ped_charge_mean_pe.shape[2] == 1855)
-    assert (ped_charge_std_pe.shape[2] == 1855)
+    assert ped_charge_mean_pe.shape[2] == 1855
+    assert ped_charge_std_pe.shape[2] == 1855
 
 
 @pytest.mark.private_data
@@ -36,8 +40,8 @@ def test_get_threshold_from_dl1_file(observed_dl1_files):
     sigma = 2.5
     file = observed_dl1_files["dl1_file1"]
     ped_thresh = get_threshold_from_dl1_file(file, sigma_clean=sigma)
-    
-    assert (ped_thresh.shape == (1855,))
+
+    assert ped_thresh.shape == (1855,)
 
 
 @pytest.mark.private_data
@@ -46,6 +50,5 @@ def test_get_unusable_pixels(observed_dl1_files):
 
     file = observed_dl1_files["dl1_file1"]
     unusable_pixels = get_unusable_pixels(file, pedestal_id=0)
-    
-    assert (len(unusable_pixels[0]) == 2)
 
+    assert len(unusable_pixels[0]) == 2

--- a/lstchain/calib/camera/tests/test_pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/tests/test_pixel_threshold_estimation.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
-from ctapipe.containers import ArrayEventContainer
 
 def test_get_ped_thresh():
     from ..pixel_threshold_estimation import get_ped_thresh
+    from ctapipe.containers import ArrayEventContainer
 
     tel_id = 1
     sigma = 2
@@ -33,12 +33,11 @@ def test_get_bias_and_std(observed_dl1_files):
 def test_get_threshold_from_dl1_file(observed_dl1_files):
     from ..pixel_threshold_estimation import get_threshold_from_dl1_file
 
-    file = observed_dl1_files["dl1_file1"]
     sigma = 2.5
+    file = observed_dl1_files["dl1_file1"]
     ped_thresh = get_threshold_from_dl1_file(file, sigma_clean=sigma)
     
     assert (ped_thresh.shape == (1855,))
-    assert (np.max(ped_thresh) > 0)
 
 
 @pytest.mark.private_data

--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -37,7 +37,7 @@
     "fraction_dynamic": 0.03,
     "threshold_dynamic": 267,
     "use_only_largest_island": false,
-    "use_pedestal_cleaning": false,
+    "use_pedestal_cleaning": true,
     "sigma": 2.5
   },
 

--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -27,6 +27,21 @@
     }
   },
 
+  "LSTImageCleaner" : {
+    "delta_time": 2,
+    "use_dynamic_cleaning": true,
+    "fraction_dynamic": 0.03,
+    "threshold_dynamic": 267,
+    "use_only_main_island": false,
+    "image_cleaner_type": "TailcutsImageCleaner",
+    "TailcutsImageCleaner": {
+        "picture_threshold_pe": 8,
+        "boundary_threshold_pe": 4,
+        "min_picture_neighbors": 2,
+        "keep_isolated_pixels": false
+    }
+  },
+
   "events_filters": {
     "intensity": [0, Infinity],
     "width": [0, Infinity],
@@ -42,14 +57,6 @@
     "proton_classifier": 1.0
   },
 
-  "tailcut": {
-    "picture_thresh":8,
-    "boundary_thresh":4,
-    "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":2,
-    "use_only_main_island":false,
-    "delta_time": 2
-  },
   "tailcuts_clean_with_pedestal_threshold": {
     "picture_thresh":8,
     "boundary_thresh":4,
@@ -58,11 +65,6 @@
     "min_number_picture_neighbors":2,
     "use_only_main_island":false,
     "delta_time": 2
-  },
-  "dynamic_cleaning": {
-    "apply": true,
-    "threshold": 267,
-    "fraction_cleaning_intensity": 0.03
   },
 
   "random_forest_energy_regressor_args": {

--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -42,6 +42,10 @@
     }
   },
 
+  "pedestal_cleaning": {
+    "sigma":2.5
+  },
+
   "events_filters": {
     "intensity": [0, Infinity],
     "width": [0, Infinity],
@@ -55,16 +59,6 @@
     "gamma_tmp_regressors": 0.8,
     "gamma_classifier": 0.2,
     "proton_classifier": 1.0
-  },
-
-  "tailcuts_clean_with_pedestal_threshold": {
-    "picture_thresh":8,
-    "boundary_thresh":4,
-    "sigma":2.5,
-    "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":2,
-    "use_only_main_island":false,
-    "delta_time": 2
   },
 
   "random_forest_energy_regressor_args": {

--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -36,7 +36,7 @@
     "use_dynamic_cleaning": true,
     "fraction_dynamic": 0.03,
     "threshold_dynamic": 267,
-    "use_only_main_island": false,
+    "use_only_largest_island": false,
     "use_pedestal_cleaning": false,
     "sigma": 2.5
   },

--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -28,22 +28,17 @@
   },
 
   "LSTImageCleaner" : {
+    "picture_threshold_pe": 8,
+    "boundary_threshold_pe": 4,
+    "min_picture_neighbors": 2,
+    "keep_isolated_pixels": false,
     "delta_time": 2,
     "use_dynamic_cleaning": true,
     "fraction_dynamic": 0.03,
     "threshold_dynamic": 267,
     "use_only_main_island": false,
-    "image_cleaner_type": "TailcutsImageCleaner",
-    "TailcutsImageCleaner": {
-        "picture_threshold_pe": 8,
-        "boundary_threshold_pe": 4,
-        "min_picture_neighbors": 2,
-        "keep_isolated_pixels": false
-    }
-  },
-
-  "pedestal_cleaning": {
-    "sigma":2.5
+    "use_pedestal_cleaning": false,
+    "sigma": 2.5
   },
 
   "events_filters": {

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -37,7 +37,7 @@
     "fraction_dynamic": 0.03,
     "threshold_dynamic": 267,
     "use_only_largest_island": false,
-    "use_pedestal_cleaning": false,
+    "use_pedestal_cleaning": true,
     "sigma": 2.5
   },
 

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -27,6 +27,21 @@
     }
   },
 
+  "LSTImageCleaner" : {
+    "delta_time": 2,
+    "use_dynamic_cleaning": true,
+    "fraction_dynamic": 0.03,
+    "threshold_dynamic": 267,
+    "use_only_main_island": false,
+    "image_cleaner_type": "TailcutsImageCleaner",
+    "TailcutsImageCleaner": {
+        "picture_threshold_pe": 8,
+        "boundary_threshold_pe": 4,
+        "min_picture_neighbors": 2,
+        "keep_isolated_pixels": false
+    }
+  },
+
   "events_filters": {
     "intensity": [0, Infinity],
     "width": [0, Infinity],
@@ -35,6 +50,7 @@
     "r": [0, Infinity],
     "leakage_intensity_width_2": [0, Infinity]
   },
+
   "n_training_events": {
     "gamma_regressors": 1.0,
     "gamma_tmp_regressors": 0.8,
@@ -42,14 +58,6 @@
     "proton_classifier": 1.0
   },
 
-  "tailcut": {
-    "picture_thresh":8,
-    "boundary_thresh":4,
-    "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":2,
-    "use_only_main_island":false,
-    "delta_time": 2
-  },
   "tailcuts_clean_with_pedestal_threshold": {
     "picture_thresh":8,
     "boundary_thresh":4,
@@ -58,11 +66,6 @@
     "min_number_picture_neighbors":2,
     "use_only_main_island":false,
     "delta_time": 2
-  },
-  "dynamic_cleaning": {
-    "apply": true,
-    "threshold": 267,
-    "fraction_cleaning_intensity": 0.03
   },
 
   "random_forest_energy_regressor_args": {

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -36,7 +36,7 @@
     "use_dynamic_cleaning": true,
     "fraction_dynamic": 0.03,
     "threshold_dynamic": 267,
-    "use_only_main_island": false,
+    "use_only_largest_island": false,
     "use_pedestal_cleaning": false,
     "sigma": 2.5
   },

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -28,22 +28,17 @@
   },
 
   "LSTImageCleaner" : {
+    "picture_threshold_pe": 8,
+    "boundary_threshold_pe": 4,
+    "min_picture_neighbors": 2,
+    "keep_isolated_pixels": false,
     "delta_time": 2,
     "use_dynamic_cleaning": true,
     "fraction_dynamic": 0.03,
     "threshold_dynamic": 267,
     "use_only_main_island": false,
-    "image_cleaner_type": "TailcutsImageCleaner",
-    "TailcutsImageCleaner": {
-        "picture_threshold_pe": 8,
-        "boundary_threshold_pe": 4,
-        "min_picture_neighbors": 2,
-        "keep_isolated_pixels": false
-    }
-  },
-
-  "pedestal_cleaning": {
-    "sigma":2.5
+    "use_pedestal_cleaning": false,
+    "sigma": 2.5
   },
 
   "events_filters": {

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -42,6 +42,10 @@
     }
   },
 
+  "pedestal_cleaning": {
+    "sigma":2.5
+  },
+
   "events_filters": {
     "intensity": [0, Infinity],
     "width": [0, Infinity],
@@ -56,16 +60,6 @@
     "gamma_tmp_regressors": 0.8,
     "gamma_classifier": 0.2,
     "proton_classifier": 1.0
-  },
-
-  "tailcuts_clean_with_pedestal_threshold": {
-    "picture_thresh":8,
-    "boundary_thresh":4,
-    "sigma":2.5,
-    "keep_isolated_pixels":false,
-    "min_number_picture_neighbors":2,
-    "use_only_main_island":false,
-    "delta_time": 2
   },
 
   "random_forest_energy_regressor_args": {

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -6,7 +6,7 @@ from ctapipe.core.traits import (
     BoolTelescopeParameter,
     create_class_enum_trait
 )
-from ctapipe.image import number_of_islands
+from ctapipe.image import number_of_islands, apply_time_delta_cleaning
 
 __all__ = [
     'apply_dynamic_cleaning',
@@ -55,6 +55,7 @@ class LSTImageCleaner(ImageCleaner):
 
         camera_geometry = self.subarray.tel[tel_id].camera.geometry
         signal_pixels = cleaner(tel_id=tel_id, image=image, arrival_times=arrival_times)
+        print(type(signal_pixels), signal_pixels.shape, signal_pixels)
         n_pixels = np.count_nonzero(signal_pixels)
         num_islands = {}
 

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -4,6 +4,7 @@ from ctapipe.core.traits import (
     FloatTelescopeParameter,
     IntTelescopeParameter,
     BoolTelescopeParameter,
+    create_class_enum_trait
 )
 from ctapipe.image import number_of_islands
 
@@ -55,6 +56,7 @@ class LSTImageCleaner(ImageCleaner):
         camera_geometry = self.subarray.tel[tel_id].camera.geometry
         signal_pixels = cleaner(tel_id=tel_id, image=image, arrival_times=arrival_times)
         n_pixels = np.count_nonzero(signal_pixels)
+        num_islands = {}
 
         if n_pixels > 0:
 
@@ -82,7 +84,7 @@ class LSTImageCleaner(ImageCleaner):
                 max_island_label = np.argmax(n_pixels_on_island)
                 signal_pixels[island_labels != max_island_label] = False
 
-        return signal_pixels, num_islands
+        return signal_pixels, num_islands, n_pixels
 
 
 def apply_dynamic_cleaning(image, signal_pixels, threshold, fraction):

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -215,7 +215,9 @@ class LSTImageCleaner(ImageCleaner):
         arrival_times = event.dl1.tel[tel_id].peak_time
         pic_thresh = self.picture_threshold_pe.tel[tel_id]
 
-        if self.use_pedestal_cleaning.tel[tel_id]:
+        if (self.use_pedestal_cleaning.tel[tel_id] and 
+            event.mon.tel[tel_id].pedestal.charge_mean.ndim == 3
+        ):
             ped_thresh = get_ped_thresh(tel_id=tel_id, 
                                         event=event, 
                                         sigma_clean=self.sigma.tel[tel_id])

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -14,6 +14,7 @@ from ctapipe.image import (
 __all__ = [
     'apply_dynamic_cleaning',
     'get_only_main_island',
+    'lst_image_cleaning',
     'LSTImageCleaner'
 ]
 

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -11,18 +11,14 @@ from ctapipe.image import (
     apply_time_delta_cleaning,
     tailcuts_clean
 )
-from ctapipe_io_lst.constants import HIGH_GAIN
 from lstchain.calib.camera.pixel_threshold_estimation import get_ped_thresh
 
 __all__ = [
     'apply_dynamic_cleaning',
     'get_only_main_island',
-    'lst_image_cleaning',
     'LSTImageCleaner'
 ]
 
-ORIGINAL_CALIBRATION_ID = 0
-INTERLEAVED_CALIBRATION_ID = 1
 
 def apply_dynamic_cleaning(image, signal_pixels, threshold, fraction):
     """

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -216,7 +216,7 @@ class LSTImageCleaner(ImageCleaner):
         pic_thresh = self.picture_threshold_pe.tel[tel_id]
 
         if self.use_pedestal_cleaning:
-            ped_thresh = get_ped_thresh(tel_id=tel_id, event=event, sigma=self.sigma)
+            ped_thresh = get_ped_thresh(tel_id=tel_id, event=event, sigma_clean=self.sigma)
             pic_thresh = np.clip(ped_thresh, pic_thresh, None)
 
         signal_pixels = tailcuts_clean(

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -112,12 +112,12 @@ class LSTImageCleaner(ImageCleaner):
     """
 
     picture_threshold_pe = FloatTelescopeParameter(
-        default_value=10.0,
+        default_value=8.0,
         help="top-level threshold in photoelectrons for `tailcuts_clean`"
     ).tag(config=True)
 
     boundary_threshold_pe = FloatTelescopeParameter(
-        default_value=5.0, help="second-level threshold in photoelectrons for `tailcuts_clean`"
+        default_value=4.0, help="second-level threshold in photoelectrons for `tailcuts_clean`"
     ).tag(config=True)
 
     min_picture_neighbors = IntTelescopeParameter(
@@ -164,7 +164,7 @@ class LSTImageCleaner(ImageCleaner):
     ).tag(config=True)
     
     sigma = FloatTelescopeParameter(
-        default_value=267,
+        default_value=2.5,
         help="`sigma` parameter for interleaved pedestal cleaning",
     ).tag(config=True)  
 

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -132,18 +132,10 @@ class LSTImageCleaner(ImageCleaner):
     """
     Clean images basically in 3 steps:
     1) Get picture threshold for `tailcuts_clean` in step 2) from interleaved
-       pedestal events if `use_pedestal_cleaning` is set to `true`
+    pedestal events if `use_pedestal_cleaning` is set to `true`
     2) Apply tailcuts image cleaning algorithm - `ctapipe.image.tailcuts_clean`
     3) Apply `lst_image_cleaning` - `lstchain.image.cleaning.lst_image_cleaning`
 
-    Returns
-    -------
-    signal_pixels: `np.ndarray`
-        Boolean mask with the selected pixels after all the cleaning steps
-    num_islands: `int`
-        Number of islands before it was reduced to one in step 5)
-    n_pixels: `int`
-        Number of pixels which survived the `tailcuts_clean` in step 2)
     """
 
     picture_threshold_pe = FloatTelescopeParameter(
@@ -203,12 +195,23 @@ class LSTImageCleaner(ImageCleaner):
     ).tag(config=True)
 
     def __call__(self, tel_id: int, event):
+        """
+        Apply LST image cleaning.
 
+        Returns
+        -------
+        signal_pixels: `np.ndarray`
+            Boolean mask with the selected pixels after all the cleaning steps
+        num_islands: `int`
+            Number of islands before it was reduced to one in step 5)
+        n_pixels: `int`
+            Number of pixels which survived the `tailcuts_clean` in step 2)
+        """
         geom = self.subarray.tel[tel_id].camera.geometry
         image = event.dl1.tel[tel_id].image
         arrival_times = event.dl1.tel[tel_id].peak_time
         pic_thresh = self.picture_threshold_pe.tel[tel_id]
-        ped_std = event.mon.tel[tel_id].pedestal.charge_std 
+        ped_std = event.mon.tel[tel_id].pedestal.charge_std
 
         if (
             self.use_pedestal_cleaning.tel[tel_id]

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -216,7 +216,9 @@ class LSTImageCleaner(ImageCleaner):
         pic_thresh = self.picture_threshold_pe.tel[tel_id]
 
         if self.use_pedestal_cleaning.tel[tel_id]:
-            ped_thresh = get_ped_thresh(tel_id=tel_id, event=event, sigma_clean=self.sigma)
+            ped_thresh = get_ped_thresh(tel_id=tel_id, 
+                                        event=event, 
+                                        sigma_clean=self.sigma.tel[tel_id])
             pic_thresh = np.clip(ped_thresh, pic_thresh, None)
 
         signal_pixels = tailcuts_clean(

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -63,12 +63,12 @@ def get_only_main_island(island_labels, signal_pixels):
     island_labels: `np.ndarray`
         Returned island labels from `ctapipe.image.number_of_islands`
     signal_pixels: `np.ndarray`
-        Mask with the selected pixels
+        Boolean mask with the selected pixels
 
     Returns
     -------
     signal_pixels: `np.ndarray`
-        Mask with the selected pixels after selecting only the main island
+        Boolean mask with the selected pixels after selecting only the main island
 
     """
 
@@ -123,7 +123,7 @@ def lst_image_cleaning(
     Returns
     -------
     signal_pixels: `np.ndarray`
-        Mask with the selected pixels after all the cleaning steps
+        Boolean mask with the selected pixels after all the cleaning steps
     num_islands: `int`
         Number of islands before it was reduced to one in step 3)
     n_pixels: `int`

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -108,16 +108,16 @@ def lst_image_cleaning(
         pixel timing information
     signal_pixels: `np.ndarray`
         boolean mask of cleaned pixels after e.g. `TailcutsImageCleaner`
-    delta_time: `FloatTelescopeParameter`
+    delta_time: `Float`
         Time limit for the `apply_time_delta_cleaning` in step 2).
         Set to `None` if no time_delta_cleaning should be applied
-    use_dynamic_cleaning: `BoolTelescopeParameter`
+    use_dynamic_cleaning: `Bool`
         Set to True, if dynamic cleaning (Step 3) should be applied
-    fraction_dynamic: `FloatTelescopeParameter`
+    fraction_dynamic: `Float`
         Fraction parameter for `apply_dynamic_cleaning`
-    threshold_dynamic: `FloatTelescopeParameter`
+    threshold_dynamic: `Float`
         Threshold parameter for `apply_dynamic_cleaning`
-    use_only_main_island: `BoolTelescopeParameter`
+    use_only_main_island: `Bool`
         Set to True if considering only the main island in step 4)
 
     Returns

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -208,10 +208,12 @@ class LSTImageCleaner(ImageCleaner):
         image = event.dl1.tel[tel_id].image
         arrival_times = event.dl1.tel[tel_id].peak_time
         pic_thresh = self.picture_threshold_pe.tel[tel_id]
+        ped_std = event.mon.tel[tel_id].pedestal.charge_std 
 
         if (
             self.use_pedestal_cleaning.tel[tel_id]
-            and event.mon.tel[tel_id].pedestal.charge_mean.ndim == 3
+            and ped_std is not None
+            and ped_std.ndim == 3
         ):
             ped_thresh = get_ped_thresh(
                 tel_id=tel_id, event=event, sigma_clean=self.sigma.tel[tel_id]

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -60,7 +60,7 @@ class LSTImageCleaner(ImageCleaner):
 
         if n_pixels > 0:
 
-            if self.delta_time is not None:
+            if self.delta_time.tel[tel_id] is not None:
                 signal_pixels = apply_time_delta_cleaning(
                     camera_geometry,
                     signal_pixels,
@@ -68,8 +68,7 @@ class LSTImageCleaner(ImageCleaner):
                     min_number_neighbors=1,
                     time_limit=self.delta_time.tel[tel_id]
                 )
-
-            if self.use_dynamic_cleaning:
+            if self.use_dynamic_cleaning.tel[tel_id]:
                 signal_pixels = apply_dynamic_cleaning(image,
                                                        signal_pixels,
                                                        self.threshold_dynamic.tel[tel_id],
@@ -77,8 +76,7 @@ class LSTImageCleaner(ImageCleaner):
 
             # check the number of islands
             num_islands, island_labels = number_of_islands(camera_geometry, signal_pixels)
-
-            if self.use_only_main_island:
+            if self.use_only_main_island.tel[tel_id]:
                 n_pixels_on_island = np.bincount(island_labels)
                 n_pixels_on_island[0] = 0  # first island is no-island and should not be considered
                 max_island_label = np.argmax(n_pixels_on_island)

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -215,7 +215,7 @@ class LSTImageCleaner(ImageCleaner):
         arrival_times = event.dl1.tel[tel_id].peak_time
         pic_thresh = self.picture_threshold_pe.tel[tel_id]
 
-        if self.use_pedestal_cleaning:
+        if self.use_pedestal_cleaning.tel[tel_id]:
             ped_thresh = get_ped_thresh(tel_id=tel_id, event=event, sigma_clean=self.sigma)
             pic_thresh = np.clip(ped_thresh, pic_thresh, None)
 

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -55,7 +55,6 @@ class LSTImageCleaner(ImageCleaner):
 
         camera_geometry = self.subarray.tel[tel_id].camera.geometry
         signal_pixels = cleaner(tel_id=tel_id, image=image, arrival_times=arrival_times)
-        print(type(signal_pixels), signal_pixels.shape, signal_pixels)
         n_pixels = np.count_nonzero(signal_pixels)
         num_islands = {}
 
@@ -67,14 +66,14 @@ class LSTImageCleaner(ImageCleaner):
                     signal_pixels,
                     arrival_times,
                     min_number_neighbors=1,
-                    time_limit=self.delta_time
+                    time_limit=self.delta_time.tel[tel_id]
                 )
 
             if self.use_dynamic_cleaning:
                 signal_pixels = apply_dynamic_cleaning(image,
                                                        signal_pixels,
-                                                       self.threshold_dynamic,
-                                                       self.fraction_dynamic)
+                                                       self.threshold_dynamic.tel[tel_id],
+                                                       self.fraction_dynamic.tel[tel_id])
 
             # check the number of islands
             num_islands, island_labels = number_of_islands(camera_geometry, signal_pixels)

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -1,6 +1,50 @@
 import numpy as np
+from ctapipe.image import ImageCleaner
+from ctapipe.core.traits import Bool, Float, Int
 
-__all__ = ['apply_dynamic_cleaning']
+__all__ = [
+    'apply_dynamic_cleaning',
+    'LSTImageCleaner'
+]
+
+class LSTImageCleaner(ImageCleaner):
+    """
+
+    """
+    def __call__():
+        
+    signal_pixels = cleaning_method(camera_geometry, image, **cleaning_parameters)
+    n_pixels = np.count_nonzero(signal_pixels)
+
+    if n_pixels > 0:
+
+        if delta_time is not None:
+            signal_pixels = apply_time_delta_cleaning(
+                camera_geometry,
+                signal_pixels,
+                peak_time,
+                min_number_neighbors=1,
+                time_limit=delta_time
+            )
+
+        if use_dynamic_cleaning:
+            threshold_dynamic = config['dynamic_cleaning']['threshold']
+            fraction_dynamic = config['dynamic_cleaning']['fraction_cleaning_intensity']
+            signal_pixels = apply_dynamic_cleaning(image,
+                                                   signal_pixels,
+                                                   threshold_dynamic,
+                                                   fraction_dynamic)
+
+        # check the number of islands
+        num_islands, island_labels = number_of_islands(camera_geometry, signal_pixels)
+        dl1_container.n_islands = num_islands
+
+        if use_main_island:
+            n_pixels_on_island = np.bincount(island_labels)
+            n_pixels_on_island[0] = 0  # first island is no-island and should not be considered
+            max_island_label = np.argmax(n_pixels_on_island)
+            signal_pixels[island_labels != max_island_label] = False
+
 
 
 def apply_dynamic_cleaning(image, signal_pixels, threshold, fraction):

--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -53,14 +53,14 @@ def apply_dynamic_cleaning(image, signal_pixels, threshold, fraction):
     return mask_dynamic_cleaning
 
 
-def get_only_main_island(camera_geometry, signal_pixels):
+def get_only_main_island(island_labels, signal_pixels):
     """
     Reduce the selected image mask to return only the main island
 
     Parameters
     ----------
-    camera_geometry: `ctapipe.instrument.camera.CameraGeometry`
-        Camera geometry for the used telescope
+    island_labels: `np.ndarray`
+        Returned island labels from `ctapipe.image.number_of_islands`
     signal_pixels: `np.ndarray`
         Mask with the selected pixels
 
@@ -68,24 +68,51 @@ def get_only_main_island(camera_geometry, signal_pixels):
     -------
     signal_pixels: `np.ndarray`
         Mask with the selected pixels after selecting only the main island
-    num_islands: `int`
-        Number of islands before it was reduced to one
 
     """
-
-    num_islands, island_labels = number_of_islands(camera_geometry, signal_pixels)
 
     n_pixels_on_island = np.bincount(island_labels)
     n_pixels_on_island[0] = 0  # first island is no-island and should not be considered
     max_island_label = np.argmax(n_pixels_on_island)
     signal_pixels[island_labels != max_island_label] = False
 
-    return signal_pixels, num_islands
+    return signal_pixels
 
 
 class LSTImageCleaner(ImageCleaner):
     """
+    Clean images in four variable steps:
+    1) Apply first image cleaning 
+       Default: TailcutsImageCleaner - `ctapipe.image.TailcutsImageCleaner`
+    2) Apply time_delta_cleaning - `ctapipe.image.apply_time_delta_cleaning`
+    3) Apply dynamic_cleaning - `lstchain.image.cleaning.apply_dynamic_cleaning`
+    4) Get only main island - `lstchain.image.cleaning.get_only_main_island`
 
+    Attributes
+    ----------
+    image_cleaner_type: `String`
+        Name of the image cleaner to be used in step 1).
+        Default: TailcutsImageCleaner
+    delta_time: `FloatTelescopeParameter`
+        Time limit for the `apply_time_delta_cleaning` in step 2).
+        Set to `None` if no time_delta_cleaning should be applied
+    use_dynamic_cleaning: `BoolTelescopeParameter`
+        Set to True, if dynamic cleaning (Step 3) should be applied
+    fraction_dynamic: `FloatTelescopeParameter`
+        Fraction parameter for `apply_dynamic_cleaning`
+    threshold_dynamic: `FloatTelescopeParameter`
+        Threshold parameter for `apply_dynamic_cleaning`
+    use_only_main_island: `BoolTelescopeParameter`
+        Set to True if considering only the main island in step 4)
+
+    Returns
+    -------
+    signal_pixels: `np.ndarray`
+        Mask with the selected pixels after all the cleaning steps
+    num_islands: `int`
+        Number of islands before it was reduced to one in step 4)
+    n_pixels: `int`
+        Number of pixels surviving the the cleaning in step 1)
     """
     image_cleaner_type = create_class_enum_trait(
         base_class=ImageCleaner, default_value="TailcutsImageCleaner"
@@ -93,7 +120,7 @@ class LSTImageCleaner(ImageCleaner):
 
     delta_time = FloatTelescopeParameter(
         default_value=2, 
-        help="Time limit for the ``delta_time_cleaning``. Set to None if no" 
+        help="Time limit for the ``time_delta_cleaning``. Set to None if no" 
         "``time_delta_cleaning`` should be applied",
     ).tag(config=True)
 
@@ -144,9 +171,8 @@ class LSTImageCleaner(ImageCleaner):
                                                        self.threshold_dynamic.tel[tel_id],
                                                        self.fraction_dynamic.tel[tel_id])
 
+            num_islands, island_labels = number_of_islands(camera_geometry, signal_pixels)
             if self.use_only_main_island.tel[tel_id]:
-                signal_pixels, num_islands = get_only_main_island(
-                    camera_geometry, signal_pixels
-                )
+                signal_pixels = get_only_main_island(island_labels, signal_pixels)
 
         return signal_pixels, num_islands, n_pixels

--- a/lstchain/image/tests/test_image.py
+++ b/lstchain/image/tests/test_image.py
@@ -6,25 +6,25 @@ from ctapipe.image import dilate
 from ctapipe.instrument import CameraGeometry
 import numpy as np
 
+
 def test_dynamic_cleaning():
 
     npixels = 1855
-    image = np.linspace(0, npixels-1, npixels)
-    signal_pixels = np.array(npixels*[True])
+    image = np.linspace(0, npixels - 1, npixels)
+    signal_pixels = np.array(npixels * [True])
     fraction = 0.03
     mean3 = np.mean(image[-3:])
     mask = apply_dynamic_cleaning(image, signal_pixels, 100, fraction)
-    assert(mask.sum() == np.sum(image>fraction*mean3))
-    mask = apply_dynamic_cleaning(image, signal_pixels,
-                                  np.max(image),
-                                  fraction)
-    assert(mask.sum() == signal_pixels.sum())
+    assert mask.sum() == np.sum(image > fraction * mean3)
+    mask = apply_dynamic_cleaning(image, signal_pixels, np.max(image), fraction)
+    assert mask.sum() == signal_pixels.sum()
+
 
 def test_lst_image_cleaning():
 
     geom = CameraGeometry.from_name("LSTCam")
     n_pixels = 1855
-    mask = np.array(1855*[False])
+    mask = np.array(1855 * [False])
     image = np.zeros((1855,))
     arrival_times = np.zeros((1855,))
 
@@ -48,9 +48,9 @@ def test_lst_image_cleaning():
         use_dynamic_cleaning=True,
         fraction_dynamic=0.3,
         threshold_dynamic=40,
-        use_only_largest_island=True
+        use_only_largest_island=True,
     )
-    
-    assert(num_islands == 2)
-    assert(signal_pixels.sum() == 5)
-    assert(n_pixels == 63)
+
+    assert num_islands == 2
+    assert signal_pixels.sum() == 5
+    assert n_pixels == 63

--- a/lstchain/image/tests/test_image.py
+++ b/lstchain/image/tests/test_image.py
@@ -1,9 +1,8 @@
 from lstchain.image.cleaning import (
     apply_dynamic_cleaning,
-    get_only_main_island,
     lst_image_cleaning,
 )
-from ctapipe.image import number_of_islands, dilate
+from ctapipe.image import dilate
 from ctapipe.instrument import CameraGeometry
 import numpy as np
 

--- a/lstchain/image/tests/test_image.py
+++ b/lstchain/image/tests/test_image.py
@@ -1,4 +1,11 @@
-from lstchain.image.cleaning import apply_dynamic_cleaning
+from lstchain.image.cleaning import (
+    apply_dynamic_cleaning,
+    get_only_main_island,
+    lst_image_cleaning,
+)
+from ctapipe.image import number_of_islands, dilate
+from ctapipe.instrument import CameraGeometry
+from traitlets.config import Config
 import numpy as np
 
 def test_dynamic_cleaning():
@@ -14,3 +21,61 @@ def test_dynamic_cleaning():
                                   np.max(image),
                                   fraction)
     assert(mask.sum() == signal_pixels.sum())
+
+def test_get_only_main_island():
+
+    # Creating a mask of pixels with two islands:
+    # Bigger island around pixel#39,40,41 and smaller one around pixel#42
+    geom = CameraGeometry.from_name("LSTCam")
+    mask = np.array(1855*[False])
+
+    num_pix = [39, 40, 41, 42]
+    for pix in num_pix:
+        some_neighs = geom.neighbors[pix][0:6]
+        mask[pix] = True
+        mask[some_neighs] = True
+
+    num_islands, island_labels = number_of_islands(geom, mask)
+    # Number of islands should be 2 here
+    assert(num_islands == 2)
+
+    signal_pixels = get_only_main_island(island_labels, mask)
+    num_island, _ = number_of_islands(geom, signal_pixels)
+    
+    assert(num_island == 1)
+    assert(signal_pixels.sum() == 13)
+
+def test_lst_image_cleaning():
+
+    geom = CameraGeometry.from_name("LSTCam")
+    n_pixels = 1855
+    mask = np.array(1855*[False])
+    image = np.zeros((1855,))
+    arrival_times = np.zeros((1855,))
+
+    num_pix = [37, 38, 39, 40, 41, 42, 43, 44]
+    for pix in num_pix:
+        mask[pix] = True
+        image[pix] = 50
+
+    mask_dilate_1 = dilate(geom, mask)
+    mask_dilate_2 = dilate(geom, mask_dilate_1)
+    image[mask_dilate_1 ^ mask] = 10
+    arrival_times[mask_dilate_1] = 15
+    arrival_times[mask_dilate_2 ^ mask_dilate_1] = 10
+
+    signal_pixels, num_islands, n_pixels = lst_image_cleaning(
+        geom=geom,
+        image=image,
+        arrival_times=arrival_times,
+        signal_pixels=mask_dilate_2,
+        delta_time=2,
+        use_dynamic_cleaning=True,
+        fraction_dynamic=0.3,
+        threshold_dynamic=40,
+        use_only_main_island=True
+    )
+    
+    assert(num_islands == 2)
+    assert(signal_pixels.sum() == 5)
+    assert(n_pixels == 63)

--- a/lstchain/image/tests/test_image.py
+++ b/lstchain/image/tests/test_image.py
@@ -21,26 +21,6 @@ def test_dynamic_cleaning():
                                   fraction)
     assert(mask.sum() == signal_pixels.sum())
 
-def test_get_only_main_island():
-
-    # Creating a mask of pixels with two islands:
-    # Bigger island around pixel#39,40,41 and smaller one around pixel#42
-    geom = CameraGeometry.from_name("LSTCam")
-    mask = np.array(1855*[False])
-
-    num_pix = [39, 40, 41, 42]
-    for pix in num_pix:
-        some_neighs = geom.neighbors[pix][0:6]
-        mask[pix] = True
-        mask[some_neighs] = True
-
-    signal_pixels, num_islands = get_only_main_island(geom, mask)
-    assert(num_islands == 2)
-
-    num_island, _ = number_of_islands(geom, signal_pixels)
-    assert(num_island == 1)
-    assert(signal_pixels.sum() == 13)
-
 def test_lst_image_cleaning():
 
     geom = CameraGeometry.from_name("LSTCam")
@@ -69,7 +49,7 @@ def test_lst_image_cleaning():
         use_dynamic_cleaning=True,
         fraction_dynamic=0.3,
         threshold_dynamic=40,
-        use_only_main_island=True
+        use_only_largest_island=True
     )
     
     assert(num_islands == 2)

--- a/lstchain/image/tests/test_image.py
+++ b/lstchain/image/tests/test_image.py
@@ -5,7 +5,6 @@ from lstchain.image.cleaning import (
 )
 from ctapipe.image import number_of_islands, dilate
 from ctapipe.instrument import CameraGeometry
-from traitlets.config import Config
 import numpy as np
 
 def test_dynamic_cleaning():
@@ -35,13 +34,10 @@ def test_get_only_main_island():
         mask[pix] = True
         mask[some_neighs] = True
 
-    num_islands, island_labels = number_of_islands(geom, mask)
-    # Number of islands should be 2 here
+    signal_pixels, num_islands = get_only_main_island(geom, mask)
     assert(num_islands == 2)
 
-    signal_pixels = get_only_main_island(island_labels, mask)
     num_island, _ = number_of_islands(geom, signal_pixels)
-    
     assert(num_island == 1)
     assert(signal_pixels.sum() == 13)
 

--- a/lstchain/image/tests/test_image.py
+++ b/lstchain/image/tests/test_image.py
@@ -1,13 +1,8 @@
-from lstchain.image.cleaning import (
-    apply_dynamic_cleaning,
-    lst_image_cleaning,
-)
-from ctapipe.image import dilate
-from ctapipe.instrument import CameraGeometry
 import numpy as np
 
 
 def test_dynamic_cleaning():
+    from lstchain.image.cleaning import apply_dynamic_cleaning
 
     npixels = 1855
     image = np.linspace(0, npixels - 1, npixels)
@@ -21,6 +16,9 @@ def test_dynamic_cleaning():
 
 
 def test_lst_image_cleaning():
+    from ctapipe.image import dilate
+    from ctapipe.instrument import CameraGeometry
+    from lstchain.image.cleaning import lst_image_cleaning
 
     geom = CameraGeometry.from_name("LSTCam")
     n_pixels = 1855

--- a/lstchain/io/config.py
+++ b/lstchain/io/config.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from copy import copy
 
 __all__ = [
+    'dump_config',
     'get_cleaning_parameters',
+    'get_mc_config',
     'get_standard_config',
     'get_srcdep_config',
     'read_configuration_file',

--- a/lstchain/io/config.py
+++ b/lstchain/io/config.py
@@ -94,23 +94,23 @@ def replace_config(base_config, new_config):
     return config
 
 
-def get_cleaning_parameters(config, clean_method_name):
+def get_cleaning_parameters(config, cleaner):
     """
     Return cleaning parameters from configuration dict.
 
     Parameters
     ----------
     config: configuration dict
-    clean_method_name: name of cleaning method
+    cleaner: name of the image cleaner
 
     Returns
     -------
     tuple (picture threshold, boundary threshold, keep isolated pixels, min number picture neighbors)
     """
-    picture_th = config["LSTImageCleaner"][clean_method_name]["picture_threshold_pe"]
-    boundary_th = config["LSTImageCleaner"][clean_method_name]["boundary_threshold_pe"]
-    isolated_pixels = config["LSTImageCleaner"][clean_method_name]["keep_isolated_pixels"]
-    min_n_picture_neighbors = config["LSTImageCleaner"][clean_method_name]["min_picture_neighbors"]
+    picture_th = config["LSTImageCleaner"][cleaner]["picture_threshold_pe"]
+    boundary_th = config["LSTImageCleaner"][cleaner]["boundary_threshold_pe"]
+    isolated_pixels = config["LSTImageCleaner"][cleaner]["keep_isolated_pixels"]
+    min_n_picture_neighbors = config["LSTImageCleaner"][cleaner]["min_picture_neighbors"]
     return picture_th, boundary_th, isolated_pixels, min_n_picture_neighbors
 
 

--- a/lstchain/io/config.py
+++ b/lstchain/io/config.py
@@ -107,10 +107,10 @@ def get_cleaning_parameters(config, cleaner):
     -------
     tuple (picture threshold, boundary threshold, keep isolated pixels, min number picture neighbors)
     """
-    picture_th = config["LSTImageCleaner"][cleaner]["picture_threshold_pe"]
-    boundary_th = config["LSTImageCleaner"][cleaner]["boundary_threshold_pe"]
-    isolated_pixels = config["LSTImageCleaner"][cleaner]["keep_isolated_pixels"]
-    min_n_picture_neighbors = config["LSTImageCleaner"][cleaner]["min_picture_neighbors"]
+    picture_th = config[cleaner]["picture_threshold_pe"]
+    boundary_th = config[cleaner]["boundary_threshold_pe"]
+    isolated_pixels = config[cleaner]["keep_isolated_pixels"]
+    min_n_picture_neighbors = config[cleaner]["min_picture_neighbors"]
     return picture_th, boundary_th, isolated_pixels, min_n_picture_neighbors
 
 

--- a/lstchain/io/config.py
+++ b/lstchain/io/config.py
@@ -107,10 +107,10 @@ def get_cleaning_parameters(config, clean_method_name):
     -------
     tuple (picture threshold, boundary threshold, keep isolated pixels, min number picture neighbors)
     """
-    picture_th = config[clean_method_name]['picture_thresh']
-    boundary_th = config[clean_method_name]['boundary_thresh']
-    isolated_pixels = config[clean_method_name]['keep_isolated_pixels']
-    min_n_picture_neighbors = config[clean_method_name]['min_number_picture_neighbors']
+    picture_th = config["LSTImageCleaner"][clean_method_name]["picture_threshold_pe"]
+    boundary_th = config["LSTImageCleaner"][clean_method_name]["boundary_threshold_pe"]
+    isolated_pixels = config["LSTImageCleaner"][clean_method_name]["keep_isolated_pixels"]
+    min_n_picture_neighbors = config["LSTImageCleaner"][clean_method_name]["min_picture_neighbors"]
     return picture_th, boundary_th, isolated_pixels, min_n_picture_neighbors
 
 

--- a/lstchain/io/config.py
+++ b/lstchain/io/config.py
@@ -3,13 +3,13 @@ from pathlib import Path
 from copy import copy
 
 __all__ = [
-    'dump_config',
-    'get_cleaning_parameters',
-    'get_mc_config',
-    'get_standard_config',
-    'get_srcdep_config',
-    'read_configuration_file',
-    'replace_config',
+    "dump_config",
+    "get_cleaning_parameters",
+    "get_mc_config",
+    "get_standard_config",
+    "get_srcdep_config",
+    "read_configuration_file",
+    "replace_config",
 ]
 
 
@@ -42,7 +42,9 @@ def get_standard_config():
     -------
     dict
     """
-    standard_config_file = Path(__file__).parent.joinpath("../data/lstchain_standard_config.json")
+    standard_config_file = Path(__file__).parent.joinpath(
+        "../data/lstchain_standard_config.json"
+    )
     return read_configuration_file(standard_config_file)
 
 
@@ -55,7 +57,9 @@ def get_mc_config():
     dict
     """
     std_cfg = get_standard_config()
-    mc_cfg = read_configuration_file(Path(__file__).parent.joinpath("../data/lstchain_mc_config.json"))
+    mc_cfg = read_configuration_file(
+        Path(__file__).parent.joinpath("../data/lstchain_mc_config.json")
+    )
     std_cfg.update(mc_cfg)
     return std_cfg
 
@@ -69,7 +73,9 @@ def get_srcdep_config():
     dict
     """
     std_cfg = get_standard_config()
-    src_dep_cfg = read_configuration_file(Path(__file__).parent.joinpath("../data/lstchain_src_dep_config.json"))
+    src_dep_cfg = read_configuration_file(
+        Path(__file__).parent.joinpath("../data/lstchain_src_dep_config.json")
+    )
     std_cfg.update(src_dep_cfg)
     return std_cfg
 
@@ -126,5 +132,5 @@ def dump_config(config, filename, overwrite=False):
     """
     if Path(filename).exists() and not overwrite:
         raise FileExistsError(f"File {filename} exists, use overwrite=True")
-    with open(filename, 'w') as file:
+    with open(filename, "w") as file:
         json.dump(config, file, indent=2)

--- a/lstchain/io/tests/test_config.py
+++ b/lstchain/io/tests/test_config.py
@@ -5,24 +5,24 @@ import tempfile
 
 def test_get_standard_config():
     std_cfg = config.get_standard_config()
-    assert 'source_config' in std_cfg
-    assert 'LSTImageCleaner' in std_cfg
+    assert "source_config" in std_cfg
+    assert "LSTImageCleaner" in std_cfg
 
 
 def test_get_srcdep_config():
     srcdep_config = config.get_srcdep_config()
-    assert 'LSTImageCleaner' in srcdep_config
-    assert srcdep_config['source_dependent']
-    assert srcdep_config['mc_nominal_source_x_deg'] == 0.4
-    assert srcdep_config['observation_mode'] == 'wobble'
-    assert srcdep_config['n_off_wobble'] == 1
+    assert "LSTImageCleaner" in srcdep_config
+    assert srcdep_config["source_dependent"]
+    assert srcdep_config["mc_nominal_source_x_deg"] == 0.4
+    assert srcdep_config["observation_mode"] == "wobble"
+    assert srcdep_config["n_off_wobble"] == 1
 
 
 def test_get_mc_config():
     mc_cfg = config.get_mc_config()
-    assert 'LSTImageCleaner' in mc_cfg
-    assert mc_cfg['LocalPeakWindowSum']['apply_integration_correction']
-    assert mc_cfg['GlobalPeakWindowSum']['apply_integration_correction']
+    assert "LSTImageCleaner" in mc_cfg
+    assert mc_cfg["LocalPeakWindowSum"]["apply_integration_correction"]
+    assert mc_cfg["GlobalPeakWindowSum"]["apply_integration_correction"]
 
 
 def test_replace_config():
@@ -46,8 +46,8 @@ def test_get_cleaning_parameters():
 
 
 def test_dump_config():
-    cfg = {'myconf': 1}
+    cfg = {"myconf": 1}
     with tempfile.NamedTemporaryFile() as file:
         config.dump_config(cfg, file.name, overwrite=True)
         read_cfg = config.read_configuration_file(file.name)
-        assert read_cfg['myconf'] == 1
+        assert read_cfg["myconf"] == 1

--- a/lstchain/io/tests/test_config.py
+++ b/lstchain/io/tests/test_config.py
@@ -36,12 +36,13 @@ def test_replace_config():
 
 def test_get_cleaning_parameters():
     std_config = config.get_standard_config()
-    cleaning_params = get_cleaning_parameters(std_config, 'TailcutsImageCleaner')
+    cleaner = "LSTImageCleaner"
+    cleaning_params = get_cleaning_parameters(std_config, cleaner)
     picture_th, boundary_th, isolated_pixels, min_n_neighbors = cleaning_params
-    assert std_config["LSTImageCleaner"]["TailcutsImageCleaner"]["picture_threshold_pe"] == picture_th
-    assert std_config["LSTImageCleaner"]["TailcutsImageCleaner"]["boundary_threshold_pe"] == boundary_th
-    assert std_config["LSTImageCleaner"]["TailcutsImageCleaner"]["keep_isolated_pixels"] == isolated_pixels
-    assert std_config["LSTImageCleaner"]["TailcutsImageCleaner"]["min_picture_neighbors"] == min_n_neighbors
+    assert std_config[cleaner]["picture_threshold_pe"] == picture_th
+    assert std_config[cleaner]["boundary_threshold_pe"] == boundary_th
+    assert std_config[cleaner]["keep_isolated_pixels"] == isolated_pixels
+    assert std_config[cleaner]["min_picture_neighbors"] == min_n_neighbors
 
 
 def test_dump_config():

--- a/lstchain/io/tests/test_config.py
+++ b/lstchain/io/tests/test_config.py
@@ -6,12 +6,12 @@ import tempfile
 def test_get_standard_config():
     std_cfg = config.get_standard_config()
     assert 'source_config' in std_cfg
-    assert 'tailcut' in std_cfg
+    assert 'LSTImageCleaner' in std_cfg
 
 
 def test_get_srcdep_config():
     srcdep_config = config.get_srcdep_config()
-    assert 'tailcut' in srcdep_config
+    assert 'LSTImageCleaner' in srcdep_config
     assert srcdep_config['source_dependent']
     assert srcdep_config['mc_nominal_source_x_deg'] == 0.4
     assert srcdep_config['observation_mode'] == 'wobble'
@@ -20,7 +20,7 @@ def test_get_srcdep_config():
 
 def test_get_mc_config():
     mc_cfg = config.get_mc_config()
-    assert 'tailcut' in mc_cfg
+    assert 'LSTImageCleaner' in mc_cfg
     assert mc_cfg['LocalPeakWindowSum']['apply_integration_correction']
     assert mc_cfg['GlobalPeakWindowSum']['apply_integration_correction']
 
@@ -36,12 +36,12 @@ def test_replace_config():
 
 def test_get_cleaning_parameters():
     std_config = config.get_standard_config()
-    cleaning_params = get_cleaning_parameters(std_config, 'tailcut')
+    cleaning_params = get_cleaning_parameters(std_config, 'TailcutsImageCleaner')
     picture_th, boundary_th, isolated_pixels, min_n_neighbors = cleaning_params
-    assert std_config['tailcut']['picture_thresh'] == picture_th
-    assert std_config['tailcut']['boundary_thresh'] == boundary_th
-    assert std_config['tailcut']['keep_isolated_pixels'] == isolated_pixels
-    assert std_config['tailcut']['min_number_picture_neighbors'] == min_n_neighbors
+    assert std_config["LSTImageCleaner"]["TailcutsImageCleaner"]["picture_threshold_pe"] == picture_th
+    assert std_config["LSTImageCleaner"]["TailcutsImageCleaner"]["boundary_threshold_pe"] == boundary_th
+    assert std_config["LSTImageCleaner"]["TailcutsImageCleaner"]["keep_isolated_pixels"] == isolated_pixels
+    assert std_config["LSTImageCleaner"]["TailcutsImageCleaner"]["min_picture_neighbors"] == min_n_neighbors
 
 
 def test_dump_config():

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -210,14 +210,15 @@ def get_dl1(
         n_pixels = np.count_nonzero(signal_pixels)
         dl1_container.n_pixels = n_pixels
 
-        parametrize_image(
-            image=image,
-            peak_time=peak_time,
-            signal_pixels=signal_pixels,
-            camera_geometry=camera_geometry,
-            focal_length=optics.equivalent_focal_length,
-            dl1_container=dl1_container,
-        )
+        if n_pixels > 0:
+            parametrize_image(
+                image=image,
+                peak_time=peak_time,
+                signal_pixels=signal_pixels,
+                camera_geometry=camera_geometry,
+                focal_length=optics.equivalent_focal_length,
+                dl1_container=dl1_container,
+            )
 
     # We set other fields which still make sense for a non-parametrized
     # image:

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -22,7 +22,6 @@ from ctapipe.image import (
     hillas_parameters,
     tailcuts_clean,
 )
-from ctapipe.image import number_of_islands, apply_time_delta_cleaning
 from ctapipe.io import EventSource, HDF5TableWriter
 from ctapipe.utils import get_dataset_path
 from traitlets.config import Config
@@ -33,7 +32,7 @@ from .volume_reducer import apply_volume_reduction
 from ..data import NormalizedPulseTemplate
 from ..calib.camera import load_calibrator_from_config
 from ..calib.camera.calibration_calculator import CalibrationCalculator
-from ..image.cleaning import apply_dynamic_cleaning, LSTImageCleaner
+from ..image.cleaning import LSTImageCleaner
 from ..image.modifier import tune_nsb_on_waveform, calculate_required_additional_nsb
 from ..image.muon import analyze_muon_event, tag_pix_thr
 from ..image.muon import create_muon_table, fill_muon_event
@@ -66,9 +65,6 @@ __all__ = [
     'get_dl1',
     'r0_to_dl1',
 ]
-
-
-cleaning_method = tailcuts_clean
 
 
 def setup_writer(writer, subarray, is_simulation):
@@ -136,9 +132,9 @@ def parametrize_image(image, peak_time, signal_pixels, camera_geometry, focal_le
     '''
 
     geom_selected = camera_geometry[signal_pixels]
-    image_selectecd = image[signal_pixels]
-    hillas = hillas_parameters(geom_selected, image_selectecd)
-# Fill container
+    image_selected = image[signal_pixels]
+    hillas = hillas_parameters(geom_selected, image_selected)
+    # Fill container
     dl1_container.fill_hillas(hillas)
 
     # convert ctapipe's width and length (in m) to deg:
@@ -151,12 +147,12 @@ def parametrize_image(image, peak_time, signal_pixels, camera_geometry, focal_le
 
     dl1_container.set_timing_features(
         geom_selected,
-        image_selectecd,
+        image_selected,
         peak_time[signal_pixels],
         hillas,
     )
     dl1_container.set_leakage(camera_geometry, image, signal_pixels)
-    dl1_container.set_concentration(geom_selected, image_selectecd, hillas)
+    dl1_container.set_concentration(geom_selected, image_selected, hillas)
     dl1_container.log_intensity = np.log10(dl1_container.intensity)
 
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -199,18 +199,17 @@ def get_dl1(
     image = dl1.image
     peak_time = dl1.peak_time
 
-    image_cleaner = LSTImageCleaner(subarray=subarray, config=Config(config["image_cleaning"]))
-    signal_pixels, num_islands = image_cleaner(tel_id=telescope_id,
-                                               image=image,
-                                               arrival_times=peak_time
+    image_cleaner = LSTImageCleaner(subarray=subarray, config=Config(config))
+    signal_pixels, num_islands, n_pixels = image_cleaner(tel_id=telescope_id,
+                                                         image=image,
+                                                         arrival_times=peak_time
     )
-    dl1_container.n_islands = num_islands
-
-    # count surviving pixels
-    n_pixels = np.count_nonzero(signal_pixels)
-    dl1_container.n_pixels = n_pixels
-
     if n_pixels > 0:
+        dl1_container.n_islands = num_islands
+        # count surviving pixels
+        n_pixels = np.count_nonzero(signal_pixels)
+        dl1_container.n_pixels = n_pixels
+
         parametrize_image(
             image=image,
             peak_time=peak_time,

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -63,21 +63,21 @@ logger = logging.getLogger(__name__)
 
 
 __all__ = [
-    'add_disp_to_parameters_table',
-    'get_dl1',
-    'apply_lh_fit',
-    'r0_to_dl1',
+    "add_disp_to_parameters_table",
+    "get_dl1",
+    "apply_lh_fit",
+    "r0_to_dl1",
 ]
 
 
 def setup_writer(writer, subarray, is_simulation):
-    '''Setup column transforms and exlusions for the hdf5 writer for dl1'''
+    """Setup column transforms and exlusions for the hdf5 writer for dl1"""
     writer.add_column_transform(
         table_name="subarray/trigger",
         col_name="tels_with_trigger",
         transform=subarray.tel_ids_to_mask,
     )
-    writer.exclude('subarray/trigger', 'tel')
+    writer.exclude("subarray/trigger", "tel")
 
     # Forcing filters for the dl1 dataset that are currently read from the pre-existing files
     writer.h5file.filters = HDF5_ZSTD_FILTERS
@@ -87,51 +87,53 @@ def setup_writer(writer, subarray, is_simulation):
 
     for tel_name in tel_names:
         # None values in telescope/image table
-        writer.exclude(f'telescope/image/{tel_name}', 'parameters')
+        writer.exclude(f"telescope/image/{tel_name}", "parameters")
         # None values in telescope/parameters table
-        writer.exclude(f'telescope/parameters/{tel_name}', 'hadroness')
-        writer.exclude(f'telescope/parameters/{tel_name}', 'disp_norm')
-        writer.exclude(f'telescope/parameters/{tel_name}', 'disp_dx')
-        writer.exclude(f'telescope/parameters/{tel_name}', 'disp_dy')
-        writer.exclude(f'telescope/parameters/{tel_name}', 'disp_angle')
-        writer.exclude(f'telescope/parameters/{tel_name}', 'disp_sign')
-        writer.exclude(f'telescope/parameters/{tel_name}', 'disp_miss')
-        writer.exclude(f'telescope/parameters/{tel_name}', 'src_x')
-        writer.exclude(f'telescope/parameters/{tel_name}', 'src_y')
+        writer.exclude(f"telescope/parameters/{tel_name}", "hadroness")
+        writer.exclude(f"telescope/parameters/{tel_name}", "disp_norm")
+        writer.exclude(f"telescope/parameters/{tel_name}", "disp_dx")
+        writer.exclude(f"telescope/parameters/{tel_name}", "disp_dy")
+        writer.exclude(f"telescope/parameters/{tel_name}", "disp_angle")
+        writer.exclude(f"telescope/parameters/{tel_name}", "disp_sign")
+        writer.exclude(f"telescope/parameters/{tel_name}", "disp_miss")
+        writer.exclude(f"telescope/parameters/{tel_name}", "src_x")
+        writer.exclude(f"telescope/parameters/{tel_name}", "src_y")
 
         if is_simulation:
-            writer.exclude(f'telescope/parameters/{tel_name}', 'dragon_time')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'ucts_time')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'tib_time')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'ucts_jump')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'ucts_trigger_type')
+            writer.exclude(f"telescope/parameters/{tel_name}", "dragon_time")
+            writer.exclude(f"telescope/parameters/{tel_name}", "ucts_time")
+            writer.exclude(f"telescope/parameters/{tel_name}", "tib_time")
+            writer.exclude(f"telescope/parameters/{tel_name}", "ucts_jump")
+            writer.exclude(f"telescope/parameters/{tel_name}", "ucts_trigger_type")
         else:
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_energy')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'log_mc_energy')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_alt')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_az')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_core_x')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_core_y')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_h_first_int')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_alt_tel')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_az_tel')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_x_max')
-            writer.exclude(f'telescope/parameters/{tel_name}', 'mc_core_distance')
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_energy")
+            writer.exclude(f"telescope/parameters/{tel_name}", "log_mc_energy")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_alt")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_az")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_core_x")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_core_y")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_h_first_int")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_alt_tel")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_az_tel")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_x_max")
+            writer.exclude(f"telescope/parameters/{tel_name}", "mc_core_distance")
 
 
 def _camera_distance_to_angle(distance, focal_length):
-    '''Convert a distance in the camera plane into an angle
+    """Convert a distance in the camera plane into an angle
 
     This should be replaced by calculating image parameters in
     telescope frame.
-    '''
+    """
     return np.rad2deg(np.arctan(distance / focal_length))
 
 
-def parametrize_image(image, peak_time, signal_pixels, camera_geometry, focal_length, dl1_container):
-    '''
+def parametrize_image(
+    image, peak_time, signal_pixels, camera_geometry, focal_length, dl1_container
+):
+    """
     Calculate image parameters and fill them into ``dl1_container``
-    '''
+    """
 
     geom_selected = camera_geometry[signal_pixels]
     image_selected = image[signal_pixels]
@@ -141,7 +143,7 @@ def parametrize_image(image, peak_time, signal_pixels, camera_geometry, focal_le
 
     # convert ctapipe's width and length (in m) to deg:
 
-    for key in ['width', 'width_uncertainty', 'length', 'length_uncertainty']:
+    for key in ["width", "width_uncertainty", "length", "length_uncertainty"]:
         value = getattr(dl1_container, key)
         setattr(dl1_container, key, _camera_distance_to_angle(value, focal_length))
 
@@ -159,11 +161,7 @@ def parametrize_image(image, peak_time, signal_pixels, camera_geometry, focal_le
 
 
 def get_dl1(
-    calibrated_event,
-    subarray,
-    telescope_id,
-    dl1_container=None,
-    custom_config={}
+    calibrated_event, subarray, telescope_id, dl1_container=None, custom_config={}
 ):
     """
     Return a DL1ParametersContainer of extracted features from a calibrated event.
@@ -196,8 +194,8 @@ def get_dl1(
     peak_time = dl1.peak_time
 
     image_cleaner = LSTImageCleaner(subarray=subarray, config=Config(config))
-    signal_pixels, n_pixels, num_islands = image_cleaner(tel_id=telescope_id,
-                                                         event=calibrated_event
+    signal_pixels, n_pixels, num_islands = image_cleaner(
+        tel_id=telescope_id, event=calibrated_event
     )
     # the `n_pixels` here is the number of pixels which survived only the `tailcuts_clean`
     # in step 2) in the LSTImageCleaner
@@ -224,12 +222,7 @@ def get_dl1(
     return dl1_container
 
 
-def apply_lh_fit(
-        event,
-        telescope_id,
-        dl1_container,
-        fitter
-):
+def apply_lh_fit(event, telescope_id, dl1_container, fitter):
     """
     Prepare and performs the extraction of DL1 parameters using a likelihood
     based reconstruction method.
@@ -253,11 +246,15 @@ def apply_lh_fit(
             lhfit_container = DL1LikelihoodParametersContainer(lhfit_call_status=0)
         else:
             try:
-                lhfit_container = fitter(event=event, telescope_id=telescope_id, dl1_container=dl1_container)
+                lhfit_container = fitter(
+                    event=event, telescope_id=telescope_id, dl1_container=dl1_container
+                )
             except Exception:
-                logger.error("Unexpected error encountered in likelihood reconstruction.\n"
-                             "Compiled likelihood reconstruction numbaCC functions may be missing.\n"
-                             "In this case you should run: lstchain/scripts/numba_compil_lhfit.py")
+                logger.error(
+                    "Unexpected error encountered in likelihood reconstruction.\n"
+                    "Compiled likelihood reconstruction numbaCC functions may be missing.\n"
+                    "In this case you should run: lstchain/scripts/numba_compil_lhfit.py"
+                )
                 raise
     else:
         lhfit_container = DL1LikelihoodParametersContainer(lhfit_call_status=-10)
@@ -289,7 +286,7 @@ def r0_to_dl1(
     # using None as default and using `get_dataset_path` only inside the function
     # prevents downloading at import time.
     if input_filename is None:
-        get_dataset_path('gamma_test_large.simtel.gz')
+        get_dataset_path("gamma_test_large.simtel.gz")
 
     if output_filename is None:
         try:
@@ -299,12 +296,13 @@ def r0_to_dl1(
             output_filename = r0_to_dl1_filename(Path(input_filename).name)
 
     if os.path.exists(output_filename):
-        raise IOError(str(output_filename) + ' exists, exiting.')
+        raise IOError(str(output_filename) + " exists, exiting.")
 
     config = replace_config(standard_config, custom_config)
 
-    source = EventSource(input_url=input_filename,
-                         config=Config(config["source_config"]))
+    source = EventSource(
+        input_url=input_filename, config=Config(config["source_config"])
+    )
     subarray = source.subarray
     is_simu = source.is_simulation
 
@@ -315,31 +313,34 @@ def r0_to_dl1(
 
     # minimum number of pe in a pixel to include it
     # in calculation of muon ring time (peak sample):
-    min_pe_for_muon_t_calc = 10.
+    min_pe_for_muon_t_calc = 10.0
 
     # Dictionary to store muon ring parameters
     muon_parameters = create_muon_table()
 
     # all this will be cleaned up in a next PR related to the configuration files
     r1_dl1_calibrator = CameraCalibrator(
-        image_extractor_type=config['image_extractor'],
+        image_extractor_type=config["image_extractor"],
         config=Config(config),
-        subarray=subarray
+        subarray=subarray,
     )
 
     if not is_simu:
 
         # Pulse extractor for muon ring analysis. Same parameters (window_width and _shift) as the one for showers, but
         # using GlobalPeakWindowSum, since the signal for the rings is expected to be very isochronous
-        r1_dl1_calibrator_for_muon_rings = CameraCalibrator(image_extractor_type = config['image_extractor_for_muons'],
-                                                            config=Config(config),subarray = subarray)
+        r1_dl1_calibrator_for_muon_rings = CameraCalibrator(
+            image_extractor_type=config["image_extractor_for_muons"],
+            config=Config(config),
+            subarray=subarray,
+        )
 
         # Component to process interleaved pedestal and flat-fields
-        calib_config = Config({config['calibration_product']: config[config['calibration_product']]})
+        calib_config = Config(
+            {config["calibration_product"]: config[config["calibration_product"]]}
+        )
         calibration_calculator = CalibrationCalculator.from_name(
-            config['calibration_product'],
-            config=calib_config,
-            subarray=source.subarray
+            config["calibration_product"], config=calib_config, subarray=source.subarray
         )
 
     calibration_index = DL1MonitoringEventIndexContainer()
@@ -347,7 +348,7 @@ def r0_to_dl1(
     dl1_container = DL1ParametersContainer()
 
     extra_im = ExtraImageInfo()
-    extra_im.prefix = ''  # get rid of the prefix
+    extra_im.prefix = ""  # get rid of the prefix
 
     # Write extra information to the DL1 file
     subarray.to_hdf(output_filename)
@@ -361,48 +362,64 @@ def r0_to_dl1(
             metadata=metadata,
         )
     nsb_tuning = False
-    if 'waveform_nsb_tuning' in config.keys():
-        nsb_tuning = config['waveform_nsb_tuning']['nsb_tuning']
+    if "waveform_nsb_tuning" in config.keys():
+        nsb_tuning = config["waveform_nsb_tuning"]["nsb_tuning"]
         if nsb_tuning:
             if is_simu:
                 nsb_original = extract_simulation_nsb(input_filename)
                 pulse_template = NormalizedPulseTemplate.load_from_eventsource(
                     subarray.tel[1].camera.readout
                 )
-                if 'nsb_tuning_ratio' in config['waveform_nsb_tuning'].keys():
+                if "nsb_tuning_ratio" in config["waveform_nsb_tuning"].keys():
                     # get value from config to possibly extract it beforehand on multiple files for averaging purposes
                     # or gain time
-                    nsb_tuning_ratio = config['waveform_nsb_tuning']['nsb_tuning_ratio']
+                    nsb_tuning_ratio = config["waveform_nsb_tuning"]["nsb_tuning_ratio"]
                 else:
                     # extract the pedestal variance difference between the current MC file and the target data
                     # FIXME? fails for multiple telescopes
-                    nsb_tuning_ratio = calculate_required_additional_nsb(input_filename,
-                                                                         config['waveform_nsb_tuning']['target_data'],
-                                                                         config=config)[0]
-                spe = np.loadtxt(config['waveform_nsb_tuning']['spe_location']).T
+                    nsb_tuning_ratio = calculate_required_additional_nsb(
+                        input_filename,
+                        config["waveform_nsb_tuning"]["target_data"],
+                        config=config,
+                    )[0]
+                spe = np.loadtxt(config["waveform_nsb_tuning"]["spe_location"]).T
                 spe_integral = np.cumsum(spe[1])
-                charge_spe_cumulative_pdf = interp1d(spe_integral, spe[0], kind='cubic',
-                                                     bounds_error=False, fill_value=0.,
-                                                     assume_sorted=True)
+                charge_spe_cumulative_pdf = interp1d(
+                    spe_integral,
+                    spe[0],
+                    kind="cubic",
+                    bounds_error=False,
+                    fill_value=0.0,
+                    assume_sorted=True,
+                )
                 allowed_tel = np.zeros(len(nsb_original), dtype=bool)
-                allowed_tel[np.array(config['source_config']['LSTEventSource']['allowed_tels'])] = True
-                logger.info('Tuning NSB on MC waveform from '
-                            + str(np.asarray(nsb_original)[allowed_tel])
-                            + 'GHz to {0:d}%'.format(int(nsb_tuning_ratio * 100 + 100.5))
-                            + ' for telescopes ids ' + str(config['source_config']['LSTEventSource']['allowed_tels']))
+                allowed_tel[
+                    np.array(config["source_config"]["LSTEventSource"]["allowed_tels"])
+                ] = True
+                logger.info(
+                    "Tuning NSB on MC waveform from "
+                    + str(np.asarray(nsb_original)[allowed_tel])
+                    + "GHz to {0:d}%".format(int(nsb_tuning_ratio * 100 + 100.5))
+                    + " for telescopes ids "
+                    + str(config["source_config"]["LSTEventSource"]["allowed_tels"])
+                )
             else:
-                logger.warning('NSB tuning on waveform active in config but file is real data, option will be ignored')
+                logger.warning(
+                    "NSB tuning on waveform active in config but file is real data, option will be ignored"
+                )
                 nsb_tuning = False
 
     lhfit_fitter = None
-    if 'lh_fit_config' in config.keys():
-        lhfit_fitter_config = {'TimeWaveformFitter': config['lh_fit_config']}
-        lhfit_fitter = TimeWaveformFitter(subarray=subarray, config=Config(lhfit_fitter_config))
+    if "lh_fit_config" in config.keys():
+        lhfit_fitter_config = {"TimeWaveformFitter": config["lh_fit_config"]}
+        lhfit_fitter = TimeWaveformFitter(
+            subarray=subarray, config=Config(lhfit_fitter_config)
+        )
 
     with HDF5TableWriter(
         filename=output_filename,
-        group_name='dl1/event',
-        mode='a',
+        group_name="dl1/event",
+        mode="a",
         filters=HDF5_ZSTD_FILTERS,
         add_prefix=True,
         # overwrite=True,
@@ -416,10 +433,10 @@ def r0_to_dl1(
             if i % 100 == 0:
                 logger.info(i)
 
-            event.dl0.prefix = ''
-            event.trigger.prefix = ''
+            event.dl0.prefix = ""
+            event.trigger.prefix = ""
             if event.simulation is not None:
-                event.simulation.prefix = 'mc'
+                event.simulation.prefix = "mc"
 
             dl1_container.reset()
 
@@ -428,8 +445,8 @@ def r0_to_dl1(
                 write_subarray_tables(writer, event, metadata)
                 cal_mc(event)
 
-                if config['mc_image_scaling_factor'] != 1:
-                    rescale_dl1_charge(event, config['mc_image_scaling_factor'])
+                if config["mc_image_scaling_factor"] != 1:
+                    rescale_dl1_charge(event, config["mc_image_scaling_factor"])
 
             else:
                 if i == 0:
@@ -439,32 +456,46 @@ def r0_to_dl1(
 
                     tel_id = calibration_calculator.tel_id
 
-
-                    #initialize the event monitoring data
+                    # initialize the event monitoring data
                     event.mon = deepcopy(source.r0_r1_calibrator.mon_data)
-                    for container in [event.mon.tel[tel_id].pedestal, event.mon.tel[tel_id].flatfield, event.mon.tel[tel_id].calibration]:
+                    for container in [
+                        event.mon.tel[tel_id].pedestal,
+                        event.mon.tel[tel_id].flatfield,
+                        event.mon.tel[tel_id].calibration,
+                    ]:
                         add_global_metadata(container, metadata)
                         add_config_metadata(container, config)
 
                     # write the first calibration event (initialized from calibration h5 file)
-                    write_calibration_data(writer,
-                                           calibration_index,
-                                           event.mon.tel[tel_id],
-                                           new_ped=True, new_ff=True)
+                    write_calibration_data(
+                        writer,
+                        calibration_index,
+                        event.mon.tel[tel_id],
+                        new_ped=True,
+                        new_ff=True,
+                    )
 
                 # flat-field or pedestal:
-                if (event.trigger.event_type == EventType.FLATFIELD or
-                        event.trigger.event_type == EventType.SKY_PEDESTAL):
+                if (
+                    event.trigger.event_type == EventType.FLATFIELD
+                    or event.trigger.event_type == EventType.SKY_PEDESTAL
+                ):
 
                     # process interleaved events (pedestals, ff, calibration)
-                    new_ped_event, new_ff_event = calibration_calculator.process_interleaved(event)
+                    (
+                        new_ped_event,
+                        new_ff_event,
+                    ) = calibration_calculator.process_interleaved(event)
 
                     # write monitoring containers if updated
                     if new_ped_event or new_ff_event:
-                        write_calibration_data(writer,
-                                           calibration_index,
-                                           event.mon.tel[tel_id],
-                                           new_ped=new_ped_event, new_ff=new_ff_event)
+                        write_calibration_data(
+                            writer,
+                            calibration_index,
+                            event.mon.tel[tel_id],
+                            new_ped=new_ped_event,
+                            new_ff=new_ff_event,
+                        )
 
                     # calibrate and gain select the event by hand for DL1
                     source.r0_r1_calibrator.calibrate(event)
@@ -472,15 +503,22 @@ def r0_to_dl1(
             # Option to add nsb in waveforms
             if nsb_tuning:
                 # FIXME? assumes same correction ratio for all telescopes
-                for tel_id in config['source_config']['LSTEventSource']['allowed_tels']:
+                for tel_id in config["source_config"]["LSTEventSource"]["allowed_tels"]:
                     waveform = event.r1.tel[tel_id].waveform
                     readout = subarray.tel[tel_id].camera.readout
                     sampling_rate = readout.sampling_rate.to_value(u.GHz)
-                    dt = (1.0 / sampling_rate)
+                    dt = 1.0 / sampling_rate
                     selected_gains = event.r1.tel[tel_id].selected_gain_channel
-                    mask_high = (selected_gains == 0)
-                    tune_nsb_on_waveform(waveform, nsb_tuning_ratio, nsb_original[tel_id] * u.GHz,
-                                         dt * u.ns, pulse_template, mask_high, charge_spe_cumulative_pdf)
+                    mask_high = selected_gains == 0
+                    tune_nsb_on_waveform(
+                        waveform,
+                        nsb_tuning_ratio,
+                        nsb_original[tel_id] * u.GHz,
+                        dt * u.ns,
+                        pulse_template,
+                        mask_high,
+                        charge_spe_cumulative_pdf,
+                    )
 
             # create image for all events
             r1_dl1_calibrator(event)
@@ -494,12 +532,14 @@ def r0_to_dl1(
             # only after the ring analysis is complete.
 
             for telescope_id, dl1_tel in event.dl1.tel.items():
-                dl1_tel.prefix = ''  # don't really need one
+                dl1_tel.prefix = ""  # don't really need one
                 tel_name = str(subarray.tel[telescope_id])[4:]
 
                 # extra info for the image table
                 extra_im.tel_id = telescope_id
-                extra_im.selected_gain_channel = event.r1.tel[telescope_id].selected_gain_channel
+                extra_im.selected_gain_channel = event.r1.tel[
+                    telescope_id
+                ].selected_gain_channel
                 add_global_metadata(extra_im, metadata)
                 add_config_metadata(extra_im, config)
 
@@ -511,7 +551,6 @@ def r0_to_dl1(
                 dl1_container.calibration_id = calibration_index.calibration_id
 
                 dl1_container.fill_event_info(event)
-
 
                 # Will determine whether this event has to be written to the
                 # DL1 output or not.
@@ -530,9 +569,7 @@ def r0_to_dl1(
                     )
 
                 except HillasParameterizationError:
-                    logging.exception(
-                        'HillasParameterizationError in get_dl1()'
-                    )
+                    logging.exception("HillasParameterizationError in get_dl1()")
 
                 if not is_simu:
                     dl1_container.ucts_time = 0
@@ -541,14 +578,18 @@ def r0_to_dl1(
                     # FIXME: just keep it as time, table writer and reader handle it
                     dl1_container.dragon_time = event.trigger.time.unix
                     dl1_container.tib_time = 0
-                    if 'ucts_jump' in vars(event.lst.tel[
-                                               telescope_id].evt.__class__):
-                        dl1_container.ucts_jump = event.lst.tel[telescope_id].evt.ucts_jump
-                    dl1_container.ucts_trigger_type = event.lst.tel[telescope_id].evt.ucts_trigger_type
-                    dl1_container.trigger_type = event.lst.tel[telescope_id].evt.tib_masked_trigger
+                    if "ucts_jump" in vars(event.lst.tel[telescope_id].evt.__class__):
+                        dl1_container.ucts_jump = event.lst.tel[
+                            telescope_id
+                        ].evt.ucts_jump
+                    dl1_container.ucts_trigger_type = event.lst.tel[
+                        telescope_id
+                    ].evt.ucts_trigger_type
+                    dl1_container.trigger_type = event.lst.tel[
+                        telescope_id
+                    ].evt.tib_masked_trigger
                 else:
                     dl1_container.trigger_type = event.trigger.event_type
-
 
                 dl1_container.az_tel = event.pointing.tel[telescope_id].azimuth
                 dl1_container.alt_tel = event.pointing.tel[telescope_id].altitude
@@ -563,141 +604,193 @@ def r0_to_dl1(
                     add_global_metadata(container, metadata)
                     add_config_metadata(container, config)
 
-                writer.write(table_name=f'telescope/parameters/{tel_name}',
-                             containers=[event.index, dl1_container])
+                writer.write(
+                    table_name=f"telescope/parameters/{tel_name}",
+                    containers=[event.index, dl1_container],
+                )
 
                 writer.write(
-                    table_name=f'telescope/image/{tel_name}',
-                    containers=[event.index, dl1_tel, extra_im]
+                    table_name=f"telescope/image/{tel_name}",
+                    containers=[event.index, dl1_tel, extra_im],
                 )
 
                 if lhfit_fitter is not None:
-                    lhfit_container = apply_lh_fit(event, telescope_id, dl1_container, lhfit_fitter)
+                    lhfit_container = apply_lh_fit(
+                        event, telescope_id, dl1_container, lhfit_fitter
+                    )
                     # Plotting code for development purpose only, will disappear in final release
-                    if lhfit_fitter.verbose >= 2 and lhfit_container["lhfit_call_status"] == 1:
-                        plot_debug(lhfit_fitter, event, telescope_id, dl1_container, str(event.index.event_id))
+                    if (
+                        lhfit_fitter.verbose >= 2
+                        and lhfit_container["lhfit_call_status"] == 1
+                    ):
+                        plot_debug(
+                            lhfit_fitter,
+                            event,
+                            telescope_id,
+                            dl1_container,
+                            str(event.index.event_id),
+                        )
                     lhfit_container.prefix = dl1_tel.prefix
                     add_global_metadata(lhfit_container, metadata)
                     add_config_metadata(lhfit_container, config)
-                    writer.write(table_name=f'telescope/likelihood_parameters/{tel_name}',
-                                 containers=[event.index, lhfit_container])
+                    writer.write(
+                        table_name=f"telescope/likelihood_parameters/{tel_name}",
+                        containers=[event.index, lhfit_container],
+                    )
 
                 # Muon ring analysis, for real data only (MC is done starting from DL1 files)
                 if not is_simu:
-                    bad_pixels = event.mon.tel[telescope_id].calibration.unusable_pixels[0]
+                    bad_pixels = event.mon.tel[
+                        telescope_id
+                    ].calibration.unusable_pixels[0]
                     # Set to 0 unreliable pixels:
-                    image = dl1_tel.image*(~bad_pixels)
+                    image = dl1_tel.image * (~bad_pixels)
 
                     # process only promising events, in terms of # of pixels with large signals:
                     if tag_pix_thr(image):
 
                         # re-calibrate r1 to obtain new dl1, using a more adequate pulse integrator for muon rings
-                        numsamples = event.r1.tel[telescope_id].waveform.shape[1]  # not necessarily the same as in r0!
-                        bad_pixels_hg = event.mon.tel[telescope_id].calibration.unusable_pixels[0]
-                        bad_pixels_lg = event.mon.tel[telescope_id].calibration.unusable_pixels[1]
+                        numsamples = event.r1.tel[telescope_id].waveform.shape[
+                            1
+                        ]  # not necessarily the same as in r0!
+                        bad_pixels_hg = event.mon.tel[
+                            telescope_id
+                        ].calibration.unusable_pixels[0]
+                        bad_pixels_lg = event.mon.tel[
+                            telescope_id
+                        ].calibration.unusable_pixels[1]
                         # Now set to 0 all samples in unreliable pixels. Important for global peak
                         # integrator in case of crazy pixels!  TBD: can this be done in a simpler
                         # way?
                         bad_pixels = bad_pixels_hg | bad_pixels_lg
-                        bad_waveform = np.transpose(np.array(numsamples*[bad_pixels]))
+                        bad_waveform = np.transpose(np.array(numsamples * [bad_pixels]))
 
                         # print('hg bad pixels:',np.where(bad_pixels_hg))
                         # print('lg bad pixels:',np.where(bad_pixels_lg))
 
                         event.r1.tel[telescope_id].waveform *= ~bad_waveform
                         r1_dl1_calibrator_for_muon_rings(event)
-                        image = dl1_tel.image*(~bad_pixels)
+                        image = dl1_tel.image * (~bad_pixels)
 
                         # Check again: with the extractor for muon rings (most likely GlobalPeakWindowSum)
                         # perhaps the event is no longer promising (e.g. if it has a large time evolution)
                         if not tag_pix_thr(image):
                             good_ring = False
                         else:
-                            muonintensityparam, dist_mask, \
-                            ring_size, size_outside_ring, muonringparam, \
-                            good_ring, radial_distribution, \
-                            mean_pixel_charge_around_ring,\
-                            muonpars = \
-                                analyze_muon_event(subarray,
-                                                   tel_id, event.index.event_id,
-                                                   image, good_ring_config=None,
-                                                   plot_rings=False, plots_path='')
+                            (
+                                muonintensityparam,
+                                dist_mask,
+                                ring_size,
+                                size_outside_ring,
+                                muonringparam,
+                                good_ring,
+                                radial_distribution,
+                                mean_pixel_charge_around_ring,
+                                muonpars,
+                            ) = analyze_muon_event(
+                                subarray,
+                                tel_id,
+                                event.index.event_id,
+                                image,
+                                good_ring_config=None,
+                                plot_rings=False,
+                                plots_path="",
+                            )
                             #                      plot_rings=True, plots_path='./')
                             #           (test) plot muon rings as png files
 
                             # Now we want to obtain the waveform sample (in HG & LG) at which the ring light peaks:
                             bright_pixels = image > min_pe_for_muon_t_calc
-                            selected_gain = event.r1.tel[telescope_id].selected_gain_channel
+                            selected_gain = event.r1.tel[
+                                telescope_id
+                            ].selected_gain_channel
                             mask_hg = bright_pixels & (selected_gain == 0)
                             mask_lg = bright_pixels & (selected_gain == 1)
 
-                            bright_pixels_waveforms_hg = event.r1.tel[telescope_id].waveform[mask_hg, :]
-                            bright_pixels_waveforms_lg = event.r1.tel[telescope_id].waveform[mask_lg, :]
-                            stacked_waveforms_hg = np.sum(bright_pixels_waveforms_hg, axis=0)
-                            stacked_waveforms_lg = np.sum(bright_pixels_waveforms_lg, axis=0)
+                            bright_pixels_waveforms_hg = event.r1.tel[
+                                telescope_id
+                            ].waveform[mask_hg, :]
+                            bright_pixels_waveforms_lg = event.r1.tel[
+                                telescope_id
+                            ].waveform[mask_lg, :]
+                            stacked_waveforms_hg = np.sum(
+                                bright_pixels_waveforms_hg, axis=0
+                            )
+                            stacked_waveforms_lg = np.sum(
+                                bright_pixels_waveforms_lg, axis=0
+                            )
 
                             # stacked waveforms from all bright pixels; shape (ngains, nsamples)
                             hg_peak_sample = np.argmax(stacked_waveforms_hg, axis=-1)
                             lg_peak_sample = np.argmax(stacked_waveforms_lg, axis=-1)
 
                         if good_ring:
-                            fill_muon_event(-1,
-                                            muon_parameters,
-                                            good_ring,
-                                            event.index.event_id,
-                                            dl1_container.dragon_time,
-                                            muonintensityparam,
-                                            dist_mask,
-                                            muonringparam,
-                                            radial_distribution,
-                                            ring_size,
-                                            size_outside_ring,
-                                            mean_pixel_charge_around_ring,
-                                            muonpars,
-                                            hg_peak_sample, lg_peak_sample)
+                            fill_muon_event(
+                                -1,
+                                muon_parameters,
+                                good_ring,
+                                event.index.event_id,
+                                dl1_container.dragon_time,
+                                muonintensityparam,
+                                dist_mask,
+                                muonringparam,
+                                radial_distribution,
+                                ring_size,
+                                size_outside_ring,
+                                mean_pixel_charge_around_ring,
+                                muonpars,
+                                hg_peak_sample,
+                                lg_peak_sample,
+                            )
 
                 # writes mc information per telescope, including photo electron image
                 if (
                     is_simu
-                    and config['write_pe_image']
+                    and config["write_pe_image"]
                     and event.simulation.tel[telescope_id].true_image is not None
                     and event.simulation.tel[telescope_id].true_image.any()
                 ):
-                    event.simulation.tel[telescope_id].prefix = ''
+                    event.simulation.tel[telescope_id].prefix = ""
                     writer.write(
-                        table_name=f'simulation/{tel_name}',
-                        containers=[event.simulation.tel[telescope_id], extra_im]
+                        table_name=f"simulation/{tel_name}",
+                        containers=[event.simulation.tel[telescope_id], extra_im],
                     )
 
         if event is None:
-            logger.warning('No events in file')
+            logger.warning("No events in file")
 
         if not is_simu and event is not None:
             # at the end of event loop ask calculation of remaining interleaved statistics
             new_ped, new_ff = calibration_calculator.output_interleaved_results(event)
             # write monitoring events
-            write_calibration_data(writer,
-                                   calibration_index,
-                                   event.mon.tel[tel_id],
-                                   new_ped=new_ped, new_ff=new_ff)
+            write_calibration_data(
+                writer,
+                calibration_index,
+                event.mon.tel[tel_id],
+                new_ped=new_ped,
+                new_ff=new_ff,
+            )
 
     if is_simu and event is not None:
         # Reconstruct source position from disp for all events and write the result in the output file
-        add_disp_to_parameters_table(output_filename, dl1_params_lstcam_key, focal_length)
+        add_disp_to_parameters_table(
+            output_filename, dl1_params_lstcam_key, focal_length
+        )
 
         # Write energy histogram from simtel file and extra metadata
         # ONLY of the simtel file has been read until the end, otherwise it seems to hang here forever
         if source.max_events is None:
-            write_simtel_energy_histogram(source, output_filename, obs_id=event.index.obs_id,
-                                          metadata=metadata)
+            write_simtel_energy_histogram(
+                source, output_filename, obs_id=event.index.obs_id, metadata=metadata
+            )
     if not is_simu:
         dir, name = os.path.split(output_filename)
-        name = name.replace('dl1', 'muons').replace('LST-1.1', 'LST-1')
+        name = name.replace("dl1", "muons").replace("LST-1.1", "LST-1")
         # Consider the possibilities of DL1 files with .fits.h5 & .h5 ending:
-        name = name.replace('.fits.h5', '.fits').replace('.h5', '.fits')
+        name = name.replace(".fits.h5", ".fits").replace(".h5", ".fits")
         muon_output_filename = Path(dir, name)
         table = Table(muon_parameters)
-        table.write(muon_output_filename, format='fits', overwrite=True)
+        table.write(muon_output_filename, format="fits", overwrite=True)
 
 
 def add_disp_to_parameters_table(dl1_file, table_path, focal):
@@ -717,32 +810,35 @@ def add_disp_to_parameters_table(dl1_file, table_path, focal):
     """
     df = pd.read_hdf(dl1_file, key=table_path)
 
-    source_pos_in_camera = sky_to_camera(df.mc_alt.values * u.rad,
-                                         df.mc_az.values * u.rad,
-                                         focal,
-                                         df.mc_alt_tel.values * u.rad,
-                                         df.mc_az_tel.values * u.rad,
-                                         )
-    disp_parameters = disp.disp(df.x.values * u.m,
-                                df.y.values * u.m,
-                                source_pos_in_camera.x,
-                                source_pos_in_camera.y)
+    source_pos_in_camera = sky_to_camera(
+        df.mc_alt.values * u.rad,
+        df.mc_az.values * u.rad,
+        focal,
+        df.mc_alt_tel.values * u.rad,
+        df.mc_az_tel.values * u.rad,
+    )
+    disp_parameters = disp.disp(
+        df.x.values * u.m,
+        df.y.values * u.m,
+        source_pos_in_camera.x,
+        source_pos_in_camera.y,
+    )
 
     with tables.open_file(dl1_file, mode="a") as file:
         tab = file.root[table_path]
-        add_column_table(tab, tables.Float32Col, 'disp_dx', disp_parameters[0].value)
+        add_column_table(tab, tables.Float32Col, "disp_dx", disp_parameters[0].value)
         tab = file.root[table_path]
-        add_column_table(tab, tables.Float32Col, 'disp_dy', disp_parameters[1].value)
+        add_column_table(tab, tables.Float32Col, "disp_dy", disp_parameters[1].value)
         tab = file.root[table_path]
-        add_column_table(tab, tables.Float32Col, 'disp_norm', disp_parameters[2].value)
+        add_column_table(tab, tables.Float32Col, "disp_norm", disp_parameters[2].value)
         tab = file.root[table_path]
-        add_column_table(tab, tables.Float32Col, 'disp_angle', disp_parameters[3].value)
+        add_column_table(tab, tables.Float32Col, "disp_angle", disp_parameters[3].value)
         tab = file.root[table_path]
-        add_column_table(tab, tables.Float32Col, 'disp_sign', disp_parameters[4])
+        add_column_table(tab, tables.Float32Col, "disp_sign", disp_parameters[4])
         tab = file.root[table_path]
-        add_column_table(tab, tables.Float32Col, 'src_x', source_pos_in_camera.x.value)
+        add_column_table(tab, tables.Float32Col, "src_x", source_pos_in_camera.x.value)
         tab = file.root[table_path]
-        add_column_table(tab, tables.Float32Col, 'src_y', source_pos_in_camera.y.value)
+        add_column_table(tab, tables.Float32Col, "src_y", source_pos_in_camera.y.value)
 
 
 def rescale_dl1_charge(event, scaling_factor):

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -20,7 +20,6 @@ from ctapipe.containers import EventType
 from ctapipe.image import (
     HillasParameterizationError,
     hillas_parameters,
-    tailcuts_clean,
 )
 from ctapipe.io import EventSource, HDF5TableWriter
 from ctapipe.utils import get_dataset_path

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -520,7 +520,7 @@ def r0_to_dl1(
                     dl1_container.fill_mc(event, subarray.positions[telescope_id])
 
                 assert event.dl1.tel[telescope_id].image is not None
-                breakpoint()
+
                 try:
                     get_dl1(
                         event,

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -200,9 +200,11 @@ def get_dl1(
                                                          image=image,
                                                          arrival_times=peak_time
     )
+    # the `n_pixels` here is the number of pixels which survived only the first step
+    # of the LSTImageCleaner (e.g. after the TailcutsImageCleaner)
     if n_pixels > 0:
         dl1_container.n_islands = num_islands
-        # count surviving pixels
+        # count surviving pixels after all the cleaning steps
         n_pixels = np.count_nonzero(signal_pixels)
         dl1_container.n_pixels = n_pixels
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -526,7 +526,7 @@ def r0_to_dl1(
                     dl1_container.fill_mc(event, subarray.positions[telescope_id])
 
                 assert event.dl1.tel[telescope_id].image is not None
-
+                breakpoint()
                 try:
                     get_dl1(
                         event,

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -192,19 +192,16 @@ def get_dl1(
 
     dl1 = calibrated_event.dl1.tel[telescope_id]
     telescope = subarray.tel[telescope_id]
-    camera_geometry = telescope.camera.geometry
-    optics = telescope.optics
 
     image = dl1.image
     peak_time = dl1.peak_time
 
     image_cleaner = LSTImageCleaner(subarray=subarray, config=Config(config))
-    signal_pixels, num_islands, n_pixels = image_cleaner(tel_id=telescope_id,
-                                                         image=image,
-                                                         arrival_times=peak_time
+    signal_pixels, n_pixels, num_islands = image_cleaner(tel_id=telescope_id,
+                                                         event=calibrated_event
     )
-    # the `n_pixels` here is the number of pixels which survived only the first step
-    # of the LSTImageCleaner (e.g. after the TailcutsImageCleaner)
+    # the `n_pixels` here is the number of pixels which survived only the `tailcuts_clean`
+    # in step 2) in the LSTImageCleaner
     if n_pixels > 0:
         dl1_container.n_islands = num_islands
         # count surviving pixels after all the cleaning steps
@@ -216,17 +213,14 @@ def get_dl1(
                 image=image,
                 peak_time=peak_time,
                 signal_pixels=signal_pixels,
-                camera_geometry=camera_geometry,
-                focal_length=optics.equivalent_focal_length,
+                camera_geometry=telescope.camera.geometry,
+                focal_length=telescope.optics.equivalent_focal_length,
                 dl1_container=dl1_container,
             )
 
     # We set other fields which still make sense for a non-parametrized
     # image:
     dl1_container.set_telescope_info(subarray, telescope_id)
-
-    # save the applied cleaning mask
-    calibrated_event.dl1.tel[telescope_id].image_mask = signal_pixels
 
     return dl1_container
 

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -249,7 +249,7 @@ def main():
                     use_dynamic_cleaning=config[cleaner]["use_dynamic_cleaning"],
                     threshold_dynamic=config[cleaner]["threshold_dynamic"],
                     fraction_dynamic=config[cleaner]["fraction_dynamic"],
-                    use_only_main_island=config[cleaner]["use_only_main_island"]
+                    use_only_largest_island=config[cleaner]["use_only_largest_island"]
                 )
 
                 # the `n_pixels` here is the number of pixels after `tailcuts_clean`

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -129,9 +129,9 @@ def main():
         log.info("Pedestal cleaning")
         sigma = config[cleaner]['sigma']
         pedestal_thresh = get_threshold_from_dl1_file(args.input_file, sigma)
-        pic_th = np.clip(pedestal_thresh, pic_th, None)
         log.info(f"Fraction of pixel cleaning thresholds above picture thr.:"
                  f"{np.sum(pedestal_thresh > pic_th ) / len(pedestal_thresh):.3f}")
+        pic_th = np.clip(pedestal_thresh, pic_th, None)
         log.info(f"Tailcut clean with pedestal threshold config used:"
                  f"{config[cleaner]}")
 

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -233,7 +233,8 @@ def main():
                     arrival_times=peak_time
                 )
 
-
+                # the `n_pixels` here is the number of pixels which survived only the first step
+                # of the LSTImageCleaner (e.g. after the TailcutsImageCleaner)
                 if n_pixels > 0:
                     dl1_container.n_islands = num_islands
                     # count surviving pixels after all the cleaning steps

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -15,6 +15,7 @@ import sys
 import argparse
 import logging
 from pathlib import Path
+from traitlets.config import Config
 
 import astropy.units as u
 import numpy as np
@@ -138,7 +139,7 @@ def main():
     optics = subarray_info.tel[tel_id].optics
     camera_geom = subarray_info.tel[tel_id].camera.geometry
 
-    image_cleaner = LSTImageCleaner(subarray=subarray_info, config=config)
+    image_cleaner = LSTImageCleaner(subarray=subarray_info, config=Config(config))
 
     dl1_container = DL1ParametersContainer()
     parameters_to_update = [

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -24,8 +24,17 @@ from ctapipe.instrument import SubarrayDescription
 
 from lstchain.calib.camera.pixel_threshold_estimation import get_threshold_from_dl1_file
 from lstchain.image.cleaning import lst_image_cleaning
-from lstchain.image.modifier import random_psf_smearer, set_numba_seed, add_noise_in_pixels
-from lstchain.io import get_dataset_keys, copy_h5_nodes, HDF5_ZSTD_FILTERS, add_source_filenames
+from lstchain.image.modifier import (
+    random_psf_smearer,
+    set_numba_seed,
+    add_noise_in_pixels,
+)
+from lstchain.io import (
+    get_dataset_keys,
+    copy_h5_nodes,
+    HDF5_ZSTD_FILTERS,
+    add_source_filenames,
+)
 
 from lstchain.io.config import (
     get_cleaning_parameters,
@@ -36,7 +45,7 @@ from lstchain.io.config import (
 from lstchain.io.io import (
     dl1_images_lstcam_key,
     dl1_params_lstcam_key,
-    global_metadata, 
+    global_metadata,
     write_metadata,
 )
 from lstchain.io.lstcontainers import DL1ParametersContainer
@@ -51,32 +60,37 @@ parser = argparse.ArgumentParser(
 
 # Required arguments
 parser.add_argument(
-    '-f', '--input-file',
+    "-f",
+    "--input-file",
     required=True,
-    help='path to the DL1a file ',
+    help="path to the DL1a file ",
 )
 
 parser.add_argument(
-    '-o', '--output-file',
+    "-o",
+    "--output-file",
     required=True,
-    help='key for the table of new parameters',
+    help="key for the table of new parameters",
 )
 # Optional arguments
 parser.add_argument(
-    '-c', '--config',
-    dest='config_file',
-    help='Path to a configuration file. If none is given, a standard configuration is applied',
+    "-c",
+    "--config",
+    dest="config_file",
+    help="Path to a configuration file. If none is given, a standard configuration is applied",
 )
 
 parser.add_argument(
-    '--no-image', action='store_true',
-    help='Pass this argument to avoid writing the images in the new DL1 files. Beware, if `increase_nsb` or `increase_psf` are True in the config, the images will not be written.',
+    "--no-image",
+    action="store_true",
+    help="Pass this argument to avoid writing the images in the new DL1 files. Beware, if `increase_nsb` or `increase_psf` are True in the config, the images will not be written.",
 )
 
 parser.add_argument(
-    '--no-pedestal-cleaning', action='store_false',
-    dest='pedestal_cleaning',
-    help='Disable pedestal cleaning. This is also done automatically for simulations.',
+    "--no-pedestal-cleaning",
+    action="store_false",
+    dest="pedestal_cleaning",
+    help="Disable pedestal cleaning. This is also done automatically for simulations.",
 )
 
 
@@ -88,7 +102,7 @@ def main():
     logging.getLogger().addHandler(handler)
 
     if Path(args.output_file).exists():
-        log.critical(f'Output file {args.output_file} already exists')
+        log.critical(f"Output file {args.output_file} already exists")
         sys.exit(1)
 
     std_config = get_standard_config()
@@ -97,8 +111,8 @@ def main():
     else:
         config = std_config
 
-    with tables.open_file(args.input_file, 'r') as f:
-        is_simulation = 'simulation' in f.root
+    with tables.open_file(args.input_file, "r") as f:
+        is_simulation = "simulation" in f.root
 
     cleaner = "LSTImageCleaner"
     use_pedestal_cleaning = config[cleaner]["use_pedestal_cleaning"]
@@ -118,22 +132,27 @@ def main():
         transition_charge = imconfig["transition_charge"]
         extra_noise_in_bright_pixels = imconfig["extra_noise_in_bright_pixels"]
         smeared_light_fraction = imconfig["smeared_light_fraction"]
-        if (increase_nsb or increase_psf):
-            log.info("NOTE: Using the image_modifier options means images will "
-                     "not be saved.")
+        if increase_nsb or increase_psf:
+            log.info(
+                "NOTE: Using the image_modifier options means images will "
+                "not be saved."
+            )
             args.no_image = True
 
     cleaning_params = get_cleaning_parameters(config, cleaner)
     pic_th, boundary_th, isolated_pixels, min_n_neighbors = cleaning_params
     if use_pedestal_cleaning is True:
         log.info("Pedestal cleaning")
-        sigma = config[cleaner]['sigma']
+        sigma = config[cleaner]["sigma"]
         pedestal_thresh = get_threshold_from_dl1_file(args.input_file, sigma)
-        log.info(f"Fraction of pixel cleaning thresholds above picture thr.:"
-                 f"{np.sum(pedestal_thresh > pic_th ) / len(pedestal_thresh):.3f}")
+        log.info(
+            f"Fraction of pixel cleaning thresholds above picture thr.:"
+            f"{np.sum(pedestal_thresh > pic_th ) / len(pedestal_thresh):.3f}"
+        )
         pic_th = np.clip(pedestal_thresh, pic_th, None)
-        log.info(f"Tailcut clean with pedestal threshold config used:"
-                 f"{config[cleaner]}")
+        log.info(
+            f"Tailcut clean with pedestal threshold config used:" f"{config[cleaner]}"
+        )
 
     subarray_info = SubarrayDescription.from_hdf(args.input_file)
     tel_id = config["allowed_tels"][0] if "allowed_tels" in config else 1
@@ -142,29 +161,29 @@ def main():
 
     dl1_container = DL1ParametersContainer()
     parameters_to_update = [
-        'intensity',
-        'x',
-        'y',
-        'r',
-        'phi',
-        'length',
-        'width',
-        'psi',
-        'skewness',
-        'kurtosis',
-        'concentration_cog',
-        'concentration_core',
-        'concentration_pixel',
-        'leakage_intensity_width_1',
-        'leakage_intensity_width_2',
-        'leakage_pixels_width_1',
-        'leakage_pixels_width_2',
-        'n_islands',
-        'intercept',
-        'time_gradient',
-        'n_pixels',
-        'wl',
-        'log_intensity'
+        "intensity",
+        "x",
+        "y",
+        "r",
+        "phi",
+        "length",
+        "width",
+        "psi",
+        "skewness",
+        "kurtosis",
+        "concentration_cog",
+        "concentration_core",
+        "concentration_pixel",
+        "leakage_intensity_width_1",
+        "leakage_intensity_width_2",
+        "leakage_pixels_width_1",
+        "leakage_pixels_width_2",
+        "n_islands",
+        "intercept",
+        "time_gradient",
+        "n_pixels",
+        "wl",
+        "log_intensity",
     ]
 
     nodes_keys = get_dataset_keys(args.input_file)
@@ -173,33 +192,38 @@ def main():
 
     metadata = global_metadata()
 
-    with tables.open_file(args.input_file, mode='r') as infile:
+    with tables.open_file(args.input_file, mode="r") as infile:
         image_table = infile.root[dl1_images_lstcam_key]
         dl1_params_input = infile.root[dl1_params_lstcam_key].colnames
-        disp_params = {'disp_dx', 'disp_dy', 'disp_norm', 'disp_angle', 'disp_sign'}
+        disp_params = {"disp_dx", "disp_dy", "disp_norm", "disp_angle", "disp_sign"}
         if set(dl1_params_input).intersection(disp_params):
             parameters_to_update.extend(disp_params)
-        uncertainty_params = {'width_uncertainty', 'length_uncertainty'}
+        uncertainty_params = {"width_uncertainty", "length_uncertainty"}
         if set(dl1_params_input).intersection(uncertainty_params):
             parameters_to_update.extend(uncertainty_params)
 
         if increase_nsb:
             rng = np.random.default_rng(
-                    infile.root.dl1.event.subarray.trigger.col('obs_id')[0])
+                infile.root.dl1.event.subarray.trigger.col("obs_id")[0]
+            )
 
         if increase_psf:
-            set_numba_seed(infile.root.dl1.event.subarray.trigger.col('obs_id')[0])
+            set_numba_seed(infile.root.dl1.event.subarray.trigger.col("obs_id")[0])
 
-        image_mask_save = not args.no_image and 'image_mask' in infile.root[dl1_images_lstcam_key].colnames
+        image_mask_save = (
+            not args.no_image
+            and "image_mask" in infile.root[dl1_images_lstcam_key].colnames
+        )
 
-        with tables.open_file(args.output_file, mode='a', filters=HDF5_ZSTD_FILTERS) as outfile:
+        with tables.open_file(
+            args.output_file, mode="a", filters=HDF5_ZSTD_FILTERS
+        ) as outfile:
             copy_h5_nodes(infile, outfile, nodes=nodes_keys)
             add_source_filenames(outfile, [args.input_file])
 
-
             params = outfile.root[dl1_params_lstcam_key].read()
             if image_mask_save:
-                image_mask = outfile.root[dl1_images_lstcam_key].col('image_mask')
+                image_mask = outfile.root[dl1_images_lstcam_key].col("image_mask")
 
             # need container to use lstchain.io.add_global_metadata and lstchain.io.add_config_metadata
             for k, item in metadata.as_dict().items():
@@ -210,22 +234,28 @@ def main():
 
                 dl1_container.reset()
 
-                image = row['image']
-                peak_time = row['peak_time']
+                image = row["image"]
+                peak_time = row["peak_time"]
 
                 if increase_nsb:
                     # Add noise in pixels, to adjust MC to data noise levels.
                     # TO BE DONE: in case of "pedestal cleaning" (not used now
                     # in MC) we should recalculate picture_th above!
-                    image = add_noise_in_pixels(rng, image,
-                                                extra_noise_in_dim_pixels,
-                                                extra_bias_in_dim_pixels,
-                                                transition_charge,
-                                                extra_noise_in_bright_pixels)
+                    image = add_noise_in_pixels(
+                        rng,
+                        image,
+                        extra_noise_in_dim_pixels,
+                        extra_bias_in_dim_pixels,
+                        transition_charge,
+                        extra_noise_in_bright_pixels,
+                    )
                 if increase_psf:
-                    image = random_psf_smearer(image, smeared_light_fraction,
-                                               camera_geom.neighbor_matrix_sparse.indices,
-                                               camera_geom.neighbor_matrix_sparse.indptr)
+                    image = random_psf_smearer(
+                        image,
+                        smeared_light_fraction,
+                        camera_geom.neighbor_matrix_sparse.indices,
+                        camera_geom.neighbor_matrix_sparse.indptr,
+                    )
 
                 signal_pixels = tailcuts_clean(
                     geom=camera_geom,
@@ -233,7 +263,7 @@ def main():
                     picture_thresh=pic_th,
                     boundary_thresh=boundary_th,
                     keep_isolated_pixels=isolated_pixels,
-                    min_number_picture_neighbors=min_n_neighbors
+                    min_number_picture_neighbors=min_n_neighbors,
                 )
                 signal_pixels, num_islands, n_pixels = lst_image_cleaning(
                     geom=camera_geom,
@@ -244,7 +274,7 @@ def main():
                     use_dynamic_cleaning=config[cleaner]["use_dynamic_cleaning"],
                     threshold_dynamic=config[cleaner]["threshold_dynamic"],
                     fraction_dynamic=config[cleaner]["fraction_dynamic"],
-                    use_only_largest_island=config[cleaner]["use_only_largest_island"]
+                    use_only_largest_island=config[cleaner]["use_only_largest_island"],
                 )
 
                 # the `n_pixels` here is the number of pixels after `tailcuts_clean`
@@ -266,17 +296,17 @@ def main():
 
                 if set(dl1_params_input).intersection(disp_params):
                     disp_dx, disp_dy, disp_norm, disp_angle, disp_sign = disp(
-                        dl1_container['x'].to_value(u.m),
-                        dl1_container['y'].to_value(u.m),
-                        params['src_x'][ii],
-                        params['src_y'][ii]
+                        dl1_container["x"].to_value(u.m),
+                        dl1_container["y"].to_value(u.m),
+                        params["src_x"][ii],
+                        params["src_y"][ii],
                     )
 
-                    dl1_container['disp_dx'] = disp_dx
-                    dl1_container['disp_dy'] = disp_dy
-                    dl1_container['disp_norm'] = disp_norm
-                    dl1_container['disp_angle'] = disp_angle
-                    dl1_container['disp_sign'] = disp_sign
+                    dl1_container["disp_dx"] = disp_dx
+                    dl1_container["disp_dy"] = disp_dy
+                    dl1_container["disp_norm"] = disp_norm
+                    dl1_container["disp_angle"] = disp_angle
+                    dl1_container["disp_sign"] = disp_sign
 
                 for p in parameters_to_update:
                     params[ii][p] = u.Quantity(dl1_container[p]).value
@@ -286,10 +316,12 @@ def main():
 
             outfile.root[dl1_params_lstcam_key][:] = params
             if image_mask_save:
-                outfile.root[dl1_images_lstcam_key].modify_column(colname='image_mask', column=image_mask)
+                outfile.root[dl1_images_lstcam_key].modify_column(
+                    colname="image_mask", column=image_mask
+                )
 
         write_metadata(metadata, args.output_file)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -131,7 +131,7 @@ def main():
         pic_thresh_ped = np.clip(pedestal_thresh, pic_thresh, None)
         config["LSTImageCleaner"]["TailcutsImageCleaner"]["picture_threshold_pe"] = pic_thresh_ped
         log.info(f"Tailcut clean with pedestal threshold config used:"
-                 f"{config['LSTImageCleaner']} with {config["pedestal_cleaning"]}")
+                 f"{config['LSTImageCleaner']} with {config['pedestal_cleaning']}")
 
     subarray_info = SubarrayDescription.from_hdf(args.input_file)
     tel_id = config["allowed_tels"][0] if "allowed_tels" in config else 1

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -41,7 +41,7 @@ ALL_SCRIPTS = find_entry_points("lstchain")
 
 
 def run_program(*args):
-    result = sp.run(args, stdout=sp.PIPE, stderr=sp.STDOUT, encoding='utf-8')
+    result = sp.run(args, stdout=sp.PIPE, stderr=sp.STDOUT, encoding="utf-8")
 
     if result.returncode != 0:
         raise ValueError(
@@ -65,16 +65,20 @@ def simulated_dl1ab(temp_dir_simulated_files, simulated_dl1_file):
     run_program("lstchain_dl1ab", "-f", simulated_dl1_file, "-o", output_file)
     return output_file
 
-def test_add_source_dependent_parameters(temp_dir_simulated_srcdep_files, simulated_dl1_file):
+
+def test_add_source_dependent_parameters(
+    temp_dir_simulated_srcdep_files, simulated_dl1_file
+):
     shutil.copy(simulated_dl1_file, temp_dir_simulated_srcdep_files / "dl1_copy.h5")
     dl1_file = temp_dir_simulated_srcdep_files / "dl1_copy.h5"
     run_program("lstchain_add_source_dependent_parameters", "-f", dl1_file)
     dl1_params_src_dep = get_srcdep_params(dl1_file)
 
-    assert 'alpha' in dl1_params_src_dep['on'].columns
-    assert 'dist' in dl1_params_src_dep['on'].columns
-    assert 'time_gradient_from_source' in dl1_params_src_dep['on'].columns
-    assert 'skewness_from_source' in dl1_params_src_dep['on'].columns
+    assert "alpha" in dl1_params_src_dep["on"].columns
+    assert "dist" in dl1_params_src_dep["on"].columns
+    assert "time_gradient_from_source" in dl1_params_src_dep["on"].columns
+    assert "skewness_from_source" in dl1_params_src_dep["on"].columns
+
 
 @pytest.fixture(scope="session")
 def merged_simulated_dl1_file(simulated_dl1_file, temp_dir_simulated_files):
@@ -122,7 +126,7 @@ def test_observed_dl1_validity(observed_dl1_files):
     assert dl1_params_tel_mon_ped_key in dl1_tables
     assert dl1_params_tel_mon_flat_key in dl1_tables
 
-    subarray = SubarrayDescription.from_hdf(observed_dl1_files['dl1_file1'])
+    subarray = SubarrayDescription.from_hdf(observed_dl1_files["dl1_file1"])
     assert 1 in subarray.tel
     assert subarray.tel[1].name == "LST"
 
@@ -244,12 +248,8 @@ def test_lstchain_merge_dl1_hdf5_observed_files(
     merged_dl1_df = pd.read_hdf(merged_dl1_observed_file, key=dl1_params_lstcam_key)
     assert merged_dl1_observed_file.is_file()
     assert len(dl1a_df) + len(dl1b_df) == len(merged_dl1_df)
-    assert dl1_images_lstcam_key in get_dataset_keys(
-        merged_dl1_observed_file
-    )
-    assert dl1_params_lstcam_key in get_dataset_keys(
-        merged_dl1_observed_file
-    )
+    assert dl1_images_lstcam_key in get_dataset_keys(merged_dl1_observed_file)
+    assert dl1_params_lstcam_key in get_dataset_keys(merged_dl1_observed_file)
 
 
 @pytest.mark.private_data
@@ -299,19 +299,19 @@ def test_lstchain_dl1_to_dl2(simulated_dl2_file):
 def test_lstchain_dl1_to_dl2_srcdep(simulated_srcdep_dl2_file):
     assert simulated_srcdep_dl2_file.is_file()
     dl2_srcdep_df = get_srcdep_params(simulated_srcdep_dl2_file)
-    assert "expected_src_x" in dl2_srcdep_df['on'].columns
-    assert "expected_src_y" in dl2_srcdep_df['on'].columns
-    assert "dist" in dl2_srcdep_df['on'].columns
-    assert "alpha" in dl2_srcdep_df['on'].columns
-    assert "time_gradient_from_source" in dl2_srcdep_df['on'].columns
-    assert "skewness_from_source" in dl2_srcdep_df['on'].columns
-    assert "gammaness" in dl2_srcdep_df['on'].columns
-    assert "reco_type" in dl2_srcdep_df['on'].columns
-    assert "reco_energy" in dl2_srcdep_df['on'].columns
-    assert "reco_disp_dx" in dl2_srcdep_df['on'].columns
-    assert "reco_disp_dy" in dl2_srcdep_df['on'].columns
-    assert "reco_src_x" in dl2_srcdep_df['on'].columns
-    assert "reco_src_y" in dl2_srcdep_df['on'].columns
+    assert "expected_src_x" in dl2_srcdep_df["on"].columns
+    assert "expected_src_y" in dl2_srcdep_df["on"].columns
+    assert "dist" in dl2_srcdep_df["on"].columns
+    assert "alpha" in dl2_srcdep_df["on"].columns
+    assert "time_gradient_from_source" in dl2_srcdep_df["on"].columns
+    assert "skewness_from_source" in dl2_srcdep_df["on"].columns
+    assert "gammaness" in dl2_srcdep_df["on"].columns
+    assert "reco_type" in dl2_srcdep_df["on"].columns
+    assert "reco_energy" in dl2_srcdep_df["on"].columns
+    assert "reco_disp_dx" in dl2_srcdep_df["on"].columns
+    assert "reco_disp_dy" in dl2_srcdep_df["on"].columns
+    assert "reco_src_x" in dl2_srcdep_df["on"].columns
+    assert "reco_src_y" in dl2_srcdep_df["on"].columns
 
 
 @pytest.mark.private_data
@@ -327,6 +327,7 @@ def test_lstchain_find_pedestals(temp_dir_observed_files, observed_dl1_files):
         assert path.is_file()
         t = read_table(path, "/interleaved_pedestal_ids")
         assert len(t) == expected_length
+
 
 @pytest.mark.private_data
 def test_lstchain_observed_dl1_to_dl2(observed_dl2_file):
@@ -348,26 +349,28 @@ def test_lstchain_observed_dl1_to_dl2_srcdep(observed_srcdep_dl2_file):
     assert observed_srcdep_dl2_file.is_file()
     dl2_srcdep_df = get_srcdep_params(observed_srcdep_dl2_file)
     srcdep_config = get_srcdep_config()
-    srcdep_assumed_positions = ['on']
-    n_off_wobble=srcdep_config.get('n_off_wobble')
+    srcdep_assumed_positions = ["on"]
+    n_off_wobble = srcdep_config.get("n_off_wobble")
     for ioff in range(n_off_wobble):
         off_angle = 2 * np.pi / (n_off_wobble + 1) * (ioff + 1)
-        srcdep_assumed_positions.append('off_{:03}'.format(round(np.rad2deg(off_angle))))
+        srcdep_assumed_positions.append(
+            "off_{:03}".format(round(np.rad2deg(off_angle)))
+        )
 
     srcdep_dl2_params = [
-        'expected_src_x',
-        'expected_src_y',
-        'dist',
-        'alpha',
-        'time_gradient_from_source',
-        'skewness_from_source',
-        'gammaness',
-        'reco_type',
-        'reco_energy',
-        'reco_disp_dx',
-        'reco_disp_dy',
-        'reco_src_x',
-        'reco_src_y'
+        "expected_src_x",
+        "expected_src_y",
+        "dist",
+        "alpha",
+        "time_gradient_from_source",
+        "skewness_from_source",
+        "gammaness",
+        "reco_type",
+        "reco_energy",
+        "reco_disp_dx",
+        "reco_disp_dy",
+        "reco_src_x",
+        "reco_src_y",
     ]
 
     for srcdep_assumed_position in srcdep_assumed_positions:
@@ -379,7 +382,7 @@ def test_dl1ab(simulated_dl1ab):
     assert simulated_dl1ab.is_file()
     with tables.open_file(simulated_dl1ab) as output:
         assert dl1_images_lstcam_key in output.root
-        assert '/source_filenames' in output.root
+        assert "/source_filenames" in output.root
         assert len(output.root.source_filenames.filenames[:]) == 1
 
 
@@ -387,34 +390,37 @@ def test_dl1ab_no_images(simulated_dl1_file, tmp_path):
     """Produce a new simulated dl1 file using the dl1ab script."""
     output_file = tmp_path / "dl1ab_no_images.h5"
 
-    config_path = tmp_path / 'config.json'
-    with config_path.open('w') as f:
+    config_path = tmp_path / "config.json"
+    with config_path.open("w") as f:
         config = get_standard_config()
-        config['LSTImageCleaner']["picture_threshold_pe"] = 10
-        config['LSTImageCleaner']["boundary_threshold_pe"] = 5
+        config["LSTImageCleaner"]["picture_threshold_pe"] = 10
+        config["LSTImageCleaner"]["boundary_threshold_pe"] = 5
         json.dump(config, f)
 
     run_program(
         "lstchain_dl1ab",
-        "-f", simulated_dl1_file,
-        "-o", output_file,
-        "-c", config_path,
-        '--no-image',
+        "-f",
+        simulated_dl1_file,
+        "-o",
+        output_file,
+        "-c",
+        config_path,
+        "--no-image",
     )
 
-    with tables.open_file(output_file, 'r') as output:
+    with tables.open_file(output_file, "r") as output:
         assert dl1_images_lstcam_key not in output.root
         assert dl1_params_lstcam_key in output.root
 
         new_parameters = output.root[dl1_params_lstcam_key][:]
 
-        with tables.open_file(simulated_dl1_file, 'r') as input_file:
+        with tables.open_file(simulated_dl1_file, "r") as input_file:
             old_parameters = input_file.root[dl1_params_lstcam_key][:]
 
             # new cleaning should result in less pixels
-            assert (new_parameters['n_pixels'] <= old_parameters['n_pixels']).all()
-            assert (new_parameters['n_pixels'] < old_parameters['n_pixels']).any()
-            assert (new_parameters['length'] != old_parameters['length']).any()
+            assert (new_parameters["n_pixels"] <= old_parameters["n_pixels"]).all()
+            assert (new_parameters["n_pixels"] < old_parameters["n_pixels"]).any()
+            assert (new_parameters["length"] != old_parameters["length"]).any()
 
 
 @pytest.mark.private_data
@@ -422,9 +428,11 @@ def test_observed_dl1ab(tmp_path, observed_dl1_files):
     output_dl1ab = tmp_path / "dl1ab.h5"
     run_program(
         "lstchain_dl1ab",
-        "-f", observed_dl1_files["dl1_file1"],
-        "-o", output_dl1ab,
-        "--no-pedestal-cleaning"
+        "-f",
+        observed_dl1_files["dl1_file1"],
+        "-o",
+        output_dl1ab,
+        "--no-pedestal-cleaning",
     )
     assert output_dl1ab.is_file()
 
@@ -432,8 +440,8 @@ def test_observed_dl1ab(tmp_path, observed_dl1_files):
     dl1 = pd.read_hdf(observed_dl1_files["dl1_file1"], key=dl1_params_lstcam_key)
 
     np.testing.assert_allclose(
-        dl1.to_numpy(dtype='float'),
-        dl1ab.to_numpy(dtype='float'),
+        dl1.to_numpy(dtype="float"),
+        dl1ab.to_numpy(dtype="float"),
         rtol=1e-3,
         equal_nan=True,
     )
@@ -492,7 +500,10 @@ def test_run_summary(run_summary_path):
 
     run_summary_table = Table.read(run_summary_path)
 
-    assert run_summary_table.meta["date"] == datetime.strptime(date, "%Y%m%d").date().isoformat()
+    assert (
+        run_summary_table.meta["date"]
+        == datetime.strptime(date, "%Y%m%d").date().isoformat()
+    )
     assert "lstchain_version" in run_summary_table.meta
     assert "run_id" in run_summary_table.columns
     assert "n_subruns" in run_summary_table.columns
@@ -510,6 +521,7 @@ def test_run_summary(run_summary_path):
 
 def test_numba_compil_lhfit():
     from lstchain.scripts import numba_compil_lhfit
-    assert numba_compil_lhfit.cc.name == 'log_pdf_CC'
-    assert 'log_pdf' in numba_compil_lhfit.cc._exported_functions
+
+    assert numba_compil_lhfit.cc.name == "log_pdf_CC"
+    assert "log_pdf" in numba_compil_lhfit.cc._exported_functions
     assert len(numba_compil_lhfit.cc._exported_functions) == 6

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -390,8 +390,8 @@ def test_dl1ab_no_images(simulated_dl1_file, tmp_path):
     config_path = tmp_path / 'config.json'
     with config_path.open('w') as f:
         config = get_standard_config()
-        config['LSTImageCleaner']["TailcutsImageCleaner"]["picture_threshold_pe"] = 10
-        config['LSTImageCleaner']["TailcutsImageCleaner"]["boundary_threshold_pe"] = 5
+        config['LSTImageCleaner']["picture_threshold_pe"] = 10
+        config['LSTImageCleaner']["boundary_threshold_pe"] = 5
         json.dump(config, f)
 
     run_program(

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -390,8 +390,8 @@ def test_dl1ab_no_images(simulated_dl1_file, tmp_path):
     config_path = tmp_path / 'config.json'
     with config_path.open('w') as f:
         config = get_standard_config()
-        config['tailcut']["picture_thresh"] = 10
-        config['tailcut']["boundary_thresh"] = 5
+        config['LSTImageCleaner']["TailcutsImageCleaner"]["picture_threshold_pe"] = 10
+        config['LSTImageCleaner']["TailcutsImageCleaner"]["boundary_threshold_pe"] = 5
         json.dump(config, f)
 
     run_program(


### PR DESCRIPTION
Referring to #972 and #667, I started refactoring the cleaning by creating a cleaning component which substitutes the cleaning parts in the `r0_to_dl1` and `dl1ab` script.

**Main changes:**

- There is now the `LSTImageCleaner`-class with a lot of traits for all the cleaning params and configurable by the config system
- It basically has 3 steps: **1)** get pedestal thresholds for `tailcuts_clean` **2)** `tailcuts_clean` **3)** `lst_image_cleaning`
- the `lst_image_cleaning` consist of the steps `apply_time_delta_cleaning`, `apply_dynamic_cleaning` and selecting the `largest_island` which can be all turned on/off by the config system
- instead of using the custom code for getting the main/largest island, i switched to the ctapipe function `ctapipe.image.morphology.largest_island` and renamed it to largest_island because main_island could be a bit ambiguous (main island could be largest or brightest one)
- the standard_config is adapted to the `LSTImageCleaner`
- the `dl1ab`-script does not use the `LSTImageCleaner` yet because it loops over the tables directly via pytables instead of using the EventSource (Want to switch that in a later PR). So the pedestal_cleaning part inside the `LSTImageCleaner` is not yet used by any script.


**Concerns/Thoughts:**

- For now, i put the pedestal_cleaning part (i.e. calculating the pedestal thresholds for the tailcuts cleaning)  in the call function of the `LSTImageCleaner`. But that would mean, that the thresholds are calculated again for every image which is a wasted effort (since it is calculated just once per run). But its not yet used as explained in the last bullet point above. So maybe its better to outsource the calculation of the pedestal thresholds outside the eventloop and pass them then to the `LSTImageCleaner`? idk maybe someone has a good solution for that ...