### PR TITLE
fix missing configs in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_extra_path = ['examples']
+
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/docs/lst_analysis_workflow.rst
+++ b/docs/lst_analysis_workflow.rst
@@ -86,9 +86,12 @@ You can also produce a config using `lstchain-dump-config`.
 DL3/IRF config files
 --------------------
 
- DL3/IRF example config files are provided in `docs/example`:
-  - `dl3_tool_config.json <examples/dl3_tool_config.json>`_
-  - `irf_tool_config.json <examples/irf_tool_config.json>`_
+
+DL3/IRF example config files are provided in `docs/example`:
+
+  - `dl3_tool_config.json <dl3_tool_config.json>`_
+  - `irf_tool_config.json <irf_tool_config.json>`_
+
 
 Such files should be used to produce DL3 files and IRFs from DL2 (see :ref:`the Analysis Steps <introduction>`)
 


### PR DESCRIPTION
@chaimain realized that config files links were broken. here is a fix.