### PR TITLE
Fix failing docs test 

### DIFF
--- a/docs/lstchain_api/high_level/index.rst
+++ b/docs/lstchain_api/high_level/index.rst
@@ -16,4 +16,4 @@ Library containing the functions and classes to perform LST high level analysis.
 .. automodapi:: lstchain.high_level.interpolate
    :no-inheritance-diagram:
 .. automodapi:: lstchain.high_level.significance_calculation
-  :no-inheritance-diagram:
+   :no-inheritance-diagram:

--- a/lstchain/high_level/__init__.py
+++ b/lstchain/high_level/__init__.py
@@ -18,6 +18,8 @@ from .interpolate import (
     compare_irfs,
     get_nearest_az_node,
     interp_params,
+    interpolate_al_cuts,
+    interpolate_gh_cuts,
     interpolate_irf,
     load_irf_grid,
 )
@@ -36,6 +38,8 @@ __all__ = [
     "get_pointing_params",
     "get_timing_params",
     "interp_params",
+    "interpolate_al_cuts",
+    "interpolate_gh_cuts",
     "interpolate_irf",
     "load_irf_grid",
     "setup_logging",

--- a/lstchain/high_level/interpolate.py
+++ b/lstchain/high_level/interpolate.py
@@ -21,8 +21,18 @@ from pyirf.interpolation import (
 )
 from scipy.spatial import Delaunay, distance, QhullError
 
-log = logging.getLogger(__name__)
+__all__ = [
+    "check_in_delaunay_triangle",
+    "compare_irfs",
+    "get_nearest_az_node",
+    "interp_params",
+    "interpolate_al_cuts",
+    "interpolate_gh_cuts",
+    "interpolate_irf",
+    "load_irf_grid",
+]
 
+log = logging.getLogger(__name__)
 
 def interp_params(params_list, data):
     """


### PR DESCRIPTION
There was a missing `__all__` in `lstchain.high_level.interpolate` module leading to the failing `build docs` test in #1105 and #1054 