### PR TITLE
Add alias to disable timelapse correction to lstchain_create_drs4_pedestal_file

### DIFF
--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -165,6 +165,11 @@ class DRS4PedestalAndSpikeHeight(Tool):
             "DRS4PedestalAndSpikeHeight.full_statistics",
             "Whether to write the full statistics about spikes or not",
         ),
+        **flag(
+            "timelapse-correction",
+            "LSTR0Corrections.apply_timelapse_correction",
+            "Wether to apply drs4 timelapse correction or not.",
+        ),
     }
 
     classes = [LSTEventSource]
@@ -196,7 +201,6 @@ class DRS4PedestalAndSpikeHeight(Tool):
 
         self.source.r0_r1_calibrator.offset = 0
         self.source.r0_r1_calibrator.apply_spike_correction = False
-        self.source.r0_r1_calibrator.apply_timelapse_correction = True
         self.source.r0_r1_calibrator.apply_drs4_pedestal_correction = False
 
         n_stats = N_GAINS * N_PIXELS * N_CAPACITORS_PIXEL

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -168,7 +168,7 @@ class DRS4PedestalAndSpikeHeight(Tool):
         **flag(
             "timelapse-correction",
             "LSTR0Corrections.apply_timelapse_correction",
-            "Wether to apply drs4 timelapse correction or not.",
+            "Whether to apply drs4 timelapse correction or not.",
         ),
     }
 


### PR DESCRIPTION
Fixes #1014 


Adds a `--no-timelapse-correction` flag to the tool to disable the dt correction

@SeiyaNozaki 