### PR TITLE
fixed calculation of noise in dim pixels parameter

### DIFF
--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -351,8 +351,8 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     # The idea is that when a strong signal is present, the biased extractor
     # will integrate around it, and the additional noise is unbiased because
     # it won't modify the integration range.
-    # The noise is defined as the number of NSB photons, i.e. the extra variance, 
-    # rather than standard deviation, of the distribution
+    # The noise is defined as the number of NSB photoelectrons, i.e. the extra
+    # variance, rather than standard deviation, of the distribution
     extra_noise_in_bright_pixels = \
         ((data_median_std_ped_pe**2 - mc_unbiased_std_ped_pe**2) *
          shower_extractor_window_width / pedestal_extractor_window_width)

--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -372,7 +372,7 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     # calculate widening of the noise bump:
     added_noise = (np.sum(dq[dq<maxq]**2)/len(dq[dq<maxq]) -
                    np.sum(dqmc[dqmc<maxq]**2)/len(dqmc[dqmc < maxq]))
-    extra_noise_in_dim_pixels = max(0, added_noise)
+    extra_noise_in_dim_pixels = max(0., added_noise)
 
     return extra_noise_in_dim_pixels, extra_bias_in_dim_pixels, \
            extra_noise_in_bright_pixels

--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -173,11 +173,11 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     Returns
     -------
     extra_noise_in_dim_pixels: `float`
-        Extra noise of dim pixels.
+        Extra noise of dim pixels (number of NSB photoelectrons).
     extra_bias_in_dim_pixels: `float`
-        Extra bias of dim pixels.
+        Extra bias of dim pixels  (direct shift in photoelectrons).
     extra_noise_in_bright_pixels: `float`
-        Extra noise of bright pixels
+        Extra noise of bright pixels  (number of NSB photoelectrons).
 
     """
 
@@ -351,6 +351,8 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     # The idea is that when a strong signal is present, the biased extractor
     # will integrate around it, and the additional noise is unbiased because
     # it won't modify the integration range.
+    # The noise is defined as the number of NSB photons, i.e. the extra variance, 
+    # rather than standard deviation, of the distribution
     extra_noise_in_bright_pixels = \
         ((data_median_std_ped_pe**2 - mc_unbiased_std_ped_pe**2) *
          shower_extractor_window_width / pedestal_extractor_window_width)
@@ -370,8 +372,7 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     # calculate widening of the noise bump:
     added_noise = (np.sum(dq[dq<maxq]**2)/len(dq[dq<maxq]) -
                    np.sum(dqmc[dqmc<maxq]**2)/len(dqmc[dqmc < maxq]))
-    added_noise = (max(0, added_noise))**0.5
-    extra_noise_in_dim_pixels = added_noise
+    extra_noise_in_dim_pixels = max(0, added_noise)
 
     return extra_noise_in_dim_pixels, extra_bias_in_dim_pixels, \
            extra_noise_in_bright_pixels


### PR DESCRIPTION
Unnecessary square root was added so the noise in dim pixels was defined as standard deviation. While later on it is used as a number of NSB photons from which poissonian number is selected (that adds this square root in the noise). Noise in the brigth pixels was properly defined (without square root)