### PR TITLE
Remove default channel from conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: lst-dev
 channels:
   - conda-forge
-  - default
 dependencies:
   - python=3.10
   - numpy


### PR DESCRIPTION
conda-forge recommends not mixing default packages with conda-forge packages.

