### PR TITLE
Make lstchain_dvr_pixselector.py back-compatible with v0.9 DL1

### DIFF
--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -233,8 +233,8 @@ def main():
         data_parameters = read_table(dl1_file, dl1_params_lstcam_key)
 
         # Get the LST camera geometry:
-        sa = LSTEventSource.create_subarray(tel_id=1)
-        camera_geom = sa.tel[1].camera.geometry
+        subarray_info = LSTEventSource.create_subarray(tel_id=1)
+        camera_geom = subarray_info.tel[1].camera.geometry
       
         # Time between first and last timestamp:
         summary_info.elapsed_time = (data_parameters['dragon_time'][-1] -
@@ -252,8 +252,9 @@ def main():
 
         found_event_types = np.unique(event_type_data)
         print('Event types found:', found_event_types)
-        if EventType.SUBARRAY.value not in found_event_types:
-            print('No shower event (SUBARRAY type) found in file! SKIPPING IT!')
+
+        if not np.any(np.isin(found_event_types, event_types_to_be_reduced)):
+            print('No reducible events were found in file! SKIPPING IT!')
             continue
 
         cosmic_mask   = event_type_data == EventType.SUBARRAY.value  # showers

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -252,7 +252,7 @@ def main():
 
         found_event_types = np.unique(event_type_data, return_counts=True)
         print('Event types found:', found_event_types[0])
-        print('Number of each type:', found_event_types[1])
+        print('Number of events of each type:', found_event_types[1])
 
         if not np.any(np.isin(found_event_types[0], 
                               event_types_to_be_reduced)):

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -56,7 +56,6 @@ from lstchain.paths import parse_dl1_filename
 from lstchain.io.io import dl1_params_lstcam_key, dl1_images_lstcam_key
 from lstchain.io.io import dl1_params_tel_mon_cal_key
 
-from ctapipe.instrument import SubarrayDescription
 from ctapipe.io import read_table
 from ctapipe.core import Container, Field
 from ctapipe.io import HDF5TableWriter

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -61,6 +61,7 @@ from ctapipe.io import read_table
 from ctapipe.core import Container, Field
 from ctapipe.io import HDF5TableWriter
 from ctapipe.containers import EventType
+from ctapipe_io_lst import LSTEventSource
 
 parser = argparse.ArgumentParser(description="DVR pixel selector")
 
@@ -232,10 +233,10 @@ def main():
 
         data_parameters = read_table(dl1_file, dl1_params_lstcam_key)
 
-        # Read some useful extra info from the file:
-        subarray_info = SubarrayDescription.from_hdf(dl1_file)
-        camera_geom = subarray_info.tel[1].camera.geometry
-
+        # Get the LST camera geometry:
+        sa = LSTEventSource.create_subarray(tel_id=1)
+        camera_geom = sa.tel[1].camera.geometry
+      
         # Time between first and last timestamp:
         summary_info.elapsed_time = (data_parameters['dragon_time'][-1] -
                                      data_parameters['dragon_time'][0])


### PR DESCRIPTION
Make lstchain_dvr_pixselector.py back-compatible with DL1 files containing obsolete instrument description: now the camera geometry is obtained from the LST event source.

Also: do not skip files in which no events are tagged as cosmics. In some files the tagging failed, and cosmics are actually tagged as "unknown" (whereas FF and pedestal are heuristically recognized in the DL1 file). We now assume those are cosmics.

