### PR TITLE
Bump ctapipe_io_lst version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - pandas>=2
   - pymongo
   - seaborn
-  - ctapipe_io_lst=0.22.0
+  - ctapipe_io_lst=0.22
   - pytest
   - pip:
       - ctaplot~=0.6.2

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - pandas>=2
   - pymongo
   - seaborn
-  - ctapipe_io_lst=0.21.0
+  - ctapipe_io_lst=0.22.0
   - pytest
   - pip:
       - ctaplot~=0.6.2

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'astropy~=5.0',
         'bokeh~=2.0',
         'ctapipe~=0.19.2',
-        'ctapipe_io_lst~=0.21.0',
+        'ctapipe_io_lst~=0.22.0',
         'ctaplot~=0.6.2',
         'eventio>=1.9.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=1.1',


### PR DESCRIPTION
The new `ctapipe_io_lst` version will allow to read EvB6 data

(tests will pass whenever [the new version of ctapipe_io_lst](https://github.com/cta-observatory/ctapipe_io_lst/releases/tag/v0.22.0) is uploaded to pypi