### PR TITLE
Fix a failing test on DL3 Tool

### DIFF
--- a/lstchain/high_level/interpolate.py
+++ b/lstchain/high_level/interpolate.py
@@ -420,7 +420,7 @@ def interpolate_irf(irfs, data_pars, interp_method="linear"):
 
     # Exclude AZ_PNT as target interpolation parameter
     # For the interpolation parameters only
-    params_sel = [d for d in data_pars.keys() if d != "AZ_PNT"]#[*d.keys()]
+    params_sel = [d for d in data_pars.keys() if d != "AZ_PNT"]
     n_grid = len(irfs)
     irf_pars_sel = np.empty((n_grid, len(params_sel)))
     interp_pars_sel = list()

--- a/lstchain/high_level/interpolate.py
+++ b/lstchain/high_level/interpolate.py
@@ -193,13 +193,9 @@ def get_nearest_az_node(
 
     if irf_num[idx] > 1:
         # Only using the overlapping nodes
-        idx_list = np.flatnonzero(
-            (irf_params_short == irf_params_short[index]).all(1)
-        )
+        idx_list = np.flatnonzero((irf_params_short == irf_params_short[index]).all(1))
         # Finding the shortest distance with respect to target azimuth
-        diff = np.abs(
-            irf_params_full[idx_list, az_idx] - target_params_full[az_idx]
-        )
+        diff = np.abs(irf_params_full[idx_list, az_idx] - target_params_full[az_idx])
         idx = idx_list[np.where(diff == diff.min())[0]][0]
     else:
         # if there are no overlapping nodes

--- a/lstchain/high_level/tests/test_interpolate.py
+++ b/lstchain/high_level/tests/test_interpolate.py
@@ -84,12 +84,8 @@ def test_interp_irf(simulated_irf_file, simulated_dl2_file):
         aeff_1_meta["AZ_PNT"] = (az_2 * 180 / np.pi, "deg")
         aeff_2_meta["B_DELTA"] = (del_2 * 180 / np.pi, "deg")
 
-        aeff_hdu_1 = fits.BinTableHDU(
-            aeff_1, header=aeff_1_meta, name="EFFECTIVE AREA"
-        )
-        aeff_hdu_2 = fits.BinTableHDU(
-            aeff_2, header=aeff_2_meta, name="EFFECTIVE AREA"
-        )
+        aeff_hdu_1 = fits.BinTableHDU(aeff_1, header=aeff_1_meta, name="EFFECTIVE AREA")
+        aeff_hdu_2 = fits.BinTableHDU(aeff_2, header=aeff_2_meta, name="EFFECTIVE AREA")
 
         # Change the energy migration for different angular pointings
         edisp_1 = Table.read(irf, hdu="ENERGY DISPERSION")
@@ -183,7 +179,7 @@ def test_interp_irf(simulated_irf_file, simulated_dl2_file):
     data_pars = {
         "ZEN_PNT": 30 * u.deg,
         "B_DELTA": (del_1 * 0.8 * u.rad).to(u.deg),
-        "AZ_PNT": 120 * u.deg
+        "AZ_PNT": 120 * u.deg,
     }
 
     hdu_g = interpolate_irf(irfs_g, data_pars)
@@ -204,8 +200,10 @@ def test_interp_irf(simulated_irf_file, simulated_dl2_file):
 
 
 def test_compare_irfs(
-    simulated_irf_file, simulated_srcdep_irf_file, simulated_dl2_file,
-    simulated_srcdep_dl2_file
+    simulated_irf_file,
+    simulated_srcdep_irf_file,
+    simulated_dl2_file,
+    simulated_srcdep_dl2_file,
 ):
     from lstchain.high_level.interpolate import compare_irfs
     from lstchain.scripts.tests.test_lstchain_scripts import run_program
@@ -257,7 +255,7 @@ def test_compare_irfs(
         srcdep_irf_file_2,
         "--point-like",
         "--source-dep",
-        "--global-alpha-cut=11"
+        "--global-alpha-cut=11",
     )
 
     irfs_diff_global_cuts = [simulated_irf_file, irf_file_2]
@@ -288,9 +286,7 @@ def test_check_delaunay_triangles(simulated_irf_file):
 
     new_irfs = check_in_delaunay_triangle(irfs, data_pars)
     new_irfs2 = check_in_delaunay_triangle(irfs, data_pars2)
-    new_irfs3 = check_in_delaunay_triangle(
-        irfs, data_pars, use_nearest_irf_node=True
-    )
+    new_irfs3 = check_in_delaunay_triangle(irfs, data_pars, use_nearest_irf_node=True)
     new_irfs4 = check_in_delaunay_triangle([irfs[0]], data_pars)
 
     t3 = Table.read(new_irfs3[0], hdu=1).meta

--- a/lstchain/tools/tests/test_tools.py
+++ b/lstchain/tools/tests/test_tools.py
@@ -55,11 +55,13 @@ def test_create_irf_point_like(temp_dir_observed_files, simulated_dl2_file):
 
     with fits.open(irf_file) as hdul:
         for hdu in hdul[1:]:
-            assert 'RAD_MAX' in hdu.header
-            assert isinstance(hdu.header['RAD_MAX'], float)
+            assert "RAD_MAX" in hdu.header
+            assert isinstance(hdu.header["RAD_MAX"], float)
 
 
-def test_create_irf_full_enclosure_with_config(temp_dir_observed_files, simulated_dl2_file):
+def test_create_irf_full_enclosure_with_config(
+    temp_dir_observed_files, simulated_dl2_file
+):
     """
     Generating full enclosure IRF file from a test DL2 files, using
     a config file
@@ -113,8 +115,8 @@ def test_create_irf_point_like_srcdep(
 
     with fits.open(irf_file) as hdul:
         for hdu in hdul[1:]:
-            assert 'AL_CUT' in hdu.header
-            assert isinstance(hdu.header['AL_CUT'], float)
+            assert "AL_CUT" in hdu.header
+            assert isinstance(hdu.header["AL_CUT"], float)
 
 
 def test_create_irf_point_like_energy_dependent_cuts(
@@ -142,7 +144,7 @@ def test_create_irf_point_like_energy_dependent_cuts(
                 "--point-like",
                 "--energy-dependent-theta",
                 "--DL3Cuts.max_theta_cut=1",
-                "--DL3Cuts.fill_theta_cut=1"
+                "--DL3Cuts.fill_theta_cut=1",
             ],
             cwd=temp_dir_observed_files,
         )
@@ -150,6 +152,7 @@ def test_create_irf_point_like_energy_dependent_cuts(
     )
 
     assert RadMax2D.read(irf_file, hdu="RAD_MAX")
+
 
 def test_create_irf_point_like_srcdep_energy_dependent_cuts(
     temp_dir_observed_srcdep_files, simulated_srcdep_dl2_file
@@ -176,8 +179,8 @@ def test_create_irf_point_like_srcdep_energy_dependent_cuts(
                 "--overwrite",
             ],
             cwd=temp_dir_observed_srcdep_files,
-       )
-       == 0
+        )
+        == 0
     )
 
     gh_cuts = QTable.read(irf_file, hdu="GH_CUTS")
@@ -186,10 +189,9 @@ def test_create_irf_point_like_srcdep_energy_dependent_cuts(
     al_cuts = QTable.read(irf_file, hdu="AL_CUTS")
     assert isinstance(al_cuts.meta["AL_CONT"], float)
 
+
 @pytest.mark.private_data
-def test_create_dl3_energy_dependent_cuts(
-    temp_dir_observed_files, observed_dl2_file
-):
+def test_create_dl3_energy_dependent_cuts(temp_dir_observed_files, observed_dl2_file):
     """
     Generating an DL3 file from a test DL2 files and test IRF file, using
     energy dependent cuts. Here the previously created IRF is used.
@@ -200,7 +202,7 @@ def test_create_dl3_energy_dependent_cuts(
     irf_file = temp_dir_observed_files / "pnt_irf.fits.gz"
 
     dl2_name = observed_dl2_file.name
-    observed_dl3_file = temp_dir_observed_files / dl2_name.replace('dl2', 'dl3')
+    observed_dl3_file = temp_dir_observed_files / dl2_name.replace("dl2", "dl3")
     observed_dl3_file = observed_dl3_file.with_suffix(".fits")
 
     assert (
@@ -222,9 +224,9 @@ def test_create_dl3_energy_dependent_cuts(
         == 0
     )
 
-    assert Observation.read(
-        event_file=observed_dl3_file, irf_file=irf_file
-    ).obs_id == 2008
+    assert (
+        Observation.read(event_file=observed_dl3_file, irf_file=irf_file).obs_id == 2008
+    )
 
 
 @pytest.mark.private_data
@@ -286,8 +288,7 @@ def test_create_dl3_with_config(temp_dir_observed_files, observed_dl2_file):
 
 @pytest.mark.private_data
 def test_create_srcdep_dl3(
-    temp_dir_observed_srcdep_files, observed_srcdep_dl2_file,
-    simulated_srcdep_irf_file
+    temp_dir_observed_srcdep_files, observed_srcdep_dl2_file, simulated_srcdep_irf_file
 ):
     """
     Generating a source-dependent DL3 file from a test DL2 files and test IRF file
@@ -318,8 +319,8 @@ def test_create_srcdep_dl3(
     hdulist = fits.open(
         temp_dir_observed_srcdep_files / dl2_to_dl3_filename(observed_srcdep_dl2_file)
     )
-    ra = hdulist[1].data['RA']
-    dec = hdulist[1].data['DEC']
+    ra = hdulist[1].data["RA"]
+    dec = hdulist[1].data["DEC"]
 
     np.testing.assert_allclose(ra, 83.63, atol=1e-2)
     np.testing.assert_allclose(dec, 22.01, atol=1e-2)
@@ -327,7 +328,7 @@ def test_create_srcdep_dl3(
 
 @pytest.mark.private_data
 def test_create_srcdep_dl3_energy_dependent_cuts(
-        temp_dir_observed_srcdep_files, observed_srcdep_dl2_file
+    temp_dir_observed_srcdep_files, observed_srcdep_dl2_file
 ):
     """
     Generating a source-dependent DL3 file from a test DL2 files and test IRF file,

--- a/lstchain/tools/tests/test_tools.py
+++ b/lstchain/tools/tests/test_tools.py
@@ -253,55 +253,6 @@ def test_create_dl3(temp_dir_observed_files, observed_dl2_file, simulated_irf_fi
         == 0
     )
 
-@pytest.mark.private_data
-def test_create_dl3_irf_interp(
-    temp_dir_observed_files, observed_dl2_file, simulated_dl2_file
-):
-    """
-    Generating an DL3 file from a test DL2 files and using IRF interpolation
-    function, to either get the interpolated IRF, or the nearest IRF node
-    """
-    from lstchain.tools.lstchain_create_dl3_file import DataReductionFITSWriter
-
-    assert (
-        run_tool(
-            DataReductionFITSWriter(),
-            argv=[
-                f"--input-dl2={observed_dl2_file}",
-                f"--output-dl3-path={temp_dir_observed_files}",
-                f"--input-irf-path={simulated_dl2_file.parent}",
-                "--irf-file-pattern=en_dep_cut*gz",
-                "--final-irf-file=final_irf_interp_1.fits.gz",
-                "--source-name=Crab",
-                "--source-ra=83.633deg",
-                "--source-dec=22.01deg",
-                "--overwrite",
-            ],
-            cwd=temp_dir_observed_files,
-        )
-        == 0
-    )
-
-    assert (
-        run_tool(
-            DataReductionFITSWriter(),
-            argv=[
-                f"--input-dl2={observed_dl2_file}",
-                f"--output-dl3-path={temp_dir_observed_files}",
-                f"--input-irf-path={simulated_dl2_file.parent}",
-                "--irf-file-pattern=en_dep_cut*gz",
-                "--final-irf-file=final_irf_interp_2.fits.gz",
-                "--source-name=Crab",
-                "--source-ra=83.633deg",
-                "--source-dec=22.01deg",
-                "--overwrite",
-                "--use-nearest-irf-node",
-            ],
-            cwd=temp_dir_observed_files,
-        )
-        == 0
-    )
-
 
 @pytest.mark.private_data
 def test_create_dl3_with_config(temp_dir_observed_files, observed_dl2_file):


### PR DESCRIPTION
A test on DL3 Tools when using IRF interpolation methods was failing as it required a list of IRFs which are not present as fixtures for the scope of the test session. These IRFs are created and tested in `lstchain/high_level/tests/test_interpolate` (through some "lengthy" code) for almost all combinations of IRF interpolations. 
As such, it is not essential to have separate and similar tests on DL3 Tools, for testing the same functionality.

This was missed in the earlier PR #711 as I tested in sequential order instead of in parallel (as done in CI).

In case, we require to have the DL3 Tools tested for the full functionality again, we would just need to shift ~150 lines of code from `lstchain/high_level/tests/test_interpolate.py` to `lstchain/conftest.py`