### PR TITLE
Update effective time calculation for observations suffered from busy stuck problem

### DIFF
--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -669,12 +669,15 @@ def get_effective_time(events):
 
     # elapsed time: sum of those time differences, excluding large ones which
     # might indicate the DAQ was stopped (e.g. if the table contains more
-    # than one run). We set 0.1 s as limit to decide a "break" occurred:
-    t_elapsed = np.sum(time_diff[time_diff < 0.1 * u.s])
-
+    # than one run). We set 0.01 s as limit to decide a "break" occurred:
+    t_elapsed = np.sum(time_diff[time_diff < 0.01 * u.s])
+    
     # delta_t is the time elapsed since the previous triggered event.
     # We exclude the null values that might be set for the first even in a file.
-    delta_t = delta_t[delta_t > 0.0 * u.s]
+    # Same as the elapsed time, we exclude events with delta_t larger than 0.01 s.
+    delta_t = delta_t[
+        (delta_t > 0.0 * u.s) & (delta_t < 0.01 * u.s)
+    ]
 
     # dead time per event (minimum observed delta_t, ):
     dead_time = np.amin(delta_t)


### PR DESCRIPTION
To calculate the elapsed time, a cut of `time_diff`<0.1 s is applied to exclude events suffered from DAQ break. However, such kind of filter is not applied to calculate the average of `delta_t` for the estimation of the trigger rate.

For example, when we have 'break' because of DAQ problem like below, the estimated trigger rate is 4.8 kHz, but the updated codes (excluding large `delta_t` events) estimate 7.4 kHz.
![eff_time_calculation](https://github.com/cta-observatory/cta-lstchain/assets/31307823/1ea9659e-0977-43e5-89ac-8938079c38d9)

Here I set 0.01 s (100 Hz) as the limit for both elapsed/effective time calculation for the moment. Any comments are welcome.