### PR TITLE
truly optional config image_modifier

### DIFF
--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -101,27 +101,25 @@ def main():
     else:
         config = std_config
 
-
     with tables.open_file(args.input_file, 'r') as f:
         is_simulation = 'simulation' in f.root
 
-    increase_nsb = False
-    increase_psf = False
     if "image_modifier" in config:
         imconfig = config["image_modifier"]
-        increase_nsb = imconfig["increase_nsb"]
-        increase_psf = imconfig["increase_psf"]
+        increase_nsb = imconfig.get("increase_nsb", False)
+        increase_psf = imconfig.get("increase_psf", False)
         if increase_nsb or increase_psf:
             log.info(f"image_modifier configuration: {imconfig}")
-        extra_noise_in_dim_pixels = imconfig["extra_noise_in_dim_pixels"]
-        extra_bias_in_dim_pixels = imconfig["extra_bias_in_dim_pixels"]
-        transition_charge = imconfig["transition_charge"]
-        extra_noise_in_bright_pixels = imconfig["extra_noise_in_bright_pixels"]
-        smeared_light_fraction = imconfig["smeared_light_fraction"]
-        if (increase_nsb or increase_psf):
             log.info("NOTE: Using the image_modifier options means images will "
                      "not be saved.")
             args.no_image = True
+        if increase_nsb:
+            extra_noise_in_dim_pixels = imconfig["extra_noise_in_dim_pixels"]
+            extra_bias_in_dim_pixels = imconfig["extra_bias_in_dim_pixels"]
+            transition_charge = imconfig["transition_charge"]
+            extra_noise_in_bright_pixels = imconfig["extra_noise_in_bright_pixels"]
+        if increase_psf:
+            smeared_light_fraction = imconfig["smeared_light_fraction"]
 
     if is_simulation:
         args.pedestal_cleaning = False

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -227,8 +227,10 @@ def main():
             params_node = outfile.root[dl1_params_lstcam_key]
             params = params_node.read()
 
-            log.warning(f"Parameters not in original DL1 file {args.input_file} that can't be recomputed:"
-                        f"{set(parameters_to_update) - set(params_node.colnames)}")
+            new_params = set(parameters_to_update) - set(params_node.colnames)
+            if new_params:
+                log.warning(f"Parameters not in original DL1 file {args.input_file} that can't be recomputed:"
+                            f"{new_params}")
             parameters_to_update = list(set(parameters_to_update) & set(params_node.colnames))
             if image_mask_save:
                 image_mask = outfile.root[dl1_images_lstcam_key].col('image_mask')

--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -104,25 +104,24 @@ def main():
     with tables.open_file(args.input_file, 'r') as f:
         is_simulation = 'simulation' in f.root
 
-    if "image_modifier" in config:
-        imconfig = config["image_modifier"]
-        increase_nsb = imconfig.get("increase_nsb", False)
-        increase_psf = imconfig.get("increase_psf", False)
-        if increase_nsb or increase_psf:
-            log.info(f"image_modifier configuration: {imconfig}")
-            log.info("NOTE: Using the image_modifier options means images will "
-                     "not be saved.")
-            args.no_image = True
-        if increase_nsb:
-            extra_noise_in_dim_pixels = imconfig["extra_noise_in_dim_pixels"]
-            extra_bias_in_dim_pixels = imconfig["extra_bias_in_dim_pixels"]
-            transition_charge = imconfig["transition_charge"]
-            extra_noise_in_bright_pixels = imconfig["extra_noise_in_bright_pixels"]
-        if increase_psf:
-            smeared_light_fraction = imconfig["smeared_light_fraction"]
+    imconfig = config.get('image_modifier', {})
+    increase_nsb = imconfig.get("increase_nsb", False)
+    increase_psf = imconfig.get("increase_psf", False)
 
-    if is_simulation:
-        args.pedestal_cleaning = False
+    if increase_nsb or increase_psf:
+        log.info(f"image_modifier configuration: {imconfig}")
+        log.info("NOTE: Using the image_modifier options means images will "
+                 "not be saved.")
+        args.no_image = True
+    if increase_nsb:
+        extra_noise_in_dim_pixels = imconfig["extra_noise_in_dim_pixels"]
+        extra_bias_in_dim_pixels = imconfig["extra_bias_in_dim_pixels"]
+        transition_charge = imconfig["transition_charge"]
+        extra_noise_in_bright_pixels = imconfig["extra_noise_in_bright_pixels"]
+    if increase_psf:
+        smeared_light_fraction = imconfig["smeared_light_fraction"]
+
+    args.pedestal_cleaning = False if is_simulation else args.pedestal_cleaning
 
     if args.pedestal_cleaning:
         log.info("Pedestal cleaning")


### PR DESCRIPTION
I suppose the intent was to have these optional, since a default value was defined.
However, the reading from the config was mandatory, which is a contradiction.

This PR fixes this.