### PR TITLE
Use numba njit code to inject NSB in R1 waveforms

### DIFF
--- a/lstchain/data/normalised_pulse_template.py
+++ b/lstchain/data/normalised_pulse_template.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.interpolate import interp1d
+from lstchain.reco.reconstructorCC import template_interpolation
 
 
 class NormalizedPulseTemplate:
@@ -54,30 +55,34 @@ class NormalizedPulseTemplate:
         Use the interpolated template to access the value of the pulse at
         time = time in gain regime = gain. Additionally, an alternative
         normalisation, origin of time and baseline can be used.
+        Uses compiled function instead of scipy to gain time.
+        Works only for a single pixel.
 
         Parameters
         ----------
         time: float array
             Time after the origin to estimate the value of the pulse
-        gain: string array
-            Identifier of the gain channel used for each pixel
+        gain: string
+            Identifier of the gain channel used
             Either "HG" or "LG"
         amplitude: float
             Normalisation factor to apply to the template
         t_0: float
             Shift in the origin of time
         baseline: float array
-            Baseline to be subtracted for each pixel
+            Baseline to be subtracted
 
         Return
         ----------
         y: array
-            Value of the template in each pixel at the requested times
+            Value of the template at the requested times
 
         """
 
-        y = amplitude * self._template[gain](time - t_0) + baseline
-        return np.array(y)
+        is_high_gain = np.array([gain == 'HG'])
+        y = amplitude * template_interpolation(is_high_gain, np.array([time-t_0]), self.t0, self.dt,
+                                               self.amplitude_HG, self.amplitude_LG) - baseline
+        return y[0]
 
     def resample_template(self):
         """

--- a/lstchain/data/tests/test_normalised_pulse_template.py
+++ b/lstchain/data/tests/test_normalised_pulse_template.py
@@ -14,10 +14,11 @@ def test_load_from_file_and_miscellaneous(tmp_path):
         f.write('0 0.1 0 0.002 0.01\n1 0.7 0.8 0.005 0.02\n'
                 '2 0.2 0.2 0.01 0.04\n3 0 0 0 0\n4 0 0 0 0')
     template = NormalizedPulseTemplate.load_from_file(path)
-    assert np.isclose(template(1.5, 'HG'), 0.45, rtol=0.1)
+    assert np.isclose(template(np.array([1.5]), 'HG'), 0.45, rtol=0.1)
     assert np.isclose(template.get_error(1.5, 'LG'), 0.03, rtol=0.2)
     assert np.isclose(template.compute_time_of_max(), 1.0, rtol=0.1)
     save_path = tmp_path / "tmp_pulse2.txt"
     template.save(save_path)
     template = NormalizedPulseTemplate.load_from_file(path, resample=True)
+    template(np.array([0.2, 0.8, 2, 3.5]), 'HG')
     template = NormalizedPulseTemplate.load_from_file(path, resample=True, dt=0.5)

--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -407,8 +407,9 @@ def tune_nsb_on_waveform(waveform, added_nsb_fraction, original_nsb,
     waveform -= baseline_correction
     for i in range(n_pixels):
         for j in range(additional_nsb[i]):
-            waveform[i] += (added_nsb_amp[i][j]
-                            * (pulse_templates(t[20:] - added_nsb_time[i][j], 'HG' if gain[i] else 'LG')))
+            waveform[i] += pulse_templates(t[20:], 'HG' if gain[i] else 'LG',
+                                           amplitude=added_nsb_amp[i][j],
+                                           t_0=added_nsb_time[i][j])
 
 
 def calculate_required_additional_nsb(simtel_filename, data_dl1_filename, config=None):

--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -377,6 +377,7 @@ def calculate_noise_parameters(simtel_filename, data_dl1_filename,
     return extra_noise_in_dim_pixels, extra_bias_in_dim_pixels, \
            extra_noise_in_bright_pixels
 
+
 def tune_nsb_on_waveform(waveform, added_nsb_fraction, original_nsb,
                          dt, pulse_templates, gain, charge_spe_cumulative_pdf):
     """
@@ -394,20 +395,20 @@ def tune_nsb_on_waveform(waveform, added_nsb_fraction, original_nsb,
     fluctuation cumulative pdf used to randomise the normalisation of
     injected pulses
     """
+    n = 25
     n_pixels, n_samples = waveform.shape
-    duration = (20 + n_samples) * dt  # TODO check needed time window, effect of edges
-    t = np.arange(-20, n_samples) * dt.value
+    duration = (n + n_samples) * dt  # TODO check needed time window, effect of edges
+    t = np.arange(-n, n_samples) * dt.value
     mean_added_nsb = (added_nsb_fraction * original_nsb) * duration
     rng = np.random.default_rng()
     additional_nsb = rng.poisson(mean_added_nsb, n_pixels)
-    added_nsb_time = rng.uniform(-20 * dt.value, -20 * dt.value + duration.value, (n_pixels, max(additional_nsb)))
+    added_nsb_time = rng.uniform(-n * dt.value, -n * dt.value + duration.value, (n_pixels, max(additional_nsb)))
     added_nsb_amp = charge_spe_cumulative_pdf(rng.uniform(size=(n_pixels, max(additional_nsb))))
-
     baseline_correction = (added_nsb_fraction * original_nsb * dt).value
     waveform -= baseline_correction
     for i in range(n_pixels):
         for j in range(additional_nsb[i]):
-            waveform[i] += pulse_templates(t[20:], 'HG' if gain[i] else 'LG',
+            waveform[i] += pulse_templates(t[n:], 'HG' if gain[i] else 'LG',
                                            amplitude=added_nsb_amp[i][j],
                                            t_0=added_nsb_time[i][j])
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -412,7 +412,7 @@ def r0_to_dl1(
             if is_simu:
                 nsb_original = extract_simulation_nsb(input_filename)
                 pulse_template = NormalizedPulseTemplate.load_from_eventsource(
-                    subarray.tel[1].camera.readout
+                    subarray.tel[1].camera.readout, resample=True
                 )
                 if 'nsb_tuning_ratio' in config['waveform_nsb_tuning'].keys():
                     # get value from config to possibly extract it beforehand on multiple files for averaging purposes

--- a/lstchain/reco/reconstructorCC.py
+++ b/lstchain/reco/reconstructorCC.py
@@ -217,7 +217,7 @@ def template_interpolation(gain, times, t0, dt, a_hg, a_lg):
             # Find the index before the requested time
             a = (times[i, j]-t0)/dt
             t = int(a)
-            if t+1 < size:
+            if 0 < t+1 < size:
                 # Select the gain and interpolate the pulse template at the requested time
                 out[i, j] = a_hg[t] * (1. - a + t) + a_hg[t+1] * (a-t) if gain[i] else \
                     a_lg[t] * (1. - a + t) + a_lg[t+1] * (a-t)


### PR DESCRIPTION
New version of #1006 done in a more recent version of lstchain (the diff ended up being the same, but it cleans up the commit history). Significantly accelerate NSB injection on waveforms compared to the current implementation using scipy.interpd1d every time.