### PR TITLE
greater or equal filters in DL3Cuts

### DIFF
--- a/lstchain/io/event_selection.py
+++ b/lstchain/io/event_selection.py
@@ -174,7 +174,7 @@ class DL3Cuts(Component):
             data["gh_score"],
             data["reco_energy"],
             gh_cuts,
-            operator.gt,
+            operator.ge,
         )
         return data[data["selected_gh"]]
 
@@ -218,7 +218,7 @@ class DL3Cuts(Component):
             data["theta"],
             data["reco_energy"],
             theta_cuts,
-            operator.lt,
+            operator.le,
         )
         return data[data["selected_theta"]]
 
@@ -261,7 +261,7 @@ class DL3Cuts(Component):
             data["alpha"],
             data["reco_energy"],
             alpha_cuts,
-            operator.lt,
+            operator.le,
         )
         return data[data["selected_alpha"]]
             

--- a/lstchain/io/tests/test_eventselection.py
+++ b/lstchain/io/tests/test_eventselection.py
@@ -100,7 +100,7 @@ def test_dl3_energy_dependent_cuts():
     assert alpha_cut["cut"][0] == 15.88 * u.deg
     assert len(data_th) == 21
     assert len(data_gh) == 26
-    assert len(data_al) == 14
+    assert len(data_al) == 17
 
 
 def test_data_binning():


### PR DESCRIPTION
I think a greater *or equal* operator is actually what we want here. For example, if a user requests an efficiency of 100%, I think he expects all events to be included, which is not the case atm.