### PR TITLE
Dvr pixel selector

### DIFF
--- a/lstchain/conftest.py
+++ b/lstchain/conftest.py
@@ -108,6 +108,8 @@ def observed_dl1_files(temp_dir_observed_files, run_summary_path):
     dl1_output_path1 = temp_dir_observed_files / "dl1_LST-1.Run02008.0000.h5"
     muons_file1 = temp_dir_observed_files / "muons_LST-1.Run02008.0000.fits"
     datacheck_file1 = temp_dir_observed_files / "datacheck_dl1_LST-1.Run02008.0000.h5"
+    dvr_file1 = temp_dir_observed_files / "DVR_settings_LST-1.Run02008.h5"
+    pixmasks_file1 = temp_dir_observed_files / "Pixel_selection_LST-1.Run02008.0000.h5"
 
     # Second set of files
     dl1_output_path2 = temp_dir_observed_files / "dl1_LST-1.Run02008.0100.h5"
@@ -148,6 +150,24 @@ def observed_dl1_files(temp_dir_observed_files, run_summary_path):
     )
 
     run_program(
+        "lstchain_dvr_pixselector",
+        "--dl1-files",
+        dl1_output_path1,
+        "--output-dir",
+        temp_dir_observed_files
+    )
+
+    run_program(
+        "lstchain_dvr_pixselector",
+        "--dl1-files",
+        dl1_output_path1,
+        "--output-dir",
+        temp_dir_observed_files,
+        "--action",
+        "create_pixel_masks"
+    )
+
+    run_program(
         "lstchain_data_r0_to_dl1",
         "-f",
         test_r0_path2,
@@ -180,6 +200,8 @@ def observed_dl1_files(temp_dir_observed_files, run_summary_path):
         'dl1_file1': dl1_output_path1,
         'muons1': muons_file1,
         'datacheck1': datacheck_file1,
+        'dvr_file1': dvr_file1,
+        'pixmasks_file1': pixmasks_file1,
         'dl1_file2': dl1_output_path2,
         'muons2': muons_file2,
         'datacheck2': datacheck_file2

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -165,7 +165,7 @@ def main():
     fraction_of_survival = 1.
     target_nevents = 5000 # number of events for the calculation (to speed up!)
     charges_cosmics = charges_data[cosmic_mask]
-    event_jump = int(charges_cosmics.shape[0] / target_nevents)
+    event_jump = int(charges_cosmics.shape[0] / target_nevents) + 1
     charges_cosmics_sampled = charges_cosmics[::event_jump, :]
 
     while fraction_of_survival > max_pix_survival_fraction:

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -46,7 +46,8 @@ class RunSummary(Container):
     min_pixel_survival_fraction = Field(np.float32(np.nan), 'min_pixel_survival_fraction')
     max_pixel_survival_fraction = Field(np.float32(np.nan), 'max_pixel_survival_fraction')
     mean_pixel_survival_fraction = Field(np.float32(np.nan), 'mean_pixel_survival_fraction')
-    fraction_of_full_CR_events = Field(np.float32(np.nan), 'fraction_of_full_CR_events')
+    fraction_of_full_shower_events = Field(np.float32(np.nan),
+                                           'fraction_of_full_shower_events')
     number_of_always_saved_pixels = Field(0, 'number_of_always_saved_pixels')
     ped_mean = Field(np.float32(np.nan), '')  # photo-electrons
     ped_stdev = Field(np.float32(np.nan), '') # photo-electrons
@@ -156,7 +157,7 @@ def main():
     # rate
 
     selected_pixels_masks = []
-    # Check what fraction of cosmics is kept with the current value of
+    # Check what fraction of shower events is kept with the current value of
     # min_charge_for_certain_selection
 
     for event_index in range(len(charges_data)):
@@ -174,7 +175,7 @@ def main():
                             len(selected_pixels_masks.flatten()))
 
     if fraction_of_survival > max_survival_fraction:
-        print("Fraction in CRs of pixels with >",
+        print("Fraction in shower events of pixels with >",
               min_charge_for_certain_selection, "pe & neighbors:",
               np.round(fraction_of_survival, 3), "higher than maximum allowed:",
               max_survival_fraction)
@@ -230,18 +231,19 @@ def main():
 
     cr_masks = selected_pixels_masks[(event_type_data==32)]
     fraction_of_survival = cr_masks.sum() / len(cr_masks.flatten())
-    print("Fraction in CRs of pixels with >", min_charge_for_certain_selection,
+    print("Fraction in shower events of pixels with >",
+          min_charge_for_certain_selection,
           "pe & neighbors:", np.round(fraction_of_survival, 3))
 
     num_sel_pixels = np.array(num_sel_pixels)
-    print('Average number of selected pixels per event:',
+    print('Average number of selected pixels per event (of any type):',
           np.round(num_sel_pixels.sum() / len(data_parameters), 2))
-    print(f'Fraction: '
+    print(f'Fraction of whole camera: '
           f'{num_sel_pixels.sum()/len(data_parameters)/camera_geom.n_pixels:.3f}')
 
 
     # Keep track of how many events were fully saved (whole camera)>
-    summary_info.fraction_of_full_CR_events = \
+    summary_info.fraction_of_full_shower_events = \
         np.round((np.sum(selected_pixels_masks[(data_parameters['event_type']==32)],
                          axis=1) ==  camera_geom.n_pixels).sum() /
                          (data_parameters['event_type']==32).sum(), 5)

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -201,7 +201,7 @@ def main():
         if fraction_of_survival <= max_pix_survival_fraction_in_ped:
             break
 
-        print("Fraction in shower events of pixels with >",
+        print("Fraction in pedestal events of pixels with >",
               min_charge_for_certain_selection, "pe & first neighbors:",
               np.round(fraction_of_survival, 3), "is higher than maximum "
                                                  "allowed:",
@@ -213,7 +213,7 @@ def main():
     if min_charge_for_certain_selection > args.picture_threshold:
         print("min_charge_for_certain_selection changed to",
               min_charge_for_certain_selection)
-    print("Fraction in shower events of pixels with >",
+    print("Fraction in pedestal events of pixels with >",
           min_charge_for_certain_selection, "pe & first neighbors:",
           np.round(fraction_of_survival, 3)),
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -189,7 +189,8 @@ def main():
     if fraction_of_survival > max_survival_fraction:
         print("Fraction in shower events of pixels with >",
               min_charge_for_certain_selection, "pe & first neighbors:",
-              np.round(fraction_of_survival, 3), "higher than maximum allowed:",
+              np.round(fraction_of_survival, 3), "is higher than maximum "
+                                                 "allowed:",
               max_survival_fraction)
         # Modify the value of min_charge_for_certain_selection to get a lower
         # survival fraction
@@ -326,9 +327,8 @@ def get_selected_pixels(charge_map, min_charge_for_certain_selection,
     # Chances are that pixels labeled as "unknown" are cosmics, so we include
     # them among the types to be reduced.
 
-    selected_pixels = np.array(geom.n_pixels * [True])
     if event_type not in event_types_to_be_reduced:
-        return selected_pixels
+        return np.array(geom.n_pixels * [True])
 
     # Now proceed with the identification of interesting pixels to be saved.
     # Keep pixels that have a charge above min_charge_for_certain_selection:

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -387,7 +387,7 @@ def main():
                             writer.write("selected_pixels_masks", data)
                 break
             except:
-                if number_of_writing_attempts > 30:
+                if number_of_writing_attempts > 60:
                     print("I gave up!")
                     exit(1)
                 print(time.asctime(time.localtime()),

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -210,8 +210,12 @@ def main():
         # survival fraction
         min_charge_for_certain_selection += 1.
 
-    print("min_charge_for_certain_selection changed to",
-          min_charge_for_certain_selection)
+    if min_charge_for_certain_selection > args.picture_threshold:
+        print("min_charge_for_certain_selection changed to",
+              min_charge_for_certain_selection)
+    print("Fraction in shower events of pixels with >",
+          min_charge_for_certain_selection, "pe & first neighbors:",
+          np.round(fraction_of_survival, 3)),
 
     summary_info.min_charge_for_certain_selection = min_charge_for_certain_selection
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+"""
+This script reads in DL1 files and determines for each event which pixels
+contain relevant information and should hence be kept when reducing the raw
+data volume.
+"""
+
 import argparse
 from pathlib import Path
 import tables
@@ -334,6 +340,9 @@ def main():
                     data.pixmask = pixmask
                     writer.write("selected_pixels_masks", data)
 
+    print()
+    print('lstchain_dvr_pixselector finished successfully!')
+    print()
 
 def get_selected_pixels(charge_map, min_charge_for_certain_selection,
                         number_of_rings, geom,

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -351,7 +351,7 @@ def main():
 
         # In case the system is temporarily unavailable writing of the file
         # may fail. If so, we try again (every minute) until we succeed,
-        # and give up after one hour:
+        # and give up after a certain number of attempts:
         number_of_writing_attempts = 0
         while True:
             try:
@@ -387,14 +387,14 @@ def main():
                             writer.write("selected_pixels_masks", data)
                 break
             except:
-                if number_of_writing_attempts > 60:
+                if number_of_writing_attempts > 30:
                     print("I gave up!")
                     exit(1)
                 print(time.asctime(time.localtime()),
                       "Could not write output, attempt",
                       number_of_writing_attempts,
-                      "... Will try again after 60 s")
-                time.sleep(60)
+                      "... Will try again after 5 minutes")
+                time.sleep(300)
                 continue
 
     print()

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -84,7 +84,7 @@ def main():
 
     output_dir = args.output_dir.absolute()
     output_dir.mkdir(exist_ok=True, parents=True)
-    output_file = Path(output_dir, f'Pixel_selection_LST-1.Run{run_id:d}.'
+    output_file = Path(output_dir, f'Pixel_selection_LST-1.Run{run_id:05d}.'
                                    f'{subrun_id:04d}.h5')
     print('Output file: ', output_file)
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -80,8 +80,11 @@ def main():
     summary_info.run_id = run_id
     summary_info.subrun_id = subrun_id
 
-    output_dir = args.output_dir
-    output_file = output_dir + f'/Pixel_selection_LST-1.Run{run_id:d}.{subrun_id:04d}.h5'
+
+    output_dir = args.output_dir.absolute()
+    output_dir.mkdir(exist_ok=True, parents=True)
+    output_file = Path(output_dir, f'/Pixel_selection_LST-1.Run{run_id:d}.'
+                                   f'{subrun_id:04d}.h5')
     print('Output file: ', output_file)
 
     data_parameters = read_table(dl1_file,

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -3,6 +3,7 @@
 import argparse
 from pathlib import Path
 import tables
+import glob
 import numpy as np
 
 from lstchain.paths import parse_dl1_filename
@@ -14,9 +15,9 @@ from ctapipe.containers import EventType
 
 parser = argparse.ArgumentParser(description="DVR pixel selector")
 
-parser.add_argument('-f', '--dl1-file', dest='dl1_file',
-                    type=Path,
-                    help='Input DL1 file name')
+parser.add_argument('-f', '--dl1-files', dest='dl1_files',
+                    type=str,
+                    help='Input DL1 file names')
 parser.add_argument('-o', '--output-dir', dest='output_dir',
                     type=Path, default='./',
                     help='Path to the output directory')
@@ -26,6 +27,9 @@ parser.add_argument('-t', '--picture-threshold', dest='picture_threshold',
 parser.add_argument('-n', '--number-of-rings', dest='number_of_rings',
                     type=int, default=1,
                     help='Number of rings around picture pixels')
+parser.add_argument('-m', '--write-pixel-masks', action='store_true',
+                    help='Write out the event-wise masks of relevant pixels'
+                    )
 
 class PixelMask(Container):
     event_id = Field(-1, 'event id')
@@ -57,6 +61,12 @@ class RunSummary(Container):
 def main():
     args = parser.parse_args()
     summary_info = RunSummary()
+
+    if (args.write_pixel_masks):
+        print('Option to write pixel masks in output file selected')
+    else:
+        print('Pixel masks will not be written in the output file. Use option '
+              '-m to write them out')
 
     # The pixel selection will be applied only to "physics triggers"
     # (showers), not to other events like interleaved pedestal and flatfield
@@ -91,209 +101,232 @@ def main():
     number_of_rings = args.number_of_rings
     summary_info.number_of_rings = number_of_rings
 
-    dl1_file = args.dl1_file
-    run_info = parse_dl1_filename(dl1_file)
-    run_id, subrun_id = run_info.run, run_info.subrun
-    summary_info.run_id = run_id
-    summary_info.subrun_id = subrun_id
+    dl1_files = glob.glob(args.dl1_files)
+    dl1_files.sort()
+    current_run_number = -1
 
-    output_dir = args.output_dir.absolute()
-    output_dir.mkdir(exist_ok=True, parents=True)
-    output_file = Path(output_dir, f'Pixel_selection_LST-1.Run{run_id:05d}.'
-                                   f'{subrun_id:04d}.h5')
-    print('Output file: ', output_file)
+    for dl1_file in dl1_files:
+        print()
+        print('Input file:', dl1_file)
 
-    data_parameters = read_table(dl1_file,
-                                 "/dl1/event/telescope/parameters/LST_LSTCam")
+        run_info = parse_dl1_filename(dl1_file)
+        run_id, subrun_id = run_info.run, run_info.subrun
+        summary_info.run_id = run_id
+        summary_info.subrun_id = subrun_id
 
-    # Read some useful extra info from the file:
-    subarray_info = SubarrayDescription.from_hdf(dl1_file)
-    focal_length = subarray_info.tel[1].optics.equivalent_focal_length
-    print('Focal length:', focal_length)
-    camera_geom = subarray_info.tel[1].camera.geometry
-    print('Camera geometry:', camera_geom)
+        output_dir = args.output_dir.absolute()
+        output_dir.mkdir(exist_ok=True, parents=True)
 
-    # Time between first and last timestamp:
-    summary_info.elapsed_time = (data_parameters['dragon_time'][-1] -
-                                 data_parameters['dragon_time'][0])
+        output_file = Path(output_dir, f'DVR_settings_LST-1.Run{run_id:05d}.h5')
 
-    summary_info.mean_zenith = np.round(90 - np.rad2deg(data_parameters['alt_tel'].mean()), 2)
+        # For writing the pixels masks we will create subrun-wise files:
+        if args.write_pixel_masks:
+            output_file = Path(output_dir, f'Pixel_selection_LST-1.Run'
+                                           f'{run_id:05d}.{subrun_id:04d}.h5')
 
-    number_of_events = len(data_parameters)
-    summary_info.number_of_events = number_of_events
+        print('Output file:', output_file)
 
-    event_type_data = data_parameters['event_type']
-    # event_type: physics trigger (32) interleaved flat-field(0) pedestal (2),
-    # unknown(255)  are those currently in use in LST1
+        data_parameters = read_table(dl1_file,
+                                     '/dl1/event/telescope/parameters/LST_LSTCam')
 
-    cosmic_mask   = event_type_data == EventType.SUBARRAY.value  # showers
-    pedestal_mask = event_type_data == EventType.SKY_PEDESTAL.value
+        # Read some useful extra info from the file:
+        subarray_info = SubarrayDescription.from_hdf(dl1_file)
+        focal_length = subarray_info.tel[1].optics.equivalent_focal_length
+        print('Focal length:', focal_length)
+        camera_geom = subarray_info.tel[1].camera.geometry
+        print('Camera geometry:', camera_geom)
 
-    data_images = read_table(dl1_file, "/dl1/event/telescope/image/LST_LSTCam")
+        # Time between first and last timestamp:
+        summary_info.elapsed_time = (data_parameters['dragon_time'][-1] -
+                                     data_parameters['dragon_time'][0])
 
-    data_calib = read_table(dl1_file, "/dl1/event/telescope/monitoring/calibration")
-    # data_calib['unusable_pixels'] , indices: (Gain  Calib_id  Pixel)
+        summary_info.mean_zenith = np.round(90 -
+                                            np.rad2deg(data_parameters['alt_tel'].mean()), 2)
 
-    # Get the "unusable" flags from the pedcal file:
-    unusable_HG = data_calib['unusable_pixels'][0][0]
-    unusable_LG = data_calib['unusable_pixels'][0][1]
+        number_of_events = len(data_parameters)
+        summary_info.number_of_events = number_of_events
 
-    #  Keep pixels that could not be properly calibrated: save them always,
-    #  in case their calibration can be later fixed:
-    keep_always_mask = (unusable_HG | unusable_LG)
-    summary_info.number_of_always_saved_pixels = keep_always_mask.sum()
+        event_type_data = data_parameters['event_type']
+        # event_type: physics trigger (32) interleaved flat-field(0) pedestal (2),
+        # unknown(255)  are those currently in use in LST1
 
-    if summary_info.number_of_always_saved_pixels > 0:
-        print(f'Pixels that will always be saved ({summary_info.number_of_always_saved_pixels}):')
-        for pixindex in np.where(keep_always_mask)[0]:
-            print(pixindex)
-    else:
-        print('Pixels that will always be saved: None')
+        cosmic_mask   = event_type_data == EventType.SUBARRAY.value  # showers
+        pedestal_mask = event_type_data == EventType.SKY_PEDESTAL.value
 
-    charges_data = data_images['image']
-    # times_data = data_images['peak_time'] # not used now
-    image_mask = data_images['image_mask']
+        data_images = read_table(dl1_file, "/dl1/event/telescope/image/LST_LSTCam")
 
-    print("Original standard cleaning, pixel survival probabilities:")
-    print('  Minimum: ', np.round(np.mean(image_mask, axis=0).min(), 5))
-    print('  Maximum: ', np.round(np.mean(image_mask, axis=0).max(), 5))
-    print('  Mean: ', np.round(np.mean(image_mask, axis=0).mean(), 5))
+        data_calib = read_table(dl1_file, "/dl1/event/telescope/monitoring/calibration")
+        # data_calib['unusable_pixels'] , indices: (Gain  Calib_id  Pixel)
 
-    # Check what fraction of pixels in shower events is kept with the current
-    # value of min_charge_for_certain_selection (and ONE ring of neighbors)
-    # We compute the value excluding the noisiest pixels (e.g. from stars)
-    fraction_of_survival = 1.
-    target_nevents = 5000 # number of events for the calculation (to speed up!)
-    charges_cosmics = charges_data[cosmic_mask]
-    event_jump = int(charges_cosmics.shape[0] / target_nevents) + 1
-    charges_cosmics_sampled = charges_cosmics[::event_jump, :]
+        # Get the "unusable" flags from the pedcal file:
+        unusable_HG = data_calib['unusable_pixels'][0][0]
+        unusable_LG = data_calib['unusable_pixels'][0][1]
 
-    while fraction_of_survival > max_pix_survival_fraction:
-        selected_pixels_masks = []
-        for charge_map in charges_cosmics_sampled:
-            selected_pixels = get_selected_pixels(charge_map,
-                                                  min_charge_for_certain_selection,
-                                                  1, camera_geom)
-            selected_pixels_masks.append(selected_pixels)
+        #  Keep pixels that could not be properly calibrated: save them always,
+        #  in case their calibration can be later fixed:
+        keep_always_mask = (unusable_HG | unusable_LG)
+        summary_info.number_of_always_saved_pixels = keep_always_mask.sum()
 
-        selected_pixels_masks = np.array(selected_pixels_masks)
-        per_pix_fraction_of_survival = (np.sum(selected_pixels_masks, axis=0) /
-                                        selected_pixels_masks.shape[0])
-        ninety_percent_dimmest = np.sort(per_pix_fraction_of_survival)[:int(
-                0.9*len(per_pix_fraction_of_survival))]
+        if summary_info.number_of_always_saved_pixels > 0:
+            print(f'Pixels that will always be saved ('
+                  f'{summary_info.number_of_always_saved_pixels}):')
+            for pixindex in np.where(keep_always_mask)[0]:
+                print(pixindex)
+        else:
+            print('Pixels that will always be saved: None')
 
-        # Compute the survival fraction using only the 90% dimmer pixels - we
-        # do not want to change the thresholds just because of stars,
-        # but rather based on the "bulk" of the diffuse NSB
-        fraction_of_survival = np.mean(ninety_percent_dimmest)
-        if fraction_of_survival <= max_pix_survival_fraction:
-            break
+        charges_data = data_images['image']
+        # times_data = data_images['peak_time'] # not used now
+        image_mask = data_images['image_mask']
 
+        print("Original standard cleaning, pixel survival probabilities:")
+        print('  Minimum: ', np.round(np.mean(image_mask, axis=0).min(), 5))
+        print('  Maximum: ', np.round(np.mean(image_mask, axis=0).max(), 5))
+        print('  Mean: ', np.round(np.mean(image_mask, axis=0).mean(), 5))
+
+        # Check what fraction of pixels in shower events is kept with the current
+        # value of min_charge_for_certain_selection (and ONE ring of neighbors)
+        # We compute the value excluding the noisiest pixels (e.g. from stars)
+        fraction_of_survival = 1.
+        target_nevents = 5000 # number of events for the calculation (to speed up!)
+        charges_cosmics = charges_data[cosmic_mask]
+        event_jump = int(charges_cosmics.shape[0] / target_nevents) + 1
+        charges_cosmics_sampled = charges_cosmics[::event_jump, :]
+
+        while fraction_of_survival > max_pix_survival_fraction:
+            selected_pixels_masks = []
+            for charge_map in charges_cosmics_sampled:
+                selected_pixels = get_selected_pixels(charge_map,
+                                                      min_charge_for_certain_selection,
+                                                      1, camera_geom)
+                selected_pixels_masks.append(selected_pixels)
+
+            selected_pixels_masks = np.array(selected_pixels_masks)
+            per_pix_fraction_of_survival = (np.sum(selected_pixels_masks, axis=0) /
+                                            selected_pixels_masks.shape[0])
+            ninety_percent_dimmest = np.sort(per_pix_fraction_of_survival)[:int(
+                    0.9*len(per_pix_fraction_of_survival))]
+
+            # Compute the survival fraction using only the 90% dimmer pixels
+            # - we do not want to change the thresholds just because of stars,
+            # but rather based on the "bulk" of the diffuse NSB
+            fraction_of_survival = np.mean(ninety_percent_dimmest)
+            if fraction_of_survival <= max_pix_survival_fraction:
+                break
+
+            print("Fraction in shower events of pixels with >",
+                  min_charge_for_certain_selection, "pe & first neighbors:",
+                  np.round(fraction_of_survival, 3), "is higher than maximum "
+                                                     "allowed:",
+                  max_pix_survival_fraction)
+            # Modify the value of min_charge_for_certain_selection to get a lower
+            # survival fraction
+            min_charge_for_certain_selection += 1.
+
+        if min_charge_for_certain_selection > args.picture_threshold:
+            print("min_charge_for_certain_selection changed to",
+                  min_charge_for_certain_selection)
         print("Fraction in shower events of pixels with >",
               min_charge_for_certain_selection, "pe & first neighbors:",
-              np.round(fraction_of_survival, 3), "is higher than maximum "
-                                                 "allowed:",
-              max_pix_survival_fraction)
-        # Modify the value of min_charge_for_certain_selection to get a lower
-        # survival fraction
-        min_charge_for_certain_selection += 1.
+              np.round(fraction_of_survival, 3)),
 
-    if min_charge_for_certain_selection > args.picture_threshold:
-        print("min_charge_for_certain_selection changed to",
-              min_charge_for_certain_selection)
-    print("Fraction in shower events of pixels with >",
-          min_charge_for_certain_selection, "pe & first neighbors:",
-          np.round(fraction_of_survival, 3)),
+        summary_info.min_charge_for_certain_selection = min_charge_for_certain_selection
 
-    summary_info.min_charge_for_certain_selection = min_charge_for_certain_selection
+        # Cuts to identify promising muon ring candidates:
+        mucan_event_list = np.where(cosmic_mask &
+                                    (data_parameters['intensity']>1000) &
+                                    (data_parameters['length']>0.5) &
+                                    (data_parameters['n_pixels']>50) &
+                                    (abs(data_parameters['time_gradient'])<5))[0]
 
-    # Cuts to identify promising muon ring candidates:
-    mucan_event_list = np.where(cosmic_mask &
-                                (data_parameters['intensity']>1000) &
-                                (data_parameters['length']>0.5) &
-                                (data_parameters['n_pixels']>50) &
-                                (abs(data_parameters['time_gradient'])<5))[0]
+        mucan_event_id_list = np.array(data_parameters['event_id'][mucan_event_list])
+        summary_info.number_of_muon_candidates = len(mucan_event_list)
 
-    mucan_event_id_list = np.array(data_parameters['event_id'][mucan_event_list])
-    summary_info.number_of_muon_candidates = len(mucan_event_list)
+        num_sel_pixels = []
+        selected_pixels_masks = []
+        event_ids = []
+        highest_removed_charge = []
 
-    num_sel_pixels = []
-    selected_pixels_masks = []
-    event_ids = []
-    highest_removed_charge = []
+        full_camera = np.array(camera_geom.n_pixels*[True])
 
-    full_camera = np.array(camera_geom.n_pixels*[True])
+        for charge_map, event_id, event_type in zip(charges_data,
+                                                    data_parameters['event_id'],
+                                                    event_type_data):
+            # keep full camera for muon candidates:
+            if event_id in mucan_event_id_list:
+                selected_pixels = full_camera
+            elif event_type not in event_types_to_be_reduced:
+                selected_pixels = full_camera
+            else:
+                selected_pixels = get_selected_pixels(charge_map,
+                                                      min_charge_for_certain_selection,
+                                                      number_of_rings,
+                                                      camera_geom)
 
-    for charge_map, event_id, event_type in zip(charges_data,
-                                                data_parameters['event_id'],
-                                                event_type_data):
-        # keep full camera for muon candidates:
-        if event_id in mucan_event_id_list:
-            selected_pixels = full_camera
-        elif event_type not in event_types_to_be_reduced:
-            selected_pixels = full_camera
-        else:
-            selected_pixels = get_selected_pixels(charge_map,
-                                                  min_charge_for_certain_selection,
-                                                  number_of_rings,
-                                                  camera_geom)
-
-        # Include pixels that must be kept for all events:
-        selected_pixels |= keep_always_mask
+            # Include pixels that must be kept for all events:
+            selected_pixels |= keep_always_mask
     
-        num_sel_pixels.append(selected_pixels.sum())
-        selected_pixels_masks.append(selected_pixels)
+            num_sel_pixels.append(selected_pixels.sum())
+            selected_pixels_masks.append(selected_pixels)
     
-        event_ids.append(event_id)
-        if selected_pixels.sum() < camera_geom.n_pixels:
-            highest_removed_charge.append(np.nanmax(charge_map[~selected_pixels]))
-        else:
-            highest_removed_charge.append(0.)
+            event_ids.append(event_id)
+            if selected_pixels.sum() < camera_geom.n_pixels:
+                highest_removed_charge.append(np.nanmax(charge_map[~selected_pixels]))
+            else:
+                highest_removed_charge.append(0.)
 
-    selected_pixels_masks = np.array(selected_pixels_masks)
+        selected_pixels_masks = np.array(selected_pixels_masks)
 
-    cr_masks = selected_pixels_masks[cosmic_mask]
-    fraction_of_survival = cr_masks.sum() / len(cr_masks.flatten())
-    print("Fraction in shower events of selected pixels:", np.round(
-            fraction_of_survival, 3))
+        cr_masks = selected_pixels_masks[cosmic_mask]
+        fraction_of_survival = cr_masks.sum() / len(cr_masks.flatten())
+        print("Fraction in shower events of selected pixels:", np.round(
+                fraction_of_survival, 3))
 
-    num_sel_pixels = np.array(num_sel_pixels)
-    print('Average number of selected pixels per event (of any type):',
-          np.round(num_sel_pixels.sum() / len(data_parameters), 2))
-    print(f'Fraction of whole camera: '
-          f'{num_sel_pixels.sum()/len(data_parameters)/camera_geom.n_pixels:.3f}')
+        num_sel_pixels = np.array(num_sel_pixels)
+        print('Average number of selected pixels per event (of any type):',
+        np.round(num_sel_pixels.sum() / len(data_parameters), 2))
+        print(f'Fraction of whole camera: '
+              f'{num_sel_pixels.sum()/len(data_parameters)/camera_geom.n_pixels:.3f}')
 
+        # Keep track of how many cosmic events were fully saved (whole camera)>
+        summary_info.fraction_of_full_shower_events = \
+            np.round((np.sum(selected_pixels_masks[cosmic_mask],
+                             axis=1) == camera_geom.n_pixels).sum() /
+                             cosmic_mask.sum(), 5)
 
-    # Keep track of how many cosmic events were fully saved (whole camera)>
-    summary_info.fraction_of_full_shower_events = \
-        np.round((np.sum(selected_pixels_masks[cosmic_mask],
-                         axis=1) == camera_geom.n_pixels).sum() /
-                         cosmic_mask.sum(), 5)
+        summary_info.ped_mean = np.round(np.mean(charges_data[pedestal_mask]),3)
+        summary_info.ped_stdev = np.round(np.std(charges_data[pedestal_mask]), 3)
 
-    summary_info.ped_mean = np.round(np.mean(charges_data[pedestal_mask]),3)
-    summary_info.ped_stdev = np.round(np.std(charges_data[pedestal_mask]), 3)
+        pixel_survival_fraction = np.mean(selected_pixels_masks, axis=0)
+        summary_info.min_pixel_survival_fraction = np.round(np.min(pixel_survival_fraction), 5)
+        summary_info.max_pixel_survival_fraction = np.round(np.max(pixel_survival_fraction), 5)
+        summary_info.mean_pixel_survival_fraction = np.round(np.mean(pixel_survival_fraction), 5)
 
-    pixel_survival_fraction = np.mean(selected_pixels_masks, axis=0)
-    summary_info.min_pixel_survival_fraction = np.round(np.min(pixel_survival_fraction), 5)
-    summary_info.max_pixel_survival_fraction = np.round(np.max(pixel_survival_fraction), 5)
-    summary_info.mean_pixel_survival_fraction = np.round(np.mean(pixel_survival_fraction), 5)
+        writer_conf = tables.Filters(complevel=9, fletcher32=True)
 
-    data = PixelMask()
-    writer_conf = tables.Filters(complevel=9, fletcher32=True)
-    with HDF5TableWriter(output_file, filters=writer_conf) as writer:
-        for evid, evtype, std_clean_npixels, highestQ, pixmask in zip(
-                event_ids, event_type_data, data_parameters['n_pixels'],
-                highest_removed_charge, selected_pixels_masks):
-            data.event_id = evid
-            data.event_type = evtype
-            data.number_of_pixels_after_standard_cleaning = std_clean_npixels
-            data.highest_removed_charge = highestQ
-            data.pixmask = pixmask
-            writer.write("selected_pixels_masks", data)
+        # In the "DVR settings determination mode" (not writing pixel masks)
+        # we will write only one file per run number
+        filemode = 'a'
+        if run_id != current_run_number:
+            filemode = 'w'
+            current_run_number = run_id
 
-    with HDF5TableWriter(output_file, filters=writer_conf, mode='a') as writer:
-        writer.write("run_summary", summary_info)
+        with HDF5TableWriter(output_file, filters=writer_conf,
+                             mode=filemode) as writer:
+            writer.write("run_summary", summary_info)
 
+        if args.write_pixel_masks:
+            data = PixelMask()
+            with HDF5TableWriter(output_file, filters=writer_conf, mode='a') as writer:
+                for evid, evtype, std_clean_npixels, highestQ, pixmask in zip(
+                        event_ids, event_type_data, data_parameters['n_pixels'],
+                        highest_removed_charge, selected_pixels_masks):
+                    data.event_id = evid
+                    data.event_type = evtype
+                    data.number_of_pixels_after_standard_cleaning = std_clean_npixels
+                    data.highest_removed_charge = highestQ
+                    data.pixmask = pixmask
+                    writer.write("selected_pixels_masks", data)
 
 
 def get_selected_pixels(charge_map, min_charge_for_certain_selection,

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -145,18 +145,30 @@ def main():
     # labeled as "unknown" are cosmics (=showers), so we include them among the
     # types to be reduced.
 
-    # For the record, keep the input "picture threshold". It is not necessarily
-    # the value that will be used for pixel selection, if it allows too many
-    # pixels to survive (see below)
+    # For the record, keep the input "picture threshold".
+    # Note that it is the value that will be used for the pixel selection
+    # algorithm, ONLY IF it results in an average fraction of surviving
+    # pixels (see below) smaller than max_pix_survival_fraction, defined below.
+    # If it allows a larger fraction of pixels to survive.
     summary_info.picture_threshold = args.picture_threshold
 
-    # The threshold charge for pixel selection will be modified, if a too
-    # high average fraction (> max_pix_survival_fraction) of pixels (and FIRST
-    # neighbors) survive, in shower events, with that picture threshold. The
-    # value is computed excluding the 10% noisiest pixels in the camera,
-    # because we want it to be stable when e.g. stars get in and out of the
-    # camera, or when changing wobbles (star field changes)
+    # The threshold charge for pixel selection, called
+    # min_charge_for_certain_selection is equal to args.picture_threshold by
+    # default, but it will be modified, if a too high average fraction
+    # (> max_pix_survival_fraction) of pixels (and FIRST neighbors) survive,
+    # in shower events, with that picture threshold (this is to adapt the
+    # selection to higher NSB levels). The survival fraction is computed
+    # excluding the 10% noisiest pixels in the camera, because we want it to
+    # be stable when e.g. stars get in and out of the camera, or when
+    # changing wobbles (star field changes).
     max_pix_survival_fraction = 0.1
+    # Note that in this calculation of survival fraction we use one ring,
+    # no matter what the value of args.number_of_rings (see below) is. This
+    # is because we want the pixels saved using args.number_of_rings=N
+    # to be a superset of those saved when using N-1 rings (otherwise the
+    # "adding one ring" operation becomes a complicated and hard to interpret
+    # one!)
+
 
     # Number of "rings" of pixels to be finally kept around pixels which are
     # above min_charge_for_certain_selection

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -17,7 +17,7 @@ parser.add_argument('-f', '--dl1-file', dest='dl1_file',
                     type=Path,
                     help='Input DL1 file name')
 parser.add_argument('-o', '--output-dir', dest='output_dir',
-                    type=Path, default=Path('./'),
+                    type=Path, default='./',
                     help='Path to the output directory')
 parser.add_argument('-t', '--picture-threshold', dest='picture_threshold',
                     type=float, default=8.,
@@ -80,10 +80,9 @@ def main():
     summary_info.run_id = run_id
     summary_info.subrun_id = subrun_id
 
-
     output_dir = args.output_dir.absolute()
     output_dir.mkdir(exist_ok=True, parents=True)
-    output_file = Path(output_dir, f'/Pixel_selection_LST-1.Run{run_id:d}.'
+    output_file = Path(output_dir, f'Pixel_selection_LST-1.Run{run_id:d}.'
                                    f'{subrun_id:04d}.h5')
     print('Output file: ', output_file)
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -179,7 +179,7 @@ def main():
 
             if not os.path.isfile(input_dvr_settings_file):
                 print('ERROR: option --write-pixel-masks selected, but file ' +
-                      input_dvr_settings_file + 'does not exist!')
+                      input_dvr_settings_file.name + 'does not exist!')
                 print('You must run first this script over all the subruns of '
                       'the run in one go, and without the --write-pixel-masks '
                       'option.')

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -79,9 +79,6 @@ def main():
     # labeled as "unknown" are cosmics (=showers), so we include them among the
     # types to be reduced.
 
-    # By default use the provided picture threshold to keep pixels:
-    min_charge_for_certain_selection = args.picture_threshold
-
     # For the record, keep the input "picture threshold". It is not necessarily
     # the value that will be used for pixel selection, if it allows too many
     # pixels too survive.
@@ -108,6 +105,9 @@ def main():
     for dl1_file in dl1_files:
         print()
         print('Input file:', dl1_file)
+
+        # By default use the provided picture threshold to keep pixels:
+        min_charge_for_certain_selection = args.picture_threshold
 
         run_info = parse_dl1_filename(dl1_file)
         run_id, subrun_id = run_info.run, run_info.subrun
@@ -146,9 +146,15 @@ def main():
         number_of_events = len(data_parameters)
         summary_info.number_of_events = number_of_events
 
-        event_type_data = data_parameters['event_type']
+        event_type_data = data_parameters['event_type'].data
         # event_type: physics trigger (32) interleaved flat-field(0) pedestal (2),
         # unknown(255)  are those currently in use in LST1
+
+        found_event_types = np.unique(event_type_data)
+        print('Event types found:', found_event_types)
+        if EventType.SUBARRAY.value not in found_event_types:
+            print('No shower event (SUBARRAY type) found in file! SKIPPING IT!')
+            continue
 
         cosmic_mask   = event_type_data == EventType.SUBARRAY.value  # showers
         pedestal_mask = event_type_data == EventType.SKY_PEDESTAL.value

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -330,17 +330,16 @@ def get_selected_pixels(charge_map, min_charge_for_certain_selection,
     if event_type not in event_types_to_be_reduced:
         return selected_pixels
 
-    # Now proceed with the identification of interesting pixels to be saved
-    selected_pixels = np.array(geom.n_pixels * [False])
-
+    # Now proceed with the identification of interesting pixels to be saved.
     # Keep pixels that have a charge above min_charge_for_certain_selection:
-    selected_pixels |= (charge_map > min_charge_for_certain_selection)
+    selected_pixels = (charge_map > min_charge_for_certain_selection)
 
     # Add "number_of_rings" rings of pixels around the already selected ones:
     for ring in range(number_of_rings):
-        additional_pixels = np.array(geom.n_pixels * [False])
-        for pix in geom.pix_id[selected_pixels]:
-            additional_pixels |= geom.neighbor_matrix[pix]
+        # we add-up (sum) the selected-pixel-wise map of neighbors, to find
+        # those who appear at least once (>0). Those should be added:
+        additional_pixels = (np.sum(geom.neighbor_matrix[selected_pixels],
+                                    axis=0)>0)
         selected_pixels |= additional_pixels
 
     # if more than min_npixels_for_full_event were selected, keep whole camera:

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -257,7 +257,8 @@ def main():
     summary_info.mean_pixel_survival_fraction = np.round(np.mean(pixel_survival_fraction), 5)
 
     data = PixelMask()
-    writer_conf = tables.Filters(complevel=5, complib='blosc:zstd', fletcher32=True)
+#    writer_conf = tables.Filters(complevel=5, complib='blosc:zstd', fletcher32=True)
+    writer_conf = tables.Filters(complevel=9, fletcher32=True)
     with HDF5TableWriter(output_file, filters=writer_conf) as writer:
         for evid, evtype, std_clean_npixels, highestQ, pixmask in zip(
                 event_ids, event_type_data, data_parameters['n_pixels'],

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -222,10 +222,7 @@ def main():
 
         # Read some useful extra info from the file:
         subarray_info = SubarrayDescription.from_hdf(dl1_file)
-        focal_length = subarray_info.tel[1].optics.equivalent_focal_length
-        print('Focal length:', focal_length)
         camera_geom = subarray_info.tel[1].camera.geometry
-        print('Camera geometry:', camera_geom)
 
         # Time between first and last timestamp:
         summary_info.elapsed_time = (data_parameters['dragon_time'][-1] -

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python
+
+import argparse
+from pathlib import Path
+import tables
+import numpy as np
+
+from lstchain.paths import parse_dl1_filename
+from ctapipe.instrument import SubarrayDescription
+from ctapipe.io import read_table
+from ctapipe.core import Container, Field
+from ctapipe.io import HDF5TableWriter
+
+parser = argparse.ArgumentParser(description="DVR pixel selector")
+
+parser.add_argument('-f', '--dl1-file', dest='dl1_file',
+                    type=Path,
+                    help='Input DL1 file name')
+parser.add_argument('-o', '--output-dir', dest='output_dir',
+                    type=Path, default='./',
+                    help='Path to the output directory')
+parser.add_argument('-t', '--picture-threshold', dest='picture_threshold',
+                    type=float, default=8.,
+                    help='Picture threshold (p.e.)')
+parser.add_argument('-n', '--number-of-rings', dest='number_of_rings',
+                    type=int, default=1,
+                    help='Number of rings around picture pixels')
+
+class PixelMask(Container):
+    event_id = Field(-1, 'event id')
+    event_type = Field(-1, 'event_type')
+    number_of_pixels_after_standard_cleaning = Field(-1, 'number_of_pixels_after_standard_cleaning')
+    highest_removed_charge = Field(np.float32(0.), 'highest_removed_charge')
+    pixmask = Field(None, 'selected pixels mask')
+    
+class RunSummary(Container):
+    run_id = Field(-1, 'run_id')
+    subrun_id = Field(-1, 'subrun_id')
+    elapsed_time = Field(-1, 'elapsed_time') # seconds
+    mean_zenith = Field(-1, 'mean_zenith') # degrees
+    number_of_events = Field(-1, 'number_of_events')
+    picture_threshold = Field(-1, 'picture_threshold') # photo-electrons
+    min_charge_for_certain_selection = Field(-1, 'min_charge_for_certain_selection') # photo-electrons
+    number_of_rings = Field(-1, 'number_of_rings')
+    number_of_muon_candidates = Field(-1, 'number_of_muon_candidates')
+    min_pixel_survival_fraction = Field(np.float32(np.nan), 'min_pixel_survival_fraction')
+    max_pixel_survival_fraction = Field(np.float32(np.nan), 'max_pixel_survival_fraction')
+    mean_pixel_survival_fraction = Field(np.float32(np.nan), 'mean_pixel_survival_fraction')
+    fraction_of_full_CR_events = Field(np.float32(np.nan), 'fraction_of_full_CR_events')
+    number_of_always_saved_pixels = Field(0, 'number_of_always_saved_pixels')
+    ped_mean = Field(np.float32(np.nan), '')  # photo-electrons
+    ped_stdev = Field(np.float32(np.nan), '') # photo-electrons
+    
+
+def main():
+    args = parser.parse_args()
+
+    summary_info = RunSummary()
+
+    # By default use the provided picture threshold to keep pixels:
+    min_charge_for_certain_selection = args.picture_threshold
+    # Value will be modified, if a too high average fraction (
+    # > max_survival_fraction) of pixels survive
+    # with that cut
+    max_survival_fraction = 0.15
+    # The new value will be the charge above which a fraction ped_cut_fraction
+    # of pedestal charges lie. This will be computed using the 90% of pixels
+    # with lower mean pedestal (to avoid pixels illuminated by bright stars to
+    # dominate the calculation)
+    ped_cut_fraction = 0.001
+
+    # Number of "rings" of pixels to be kept around pixels which are above
+    # min_charge_for_certain_selection
+    number_of_rings = args.number_of_rings
+    summary_info.number_of_rings = number_of_rings
+
+    dl1_file = args.dl1_file
+    run_info = parse_dl1_filename(dl1_file)
+    run_id, subrun_id = run_info.run, run_info.subrun
+    summary_info.run_id = run_id
+    summary_info.subrun_id = subrun_id
+
+    output_dir = args.output_dir
+    output_file = output_dir + f'/Pixel_selection_LST-1.Run{run_id:d}.{subrun_id:04d}.h5'
+    print('Output file: ', output_file)
+
+    data_parameters = read_table(dl1_file,
+                                 "/dl1/event/telescope/parameters/LST_LSTCam")
+
+    # Read some useful extra info from the file:
+    subarray_info = SubarrayDescription.from_hdf(dl1_file)
+    focal_length = subarray_info.tel[1].optics.equivalent_focal_length
+    print('Focal length:', focal_length)
+    camera_geom = subarray_info.tel[1].camera.geometry
+    print('Camera geometry:', camera_geom)
+
+    # Time between first and last timestamp:
+    summary_info.elapsed_time = (data_parameters['dragon_time'][-1] -
+                                 data_parameters['dragon_time'][0])
+
+    summary_info.mean_zenith = np.round(90 - np.rad2deg(data_parameters['alt_tel'].mean()), 2)
+
+    number_of_events = len(data_parameters)
+    summary_info.number_of_events = number_of_events
+
+    event_type_data = data_parameters['event_type']
+    data_images = read_table(dl1_file, "/dl1/event/telescope/image/LST_LSTCam")
+
+    data_calib = read_table(dl1_file, "/dl1/event/telescope/monitoring/calibration")
+    # data_calib['unusable_pixels'] , indices: (Gain  Calib_id  Pixel)
+
+    # Get the "unusable" flags from the pedcal file:
+    unusable_HG = data_calib['unusable_pixels'][0][0]
+    unusable_LG = data_calib['unusable_pixels'][0][1]
+
+    #  Keep pixels that could not be properly calibrated: save them always,
+    #  in case their calibration can be later fixed:
+    keep_always_mask = (unusable_HG | unusable_LG)
+    summary_info.number_of_always_saved_pixels = keep_always_mask.sum()
+
+    if summary_info.number_of_always_saved_pixels > 0:
+        print(f'Pixels that will always be saved ({summary_info.number_of_always_saved_pixels}):')
+        for pixindex in np.where(keep_always_mask)[0]:
+            print(pixindex)
+    else:
+        print('Pixels that will always be saved: None')
+
+    charges_data = data_images['image']
+    # times_data = data_images['peak_time'] # not used now
+    image_mask = data_images['image_mask']
+
+    print("Original standard cleaning, pixel survival probabilities:")
+    print('  Minimum: ', np.mean(image_mask, axis=0).min())
+    print('  Maximum: ', np.mean(image_mask, axis=0).max())
+    print('  Mean: ', np.mean(image_mask, axis=0).mean())
+
+    # NOTE: for files which have no interleaved pedestals or which have too few
+    # because it is the last subrun in a run, we may have trouble...
+
+    ped_mean = np.nanmean(charges_data[event_type_data==2], axis=0)
+    # Exclude 10% of brightest pixels (to avoid influence of stars, here we want
+    # to estimate the "~diffuse" NSB, or "average in the bulk of the pixels, not
+    # including bright stars")
+    ninety_percent_dimmest_pixels = np.argsort(ped_mean)[:-int(len(ped_mean)*0.1)]
+    # pedestal charges for those 90% of the pixels:
+    pq = charges_data[event_type_data==2][:,ninety_percent_dimmest_pixels].flatten()
+    # Cut that keeps a given fraction (pedcutfraction) of the pedestal charges:
+
+    charge_per_mil_pedestal = np.sort(pq)[-int(ped_cut_fraction*len(pq))]
+    charge_per_mil_pedestal = np.round(charge_per_mil_pedestal)
+    # We round it to an integer number of photo-electrons. We want to avoid too
+    # many different ways of reducing the data. This is also why we use the
+    # fixed value picture_threshold unless it results in a too high survival
+    # rate
+
+    selected_pixels_masks = []
+    # Check what fraction of cosmics is kept with the current value of
+    # min_charge_for_certain_selection
+
+    for event_index in range(len(charges_data)):
+        if event_type_data[event_index] != 32:
+            continue # skip interleaved events
+        charge_map = charges_data[event_index]
+        selected_pixels = get_selected_pixels(charge_map,
+                                              min_charge_for_certain_selection,
+                                              number_of_rings, camera_geom,
+                                              data_parameters['event_type'][event_index])
+        selected_pixels_masks.append(selected_pixels)
+    selected_pixels_masks = np.array(selected_pixels_masks)
+
+    fraction_of_survival = (selected_pixels_masks.sum() /
+                            len(selected_pixels_masks.flatten()))
+
+    if fraction_of_survival > max_survival_fraction:
+        print("Fraction in CRs of pixels with >",
+              min_charge_for_certain_selection, "pe & neighbors:",
+              fraction_of_survival, "higher than maximum allowed:",
+              max_survival_fraction)
+        # Modify the value of min_charge_for_certain_selection to get a lower
+        # survival fraction
+        min_charge_for_certain_selection = charge_per_mil_pedestal
+        print("min_charge_for_certain_selection changed to",
+              min_charge_for_certain_selection)
+
+    summary_info.min_charge_for_certain_selection = min_charge_for_certain_selection
+
+    # Cuts to identify promising muon ring candidates:
+    mucan_event_list = np.where((event_type_data==32) &
+                                (data_parameters['intensity']>1000) &
+                                (data_parameters['length']>0.5) &
+                                (data_parameters['n_pixels']>50) &
+                                (abs(data_parameters['time_gradient'])<5))[0]
+
+    mucan_event_id_list = np.array(data_parameters['event_id'][mucan_event_list])
+    summary_info.number_of_muon_candidates = len(mucan_event_list)
+
+    num_sel_pixels = []
+    selected_pixels_masks = []
+    event_ids = []
+    highest_removed_charge = []
+
+    full_camera = np.array(camera_geom.n_pixels*[True])
+
+    for event_index in range(len(charges_data)):
+        # keep full camera for muon candidates:
+        if data_parameters['event_id'][event_index] in mucan_event_id_list:
+            selected_pixels = full_camera
+        else:
+            charge_map = charges_data[event_index]
+            selected_pixels = get_selected_pixels(charge_map,
+                                                  min_charge_for_certain_selection,
+                                                  number_of_rings,
+                                                  camera_geom,
+                                                  data_parameters['event_type'][event_index])
+        # Include pixels that must be kept for all events:
+        selected_pixels |= keep_always_mask
+    
+        num_sel_pixels.append(selected_pixels.sum())
+        selected_pixels_masks.append(selected_pixels)
+    
+        event_ids.append(data_parameters['event_id'][event_index])
+        if selected_pixels.sum() < camera_geom.n_pixels:
+            highest_removed_charge.append(np.nanmax(charge_map[~selected_pixels]))
+        else:
+            highest_removed_charge.append(0.)
+
+    selected_pixels_masks = np.array(selected_pixels_masks)
+    num_sel_pixels = np.array(num_sel_pixels)
+
+    print('selected pixels per event:', num_sel_pixels.sum()/len(data_parameters))
+    print(f'Fraction: '
+          f'{num_sel_pixels.sum()/len(data_parameters)/camera_geom.n_pixels:.3f}')
+
+    cr_masks = selected_pixels_masks[(event_type_data==32)]
+    fraction_of_survival = cr_masks.sum() / len(cr_masks.flatten())
+    print("Fraction in CRs of pixels with >", min_charge_for_certain_selection,
+          "pe & neighbors:", fraction_of_survival)
+
+    # Keep track of how many events were fully saved (whole camera)>
+    summary_info.fraction_of_full_CR_events = \
+        np.round((np.sum(selected_pixels_masks[(data_parameters['event_type']==32)],
+                         axis=1) ==  camera_geom.n_pixels).sum() /
+                         (data_parameters['event_type']==32).sum(), 5)
+
+    summary_info.ped_mean = np.round(np.mean(charges_data[(data_parameters['event_type']==2)]), 3)
+    summary_info.ped_stdev = np.round(np.std(charges_data[(data_parameters['event_type']==2)]), 3)
+
+    pixel_survival_fraction = np.mean(selected_pixels_masks, axis=0)
+    summary_info.min_pixel_survival_fraction = np.round(np.min(pixel_survival_fraction), 5)
+    summary_info.max_pixel_survival_fraction = np.round(np.max(pixel_survival_fraction), 5)
+    summary_info.mean_pixel_survival_fraction = np.round(np.mean(pixel_survival_fraction), 5)
+
+    data = PixelMask()
+    writer_conf = tables.Filters(complevel=5, complib='blosc:zstd', fletcher32=True)
+    with HDF5TableWriter(output_file, filters=writer_conf) as writer:
+        for evid, evtype, std_clean_npixels, highestQ, pixmask in zip(
+                event_ids, event_type_data, data_parameters['n_pixels'],
+                highest_removed_charge, selected_pixels_masks):
+            data.event_id = evid
+            data.event_type = evtype
+            data.number_of_pixels_after_standard_cleaning = std_clean_npixels
+            data.highest_removed_charge = highestQ
+            data.pixmask = pixmask
+            writer.write("selected_pixels_masks", data)
+
+    with HDF5TableWriter(output_file, filters=writer_conf, mode='a') as writer:
+        writer.write("run_summary", summary_info)
+
+
+
+def get_selected_pixels(charge_map, min_charge_for_certain_selection,
+                        number_of_rings, geom, event_type,
+                        min_npixels_for_full_event=500):
+    """
+    Function to select the pixels which likely contain a Cherenkov signal
+
+    Parameters
+    ----------
+    charge_map: ndarray, pixel-wise charges in photo-electrons
+
+    min_charge_for_certain_selection: pixels above this charge will be selected
+
+    number_of_rings: number of "rings" of pixels around the pixels selected by
+    their charge that will also be selected (N=1 means just the immediate
+    neighbors; N=2 adds the neighbors of neighbors and so on)
+
+    geom: camera geometry
+
+    event_type: physics trigger (32) interleaved flat-field(0) or pedestal (2)
+
+    min_npixels_for_full_event: full camera will be selected for events with
+    more than this number of pixels passing the standard selection
+
+    Returns
+    -------
+    ndarray (boolean): mask containing the selected pixels
+
+    """
+
+    # Keep all pixels in interleaved pedestal and flatfield events:
+    if event_type != 32:
+        return np.array(geom.n_pixels * [True])
+
+    selected_pixels = np.array(geom.n_pixels * [False])
+
+    # Keep pixels that have a charge above min_charge_for_certain_selection:
+    selected_pixels |= (charge_map > min_charge_for_certain_selection)
+
+    # Add "number_of_rings" rings of pixels around the already selected ones:
+    for ring in range(number_of_rings):
+        additional_pixels = np.array(geom.n_pixels * [False])
+        for pix in geom.pix_id[selected_pixels]:
+            additional_pixels |= geom.neighbor_matrix[pix]
+        selected_pixels |= additional_pixels
+
+    # if more than min_npixels_for_full_event were selected, keep whole camera:
+    if selected_pixels.sum() > min_npixels_for_full_event:
+        selected_pixels = np.array(geom.n_pixels * [True])
+
+    return selected_pixels

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -17,7 +17,7 @@ parser.add_argument('-f', '--dl1-file', dest='dl1_file',
                     type=Path,
                     help='Input DL1 file name')
 parser.add_argument('-o', '--output-dir', dest='output_dir',
-                    type=Path, default='./',
+                    type=Path, default=Path('./'),
                     help='Path to the output directory')
 parser.add_argument('-t', '--picture-threshold', dest='picture_threshold',
                     type=float, default=8.,

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -244,9 +244,8 @@ def main():
 
     cr_masks = selected_pixels_masks[cosmic_mask]
     fraction_of_survival = cr_masks.sum() / len(cr_masks.flatten())
-    print("Fraction in shower events of pixels with >",
-          min_charge_for_certain_selection,
-          "pe & neighbors:", np.round(fraction_of_survival, 3))
+    print("Fraction in shower events of selected pixels:", np.round(
+            fraction_of_survival, 3))
 
     num_sel_pixels = np.array(num_sel_pixels)
     print('Average number of selected pixels per event (of any type):',

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -144,17 +144,16 @@ def main():
 
     # For the record, keep the input "picture threshold". It is not necessarily
     # the value that will be used for pixel selection, if it allows too many
-    # pixels too survive.
+    # pixels to survive (see below)
     summary_info.picture_threshold = args.picture_threshold
 
-    # Value will be modified, if a too high average fraction (
-    # > max_pix_survival_fraction) of pixels (and FIRST neighbors)
-    # survive, in shower events, with that picture threshold. The value is
-    # computed excluding the 10% noisiest pixels in the camera, because we
-    # want it to be stable when e.g. stars get in and out of the camera,
-    # or when changing wobbles (star field changes)
+    # The threshold charge for pixel selection will be modified, if a too
+    # high average fraction (> max_pix_survival_fraction) of pixels (and FIRST
+    # neighbors) survive, in shower events, with that picture threshold. The
+    # value is computed excluding the 10% noisiest pixels in the camera,
+    # because we want it to be stable when e.g. stars get in and out of the
+    # camera, or when changing wobbles (star field changes)
     max_pix_survival_fraction = 0.1
-
 
     # Number of "rings" of pixels to be finally kept around pixels which are
     # above min_charge_for_certain_selection

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -206,7 +206,6 @@ def main():
 
     full_camera = np.array(camera_geom.n_pixels*[True])
 
-    for event_index in range(len(charges_data)):
     for charge_map, event_id, event_type in zip(charges_data,
                                                 data_parameters['event_id'],
                                                 event_type_data):

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -21,8 +21,8 @@ This creates in the output directory (which is the current by default) a file
 DVR_settings_LST-1.Run12469.h5 which contains a table "run_summary" which
 includes the DVR algorithm parameters determined for each subrun.
 
-Then we run again the script, but subrun by subrun, and using the option to
-create the pixel maks:
+Then we run again the script over all subruns, and using the option to create
+the pixel maks:
 
 lstchain_dvr_pixselector -f "/xxx/yyy/dl1_LST-1.Run12469.????.h5" --write-pixel-masks
 
@@ -34,9 +34,9 @@ different ways of reducing the data, so we "discretize" the threshold in
 will be computed and written out to a file
 Pixel_selection_LST-1.Run12469.xxxx.h5  for each subrun xxxx
 
-If the option --write-pixel-masks is used, and there is more than one input
-DL1 file, or the DVR_settings_LST-1.Run*.h5 file is not found, the program
-will stop and show an error message.
+If the option --write-pixel-masks is used, then options --number-of-rings and
+--picture-threshold will be ignored, since the DVR settings will be obtained
+from the DVR_settings file.
 
 """
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -112,10 +112,7 @@ def main():
               'corresponding DVR_settings_*.h5 file')
         print('(the --picture_threshold and --number-of-rings command-line '
               'options, if provided, will be ignored!)')
-        if len(dl1_files) > 1:
-            print('ERROR: option --write-pixel-masks can be used only with '
-                  'a single input DL1 file')
-            exit(1)
+        exit(1)
 
     else:
         print('I will calculate the Data Volume Reduction parameters from '

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -227,16 +227,18 @@ def main():
             highest_removed_charge.append(0.)
 
     selected_pixels_masks = np.array(selected_pixels_masks)
-    num_sel_pixels = np.array(num_sel_pixels)
-
-    print('selected pixels per event:', num_sel_pixels.sum()/len(data_parameters))
-    print(f'Fraction: '
-          f'{num_sel_pixels.sum()/len(data_parameters)/camera_geom.n_pixels:.3f}')
 
     cr_masks = selected_pixels_masks[(event_type_data==32)]
     fraction_of_survival = cr_masks.sum() / len(cr_masks.flatten())
     print("Fraction in CRs of pixels with >", min_charge_for_certain_selection,
           "pe & neighbors:", np.round(fraction_of_survival, 3))
+
+    num_sel_pixels = np.array(num_sel_pixels)
+    print('Average number of selected pixels per event:',
+          np.round(num_sel_pixels.sum() / len(data_parameters), 2))
+    print(f'Fraction: '
+          f'{num_sel_pixels.sum()/len(data_parameters)/camera_geom.n_pixels:.3f}')
+
 
     # Keep track of how many events were fully saved (whole camera)>
     summary_info.fraction_of_full_CR_events = \

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -112,7 +112,6 @@ def main():
               'corresponding DVR_settings_*.h5 file')
         print('(the --picture_threshold and --number-of-rings command-line '
               'options, if provided, will be ignored!)')
-        exit(1)
 
     else:
         print('I will calculate the Data Volume Reduction parameters from '
@@ -184,7 +183,7 @@ def main():
                 print('You must run first this script over all the subruns of '
                       'the run in one go, and without the --write-pixel-masks '
                       'option.')
-                exit(2)
+                exit(1)
 
             dvr_settings = read_table(input_dvr_settings_file, '/run_summary')
             # We just take the values below from the first table row, because by

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -180,12 +180,12 @@ def main():
     # fixed value picture_threshold unless it results in a too high survival
     # rate
 
-    selected_pixels_masks = []
     # Check what fraction of pixels in PEDESTAL events is kept with the current
     # value of min_charge_for_certain_selection (and ONE ring of neighbors)
 
     fraction_of_survival = 1.
     while fraction_of_survival > max_pix_survival_fraction_in_ped:
+        selected_pixels_masks = []
         for charge_map, event_type in zip(charges_data, event_type_data):
             # use only pedestal events:
             if event_type != EventType.SKY_PEDESTAL.value:

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -132,9 +132,9 @@ def main():
     image_mask = data_images['image_mask']
 
     print("Original standard cleaning, pixel survival probabilities:")
-    print('  Minimum: ', np.mean(image_mask, axis=0).min())
-    print('  Maximum: ', np.mean(image_mask, axis=0).max())
-    print('  Mean: ', np.mean(image_mask, axis=0).mean())
+    print('  Minimum: ', np.round(np.mean(image_mask, axis=0).min(), 5))
+    print('  Maximum: ', np.round(np.mean(image_mask, axis=0).max(), 5))
+    print('  Mean: ', np.round(np.mean(image_mask, axis=0).mean(), 5))
 
     # NOTE: for files which have no interleaved pedestals or which have too few
     # because it is the last subrun in a run, we may have trouble...
@@ -176,7 +176,7 @@ def main():
     if fraction_of_survival > max_survival_fraction:
         print("Fraction in CRs of pixels with >",
               min_charge_for_certain_selection, "pe & neighbors:",
-              fraction_of_survival, "higher than maximum allowed:",
+              np.round(fraction_of_survival, 3), "higher than maximum allowed:",
               max_survival_fraction)
         # Modify the value of min_charge_for_certain_selection to get a lower
         # survival fraction
@@ -236,7 +236,7 @@ def main():
     cr_masks = selected_pixels_masks[(event_type_data==32)]
     fraction_of_survival = cr_masks.sum() / len(cr_masks.flatten())
     print("Fraction in CRs of pixels with >", min_charge_for_certain_selection,
-          "pe & neighbors:", fraction_of_survival)
+          "pe & neighbors:", np.round(fraction_of_survival, 3))
 
     # Keep track of how many events were fully saved (whole camera)>
     summary_info.fraction_of_full_CR_events = \

--- a/lstchain/scripts/tests/test_lstchain_scripts.py
+++ b/lstchain/scripts/tests/test_lstchain_scripts.py
@@ -143,6 +143,18 @@ def test_observed_dl1_validity(observed_dl1_files):
     )
     np.testing.assert_allclose(dl1_df["dragon_time"], dl1_df["trigger_time"])
 
+@pytest.mark.private_data
+def test_dvr_file_validity(observed_dl1_files):
+    dvr_file = pd.read_hdf(observed_dl1_files["dvr_file1"], key="run_summary")
+    assert "mean_pixel_survival_fraction" in dvr_file.columns
+    assert dvr_file['number_of_events'].iloc[0] == 200
+    assert dvr_file['mean_pixel_survival_fraction'].iloc[0] < 0.1
+
+@pytest.mark.private_data
+def test_pixmasks_file_validity(observed_dl1_files):
+    pixmasks_file = tables.open_file(observed_dl1_files["pixmasks_file1"])
+    pixmasks = pixmasks_file.root.selected_pixels_masks.col('pixmask')
+    assert pixmasks.sum() < 0.1 * len(pixmasks.flatten())
 
 @pytest.mark.private_data
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This scripts uses DL1 files to identify (event-wise) pixels likely containing a signal, and creates hdf5 files with this information for use in the raw data volume reduction.

~~There are no tests for this script as of now, it requires to have DL1 files with the DL1a images. Are they produced? At the end of the tests the created DL1 files only have DL1b.~~