### PR TITLE
Set correct NSB tuning settings for low-zenith MC

### DIFF
--- a/lstchain/data/lstchain_dl1ab_tune_MC_to_Crab_config.json
+++ b/lstchain/data/lstchain_dl1ab_tune_MC_to_Crab_config.json
@@ -12,12 +12,12 @@
 
   "image_modifier": {
     "increase_nsb": true,
-    "extra_noise_in_dim_pixels": 1.2,
-    "extra_bias_in_dim_pixels": 0.5,
+    "extra_noise_in_dim_pixels": 1.62,
+    "extra_bias_in_dim_pixels": 0.655,
     "transition_charge": 8,
-    "extra_noise_in_bright_pixels": 1.2,
-    "increase_psf": true,
-    "smeared_light_fraction": 0.125
+    "extra_noise_in_bright_pixels": 2.08,
+    "increase_psf": false,
+    "smeared_light_fraction": 0
   },
 
   "tailcut": {


### PR DESCRIPTION
NSB parameters are obtained with the fixed code for finding the NSB-tuning parameters (#1024).  Note: the replaced parameters were very outdated, not obtained with the immediately earlier version, and were not those used for Crab in the analyses over the past few months.

Also switched off obsolete optical PSF tuning.