### PR TITLE
checking if parameters exist before trying to update them

### DIFF
--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -226,8 +226,12 @@ def main():
             copy_h5_nodes(infile, outfile, nodes=nodes_keys)
             add_source_filenames(outfile, [args.input_file])
 
+            params_node = outfile.root[dl1_params_lstcam_key]
+            params = params_node.read()
 
-            params = outfile.root[dl1_params_lstcam_key].read()
+            log.warning(f"Parameters not in original DL1 file {args.input_file} that can't be recomputed:"
+                        f"{set(parameters_to_update) - set(params_node.colnames)}")
+            parameters_to_update = list(set(parameters_to_update) & set(params_node.colnames))
             if image_mask_save:
                 image_mask = outfile.root[dl1_images_lstcam_key].col('image_mask')
 


### PR DESCRIPTION
Fixes #1032 

That is the simplest solution at the moment, the alternative being to revert entirely the `sin_az_tel` addition.