### PR TITLE
Change way to access monitoring info in dl1 file

### DIFF
--- a/lstchain/calib/camera/pixel_threshold_estimation.py
+++ b/lstchain/calib/camera/pixel_threshold_estimation.py
@@ -24,10 +24,10 @@ def get_bias_and_std(dl1_file):
     """
     with tables.open_file(dl1_file) as f:
         ped = f.root[dl1_params_tel_mon_ped_key]
-        ped_charge_mean = np.array(ped.cols.charge_mean)
-        ped_charge_std = np.array(ped.cols.charge_std)
+        ped_charge_mean = ped.col('charge_mean')
+        ped_charge_std = ped.col('charge_std')
         calib = f.root[dl1_params_tel_mon_cal_key]
-        dc_to_pe = np.array(calib.cols.dc_to_pe[ORIGINAL_CALIBRATION_ID])
+        dc_to_pe = calib.col('dc_to_pe')[ORIGINAL_CALIBRATION_ID]
         ped_charge_mean_pe = ped_charge_mean * dc_to_pe
         ped_charge_std_pe = ped_charge_std * dc_to_pe
 


### PR DESCRIPTION
The former approach np.array(f.root[].cols.charge_mean) results in some cases  in an attempt to allocate a huge array (instead of just 2x2x1855), and hence a crash.  So far I only had this problem at PIC, using lstchain 0.9.13. No idea why...
With current main branch the same code works well at the IT cluster. 

Since the new lines work in both cases, I propose to merge the change.