### PR TITLE
Catch all exceptions in create_run_summary

### DIFF
--- a/lstchain/scripts/lstchain_create_run_summary.py
+++ b/lstchain/scripts/lstchain_create_run_summary.py
@@ -182,7 +182,7 @@ def type_of_run(date_path, run_number, counters, n_events=500):
         else:
             run_type = "ERROR"
 
-    except (AttributeError, ValueError, IOError, IndexError) as err:
+    except Exception as err:
         log.error(f"File {filename} has error: {err!r}")
 
         run_type = "ERROR"


### PR DESCRIPTION
The EVBv6 test files created an exception that was not handled, preventing the creating of the run summary.

I think it does not really make sense here to check for specific exceptions, anything we can't identify is probably not analyzable at the moment.