### PR TITLE
Use interleaved events to get the pedestal std deviation in the likelihood reco

### DIFF
--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -277,6 +277,7 @@
     "n_peaks": 0,
     "no_asymmetry": false,
     "use_weight": false,
+    "use_interleaved": true,
     "verbose": 0
   }
 }

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -376,8 +376,8 @@ def r0_to_dl1(
 
         # Pulse extractor for muon ring analysis. Same parameters (window_width and _shift) as the one for showers, but
         # using GlobalPeakWindowSum, since the signal for the rings is expected to be very isochronous
-        r1_dl1_calibrator_for_muon_rings = CameraCalibrator(image_extractor_type = config['image_extractor_for_muons'],
-                                                            config=Config(config),subarray = subarray)
+        r1_dl1_calibrator_for_muon_rings = CameraCalibrator(image_extractor_type=config['image_extractor_for_muons'],
+                                                            config=Config(config), subarray=subarray)
 
         # Component to process interleaved pedestal and flat-fields
         calib_config = Config({config['calibration_product']: config[config['calibration_product']]})
@@ -443,6 +443,11 @@ def r0_to_dl1(
     if 'lh_fit_config' in config.keys():
         lhfit_fitter_config = {'TimeWaveformFitter': config['lh_fit_config']}
         lhfit_fitter = TimeWaveformFitter(subarray=subarray, config=Config(lhfit_fitter_config))
+        if lhfit_fitter_config['TimeWaveformFitter']['use_interleaved'] and not is_simu:
+            tmp_source = EventSource(input_url=input_filename,
+                                      config=Config(config["source_config"]))
+            lhfit_fitter.get_ped_from_interleaved(tmp_source)
+            del tmp_source
 
     with HDF5TableWriter(
         filename=output_filename,

--- a/lstchain/reco/reconstructor.py
+++ b/lstchain/reco/reconstructor.py
@@ -6,13 +6,13 @@ import astropy.units as u
 
 from lstchain.data.normalised_pulse_template import NormalizedPulseTemplate
 
+from ctapipe.containers import EventType
 from ctapipe.core import TelescopeComponent
-from ctapipe.core.traits import Bool, Float, FloatTelescopeParameter, Int, Path
+from ctapipe.core.traits import Bool, Float, FloatTelescopeParameter, Int
 from lstchain.io.lstcontainers import DL1LikelihoodParametersContainer
 from lstchain.reco.reconstructorCC import log_pdf as log_pdf
 
 logger = logging.getLogger(__name__)
-
 
 
 class TimeWaveformFitter(TelescopeComponent):
@@ -37,8 +37,8 @@ class TimeWaveformFitter(TelescopeComponent):
                                   'likelihood. If false all samples are equivalent.', allow_none=False).tag(config=True)
     no_asymmetry = Bool(False, help='If true, the asymmetry of the spatial model is fixed to 0.',
                         allow_none=False).tag(config=True)
-    use_interleaved = Path(None, help='Location of the dl1 file used to estimate the pedestal exploiting interleaved'
-                                      ' events.', allow_none=True).tag(config=True)
+    use_interleaved = Bool(None, help='If true, the std deviation of pedestals and dimmed pixels are estimated on '
+                                      'interleaved events', allow_none=True).tag(config=True)
     n_peaks = Int(0, help='Maximum brightness (p.e.) for which the full likelihood computation is used. '
                           'If the Poisson term for Np.e.>n_peak is more than 1e-6 a Gaussian approximation is used.',
                   allow_none=False).tag(config=True)
@@ -96,6 +96,8 @@ class TimeWaveformFitter(TelescopeComponent):
         self.transition_charges = {}
         for tel_id in subarray.tel:
             self.transition_charges[tel_id] = transition_charges[self.crosstalk.tel[tel_id]]
+        self.error = None
+        self.allowed_pixels = True
 
         self.start_parameters = None
         self.names_parameters = None
@@ -103,6 +105,31 @@ class TimeWaveformFitter(TelescopeComponent):
         self.error_parameters = None
         self.bound_parameters = None
         self.fcn = None
+
+    def get_ped_from_interleaved(self, source):
+        """
+
+        Parameters
+        ----------
+        source
+
+        """
+        self.error = {}
+        waveforms = {}
+        for tel_id in self.subarray.tel:
+            waveforms[tel_id] = []
+        for i, event in enumerate(source):
+            if event.trigger.event_type == EventType.SKY_PEDESTAL:
+                source.r0_r1_calibrator.calibrate(event)
+                for tel_id in event.r1.tel.keys():
+                    waveforms[tel_id].append(event.r1.tel[tel_id].waveform.squeeze())
+        for tel_id, tel_waveforms in waveforms.items():
+            x=np.concatenate(np.asarray(tel_waveforms), axis=1)
+            std=[]
+            for elt in x:
+                std.append(np.nanstd(elt))
+            self.error[tel_id] = std
+            self.allowed_pixels = (std > 0.5 * np.median(std))
 
     def call_setup(self, event, telescope_id, dl1_container):
         """
@@ -212,6 +239,7 @@ class TimeWaveformFitter(TelescopeComponent):
                             }
 
         mask_pixel, mask_time = self.clean_data(pix_x, pix_y, pix_radius, times, start_parameters, telescope_id)
+        mask_pixel = mask_pixel & self.allowed_pixels
         spatial_ones = np.ones(np.sum(mask_pixel))
 
         is_high_gain = is_high_gain[mask_pixel]
@@ -226,7 +254,7 @@ class TimeWaveformFitter(TelescopeComponent):
         pix_area = geometry.pix_area[mask_pixel].to_value(unit ** 2)
 
         data = waveform
-        error = None  # TODO include option to use calibration data
+        error = self.error
 
         filter_pixels = np.nonzero(~mask_pixel)
         filter_times = np.nonzero(~mask_time)
@@ -234,6 +262,8 @@ class TimeWaveformFitter(TelescopeComponent):
         if error is None:
             std = np.std(data[~mask_pixel])
             error = np.full(data.shape[0], std)
+        else:
+            error = self.error[telescope_id]
 
         data = np.delete(data, filter_pixels, axis=0)
         data = np.delete(data, filter_times, axis=1)


### PR DESCRIPTION
Add a small method to estimate the pedestal deviation pixel-wise from interleaved events instead of event-wise from signal-less pixels in the likelihood reconstruction method.
Also remove obviously dimmed pixels for the subrun.

Will likely become mandatory to analyse DVRed data.