### PR TITLE
PR for ctapipe 0.17 : write pedestal and ff events to a h5 files

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -286,7 +286,7 @@
       "transform_waveform": true,
       "waveform_dtype": "uint16",
       "waveform_offset": 400,
-      "waveform_scale": 1  
+      "waveform_scale": 80  
     }
   }
 }

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -276,5 +276,17 @@
     "nsb_tuning": false,
     "nsb_tuning_ratio": 0.52,
     "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+  },
+  "write_interleaved_events":{
+    "DataWriter": {
+      "overwrite":  true,
+      "write_images": false,
+      "write_parameters": false,
+      "write_waveforms": true,
+      "transform_waveform": true,
+      "waveform_dtype": "uint16",
+      "waveform_offset": 400,
+      "waveform_scale": 1  
+    }
   }
 }

--- a/lstchain/image/tests/test_modifier.py
+++ b/lstchain/image/tests/test_modifier.py
@@ -59,7 +59,7 @@ def test_calculate_noise_parameters(mc_gamma_testfile, observed_dl1_files):
         mc_gamma_testfile,
         observed_dl1_files["dl1_file1"]
     )
-    #assert np.isclose(extra_noise_in_dim_pixels, 1.96, atol=0.01)
+    assert np.isclose(extra_noise_in_dim_pixels, 1.96, atol=0.01)
     assert np.isclose(extra_bias_in_dim_pixels, 0.0, atol=0.1)
     assert extra_noise_in_bright_pixels == 0.0
 

--- a/lstchain/image/tests/test_modifier.py
+++ b/lstchain/image/tests/test_modifier.py
@@ -59,7 +59,7 @@ def test_calculate_noise_parameters(mc_gamma_testfile, observed_dl1_files):
         mc_gamma_testfile,
         observed_dl1_files["dl1_file1"]
     )
-    assert np.isclose(extra_noise_in_dim_pixels, 1.96, atol=0.01)
+    #assert np.isclose(extra_noise_in_dim_pixels, 1.96, atol=0.01)
     assert np.isclose(extra_bias_in_dim_pixels, 0.0, atol=0.1)
     assert extra_noise_in_bright_pixels == 0.0
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -446,7 +446,7 @@ def r0_to_dl1(
 
     # initialize the writer of the interleaved events 
     interleaved_writer = None
-    if 'write_interleaved_events' in config.keys():
+    if 'write_interleaved_events' in config:
         interleaved_writer_config = Config(config['write_interleaved_events'])
         dir, name = os.path.split(output_filename)
         name = name.replace('dl1', 'interleaved').replace('LST-1.1', 'LST-1')
@@ -524,7 +524,8 @@ def r0_to_dl1(
                     # write the calibrated R1 waveform without gain selection
                     source.r0_r1_calibrator.select_gain = False
                     source.r0_r1_calibrator.calibrate(event)
-                    interleaved_writer(event)
+                    if interleaved_writer is not None:
+                        interleaved_writer(event)
                     
                     # calibrate and gain select the event by hand for DL1
                     source.r0_r1_calibrator.select_gain = True
@@ -764,7 +765,7 @@ def r0_to_dl1(
         table.write(muon_output_filename, format='fits', overwrite=True)
         
         # close the interleaved output file and write metadata
-        if 'write_interleaved_events' in config.keys():
+        if interleaved_writer is not None:
             interleaved_writer.finish()
 
 

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -449,7 +449,10 @@ def r0_to_dl1(
     if 'write_interleaved_events' in config:
         interleaved_writer_config = Config(config['write_interleaved_events'])
         dir, name = os.path.split(output_filename)
-        name = name.replace('dl1', 'interleaved').replace('LST-1.1', 'LST-1')
+        if 'dl1' in name: 
+            name = name.replace('dl1', 'interleaved').replace('LST-1.1', 'LST-1')
+        else:
+            name = f"interleaved_{name}"
         interleaved_output_file = Path(dir, name)
         interleaved_writer = DataWriter(event_source=source,output_path=interleaved_output_file,config=interleaved_writer_config)
        


### PR DESCRIPTION
New commit for the code in PR [https://github.com/cta-observatory/cta-lstchain/pull/1072](https://github.com/cta-observatory/cta-lstchain/pull/1072) with correct rebase to ctapipe_0.17. It substitutes PR 1072