### PR TITLE
Change conda installation to mamba setup in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Mamba setup
         uses: mamba-org/provision-with-micromamba@v14
         with:
-          activate-environment: "lst-dev"
+          environment-name: "lst-dev"
           environment-file: environment.yml
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
   pyflakes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -45,7 +45,7 @@ jobs:
         ctapipe-version: [v0.12.0]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -98,12 +98,12 @@ jobs:
     needs: pyflakes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,20 +49,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Prepare conda installation
+      - name: Prepare mamba installation
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          # fix mamba error that the directory does not exist
-          mkdir -p ~/conda_pkgs_dir/cache
           # setup correct python version
           sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
 
-      - name: Conda setup
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Mamba setup
+        uses: mamba-org/provision-with-micromamba@v14
         with:
-          mamba-version: "*"
-          auto-update-conda: true
           activate-environment: "lst-dev"
           environment-file: environment.yml
 


### PR DESCRIPTION
CI is currently failing. The problem is related to conda installation with `conda-incubator/setup-miniconda@v2`. Same happened in ctapipe (see https://github.com/cta-observatory/ctapipe/pull/2207). I also updated version of checkout and python setup actions