### PR TITLE
Update dependencies to current versions, add python 3.11 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install doc dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-        ctapipe-version: ["v0.19.0"]
+        python-version: ["3.9", "3.10", "3.11"]
+        ctapipe-version: ["v0.19.2"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: pyflakes
         run: |

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - astropy=5
   - pip
   - ctapipe=0.19
-  - gammapy=1
+  - gammapy=1.1
   - h5py
   - ipython
   - jupyter

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - default
 dependencies:
   - python=3.10
-  - numpy=1.22
+  - numpy
   - astropy=5
   - pip
   - ctapipe=0.19.2

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - h5py
   - ipython
   - jupyter
-  - matplotlib=3.5
+  - matplotlib=3.7
   - notebook
   - iminuit>=2
   - joblib~=1.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - toml
   - protobuf=3.20
   - pyparsing
-  - scikit-learn=1.0
+  - scikit-learn=1.2
   - sphinx=4
   - sphinx-automodapi
   - sphinx_rtd_theme

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy=1.22
   - astropy=5
   - pip
-  - ctapipe=0.19
+  - ctapipe=0.19.2
   - gammapy=1.1
   - h5py
   - ipython

--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -79,7 +79,6 @@
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
-    "verbose": 0,
     "warm_start": false
   },
 
@@ -97,7 +96,6 @@
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
-    "verbose": 0,
     "warm_start": false
   },
 
@@ -115,7 +113,6 @@
     "bootstrap": true,
     "oob_score": false,
     "random_state": 42,
-    "verbose": 0.0,
     "warm_start": false,
     "class_weight": null
   },
@@ -134,7 +131,6 @@
     "bootstrap": true,
     "oob_score": false,
     "random_state": 42,
-    "verbose": 0.0,
     "warm_start": false,
     "class_weight": null
   },

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -79,7 +79,6 @@
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
-    "verbose": 0,
     "warm_start": false
   },
 
@@ -97,7 +96,6 @@
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
-    "verbose": 0,
     "warm_start": false
   },
 
@@ -115,7 +113,6 @@
     "bootstrap": true,
     "oob_score": false,
     "random_state": 42,
-    "verbose": 0.0,
     "warm_start": false,
     "class_weight": null
   },
@@ -134,7 +131,6 @@
     "bootstrap": true,
     "oob_score": false,
     "random_state": 42,
-    "verbose": 0.0,
     "warm_start": false,
     "class_weight": null
   },

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,4 +10,4 @@ long_description_content_type = text/markdown
 github_project = cta-observatory/cta-lstchain
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'astropy~=5.0',
         'bokeh~=2.0',
-        'ctapipe~=0.19.0',
+        'ctapipe~=0.19.2',
         'ctapipe_io_lst~=0.21.0',
         'ctaplot~=0.6.2',
         'eventio>=1.9.1,<2.0.0a0',  # at least 1.1.1, but not 2

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'ctapipe_io_lst~=0.21.0',
         'ctaplot~=0.6.2',
         'eventio>=1.9.1,<2.0.0a0',  # at least 1.1.1, but not 2
-        'gammapy~=1.0',
+        'gammapy~=1.1',
         'h5py',
         'iminuit>=2',
         'joblib~=1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'pyirf~=0.8.0',
         'scipy>=1.8',
         'seaborn',
-        'scikit-learn~=1.0',
+        'scikit-learn~=1.2',
         'tables',
         'toml',
         'pymongo',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'h5py',
         'iminuit>=2',
         'joblib~=1.2.0',
-        'matplotlib~=3.5',
+        'matplotlib~=3.7',
         'numba',
         'numpy',
         'pandas',


### PR DESCRIPTION
There was a [gammapy release](https://github.com/gammapy/gammapy/releases/tag/v1.1) very recently and we can also follow the latest [ctapipe](https://github.com/cta-observatory/ctapipe/releases/tag/v0.19.2) one