### PR TITLE
Add code snippet to documentation to show how to print config and calibration files used in the analysis

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,16 +69,16 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "matplotlib": ("https://matplotlib.org/", None),
     "traitlets": ("https://traitlets.readthedocs.io/en/stable/", None),
-    "ctapipe": ("https://cta-observatory.github.io/ctapipe/", None)
+    "ctapipe": ("https://ctapipe.readthedocs.io/en/stable/", None)
 }
 
 # These links are ignored in the checks, necessary due to broken intersphinx for
 # these
 nitpick_ignore = [
-    # ("py:class", "ctapipe.instrument.camera.geometry.CameraGeometry"),
-    # ("py:class", "ctapipe.core.tool.Tool"),
-    # ("py:class", "ctapipe.core.component.Component"),
-    # ("py:class", "ctapipe.core.container.Container"),
+    ("py:class", "ctapipe.instrument.camera.geometry.CameraGeometry"),
+    ("py:class", "ctapipe.core.tool.Tool"),
+    ("py:class", "ctapipe.core.component.Component"),
+    ("py:class", "ctapipe.core.container.Container"),
     ("py:class", "ctapipe.calib.camera.flatfield.FlatFieldCalculator"),
     ("py:class", "ctapipe.calib.camera.pedestals.PedestalCalculator"),
 ]

--- a/docs/snippets.rst
+++ b/docs/snippets.rst
@@ -24,3 +24,45 @@ In bash:
 
     h5dump -a /LSTCHAIN_VERSION dl1_file.h5
 
+.. note::
+    ctapipe and ctapipe_io_lst versions are also stored in the metadata.
+    You can print them with the same commands, replacing LSTCHAIN_VERSION by CTAPIPE_VERSION or CTAPIPE_IO_LST_VERSION.
+
+Print configuration parameters used by the script/tool
+------------------------------------------------------
+The configuration file used by a given script/tool is stored in the metadata of the output file. Note that the
+configuration file can contain more parameters than the ones used in a given analysis stage as the same configuration
+file can be used for several stages.
+
+.. code-block:: python
+
+    import tables
+    import yaml
+    filename = 'dl1_file.h5'
+    with tables.open_file(filename) as file:
+        config = yaml.safe_load(file.root.dl1.event.telescope.parameters.LST_LSTCam.attrs["config"])
+    print(config)
+    # Or for a given parameter section e.g.:
+    print(config['tailcut_clean_with_pedestal_threshold'])
+
+Print calibration and auxiliary files used by the script/tool
+-------------------------------------------------------------
+For observed data, the calibration and auxiliary files used to produce DL1 data are stored
+in the metadata of the DL1 files. You can print them with the following command:
+
+.. code-block:: python
+
+    import tables
+    import yaml
+    filename = 'dl1_file.h5'
+    with tables.open_file(filename) as file:
+        config = yaml.safe_load(file.root.dl1.event.telescope.monitoring.calibration.attrs["config"])
+    # Drive log with pointing information
+    print(config['source_config']['LSTEventSource']['PointingSource'])
+    # Run summary file with reference timestamps and counters for timestamp calculation
+    print(config['source_config']['LSTEventSource']['EventTimeCalculator'])
+    # Calibration files (DRS4 baseline corrections, calibration coefficients, time calibration, etc)
+    print(config['source_config']['LSTEventSource']['LSTR0Corrections'])
+    print(config['LSTCalibrationCalculator']['systematic_correction_path'])
+
+All these metadata information can be accessed interactively using ViTables.


### PR DESCRIPTION
I also changed the link to ctapipe documentation to readthedocs link (for intersphinx mapping) and add some py class references from ctapipe to nitpick ignore list to avoid showing so many warnings that were preventing automatic deployment of the documentation.

follow-up of #1086 