### PR TITLE
Fix dl1ab: writing params using astropy tables

### DIFF
--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -347,7 +347,7 @@ def main():
                      path=dl1_params_lstcam_key,
                      overwrite=True,
                      append=True,
-                     compression=HDF5_ZSTD_FILTERS.complib,
+                     # compression=HDF5_ZSTD_FILTERS.complib,
                      compression_opts=HDF5_ZSTD_FILTERS.complevel)
 
 

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -347,6 +347,7 @@ def main():
                      path=dl1_params_lstcam_key,
                      overwrite=True,
                      append=True,
+                     serialize_meta=True,
                      # compression=HDF5_ZSTD_FILTERS.complib,
                      compression_opts=HDF5_ZSTD_FILTERS.complevel)
 


### PR DESCRIPTION
Trying to fix DL1ab parameters writing
The issue arose when trying to compute DL1ab starting from files from lstchain v0.9.6 using lstchain v0.9.8, the parameters `sin_az_tel` did not exist in the former, so it can't be _recomputed_ the way it currently is in lstchain.

We could however completely overwrite the parameters table. This is actually more flexible and simpler.
But I can't use ` HDF5_ZSTD_FILTERS.complib` there because `blosc:zstd` is not recognized by astropy table writer.

 