### PR TITLE
Normalize `az_tel` to the range of [0, 360) and compute sin_az_tel in dl1_to_dl2 step

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -399,9 +399,9 @@ def build_models(filegammas, fileprotons,
 
     # Dealing with `sin_az_tel` missing data because of the former version of lstchain
     if 'sin_az_tel' not in df_gamma.columns:
-        df_gamma.sin_az_tel = np.sin(df_gamma.az_tel)
+        df_gamma['sin_az_tel'] = np.sin(df_gamma.az_tel)
     if 'sin_az_tel' not in df_proton.columns:
-        df_proton.sin_az_tel = np.sin(df_proton.az_tel)
+        df_proton['sin_az_tel'] = np.sin(df_proton.az_tel)
 
     # Training MC gammas in reduced viewcone
     src_r_min = config['train_gamma_src_r_deg'][0]

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -13,8 +13,7 @@ import astropy.units as u
 import joblib
 import numpy as np
 import pandas as pd
-from astropy.coordinates import SkyCoord
-from astropy.coordinates import Angle
+from astropy.coordinates import SkyCoord, Angle
 from astropy.time import Time
 from pathlib import Path
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -102,7 +102,7 @@ def apply_to_file(filename, models_dict, output_dir, config):
 
     # Dealing with `sin_az_tel` missing data because of the former version of lstchain
     if 'sin_az_tel' not in data.columns:
-        data.sin_az_tel = np.sin(data.az_tel)
+        data['sin_az_tel'] = np.sin(data.az_tel)
 
     subarray_info = SubarrayDescription.from_hdf(filename)
     tel_id = config["allowed_tels"][0] if "allowed_tels" in config else 1


### PR DESCRIPTION
Related to #1079 

This PR normalize `az_tel` values to the range of [0, 360) degrees which is same as the distribution of MC data points. In addition, if there is no `sin_az_tel` in DL1 file because the DL1 was created using former version of lstchain, it computes `sin_az_tel` in dl1_to_dl2 step.