### PR TITLE
Make ctaplot optional

### DIFF
--- a/lstchain/mc/plot_utils.py
+++ b/lstchain/mc/plot_utils.py
@@ -2,7 +2,6 @@ import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from ctaplot.plots import plot_sensitivity_magic_performance
 from matplotlib.colors import LogNorm
 from pyirf.spectral import CRAB_MAGIC_JHEAP2015
 from astropy.visualization import quantity_support
@@ -304,6 +303,10 @@ def sensitivity_plot_comparison(energy, sensitivity, ax=None):
     -------
     fig_sens: `matplotlib.pyplot.figure` Figure containing sensitivity plot
     """
+    try:
+        from ctaplot.plots import plot_sensitivity_magic_performance
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("Please install ctaplot: pip install ctaplot")
 
     # Final sensitivity plot
     ax = plt.gca() if ax is None else ax

--- a/lstchain/scripts/benchmarks/charge_benchmark.py
+++ b/lstchain/scripts/benchmarks/charge_benchmark.py
@@ -4,15 +4,9 @@ import os
 import sys
 from pathlib import Path
 
-import ctaplot
 import matplotlib.pyplot as plt
 import tables
 from astropy.table import Table
-from ctaplot.plots.calib import (
-    plot_charge_resolution,
-    plot_photoelectron_true_reco,
-    plot_pixels_pe_spectrum,
-)
 from matplotlib.backends.backend_pdf import PdfPages
 
 from lstchain.io.config import (
@@ -49,6 +43,18 @@ args = parser.parse_args()
 
 
 def main():
+    try:
+        import ctaplot
+    except ModuleNotFoundError:
+        print("ctaplot is needed for this script, please install using `pip install ctaplot`", file=sys.stderr)
+        sys.exit(1)
+
+    from ctaplot.plots.calib import (
+        plot_charge_resolution,
+        plot_photoelectron_true_reco,
+        plot_pixels_pe_spectrum,
+    )
+
     ctaplot.set_style()
 
     output_dir = args.output_dir.absolute()

--- a/lstchain/scripts/lstchain_mc_sensitivity.py
+++ b/lstchain/scripts/lstchain_mc_sensitivity.py
@@ -13,13 +13,12 @@ $> python lstchain_mc_sensitivity.py
 --o /output/path
 
 """
-
+import sys
 import argparse
 import os
 import warnings
 
 import astropy.units as u
-import ctaplot
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -36,8 +35,6 @@ from lstchain.mc.sensitivity import (
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=RuntimeWarning)
-
-ctaplot.set_style()
 
 parser = argparse.ArgumentParser(description="Compute MC sensitivity curve.")
 
@@ -57,6 +54,15 @@ parser.add_argument('--output_path', '--o', type=str,
 
 def main():
     args = parser.parse_args()
+
+    try:
+        import ctaplot
+    except ModuleNotFoundError:
+        print("ctaplot is needed for this script, please install using `pip install ctaplot`", file=sys.stderr)
+        sys.exit(1)
+
+    ctaplot.set_style()
+
     
     ntelescopes_gamma = 1
     n_bins_energy = 20  # Number of energy bins

--- a/lstchain/visualization/plot_dl2.py
+++ b/lstchain/visualization/plot_dl2.py
@@ -6,7 +6,6 @@ Usage:
 import os
 
 import astropy.units as u
-import ctaplot
 import joblib
 import matplotlib
 import matplotlib.pyplot as plt
@@ -176,8 +175,12 @@ def energy_results(dl2_data, points_outfile=None, plot_outfile=None):
     -------
     fig, axes: `matplotlib.pyplot.figure`, `matplotlib.pyplot.axes`
     """
-    fig, axes = plt.subplots(2, 2, figsize=(12, 8))
+    try:
+        import ctaplot
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("This function needs ctaplot. Please install ctaplot: pip install ctaplot")
 
+    fig, axes = plt.subplots(2, 2, figsize=(12, 8))
     ctaplot.plot_energy_resolution(dl2_data.mc_energy.values * u.TeV,
                                    dl2_data.reco_energy.values * u.TeV,
                                    ax=axes[0, 0], bias_correction=False)
@@ -562,6 +565,11 @@ def plot_roc_gamma(dl2_data, energy_bins=None, ax=None, **kwargs):
     -------
     ax: `matplotlib.pyplot.axis`
     """
+    try:
+        import ctaplot
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("This function needs ctaplot. Please install ctaplot: pip install ctaplot")
+
     if energy_bins is None:
         ax = ctaplot.plot_roc_curve_gammaness(dl2_data.mc_type, dl2_data.gammaness,
                                               ax=ax,
@@ -595,6 +603,10 @@ def plot_energy_resolution(dl2_data, ax=None, bias_correction=False, cta_req_nor
     -------
     ax: `matplotlib.pyplot.axes`
     """
+    try:
+        import ctaplot
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("This function needs ctaplot. Please install ctaplot: pip install ctaplot")
 
     ax = ctaplot.plot_energy_resolution(dl2_data.mc_energy.values * u.TeV,
                                         dl2_data.reco_energy.values * u.TeV,
@@ -628,6 +640,10 @@ def plot_angular_resolution(dl2_data, ax=None, bias_correction=False, cta_req_no
     -------
     ax: `matplotlib.pyplot.axes`
     """
+    try:
+        import ctaplot
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("This function needs ctaplot. Please install ctaplot: pip install ctaplot")
 
     ax = ctaplot.plot_angular_resolution_per_energy(dl2_data.mc_alt.values * u.rad,
                                                     dl2_data.reco_alt.values * u.rad,
@@ -660,6 +676,10 @@ def direction_results(dl2_data, points_outfile=None, plot_outfile=None):
     -------
     fig, axes: `matplotlib.pyplot.figure`, `matplotlib.pyplot.axes`
     """
+    try:
+        import ctaplot
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("This function needs ctaplot. Please install ctaplot: pip install ctaplot")
 
     fig, axes = plt.subplots(2, 2, figsize=(15, 12))
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'bokeh~=2.0',
         'ctapipe~=0.19.2',
         'ctapipe_io_lst~=0.22.0',
-        'ctaplot~=0.6.2',
         'eventio>=1.9.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=1.1',
         'h5py',
@@ -66,7 +65,7 @@ setup(
         'jinja2~=3.0.2',  # pinned for bokeh 1.0 compatibility
     ],
     extras_require={
-        "all": tests_require + docs_require,
+        "all": tests_require + docs_require + ["ctaplot~=0.6.2"],
         "tests": tests_require,
         "docs": docs_require,
     },


### PR DESCRIPTION
After the recent discussions about pip vs. conda and mixing the installation of dependencies between the two, I though it might be best to also have conda package for lstchain releases.

To create a conda forge package, all dependencies must be available from conda-forge. The only package missing is ctaplot.

Here, the simplest solution was to make ctaplot optional (creating a nice error message how to install it when it is needed).

We could alternatively also create a conda-forge package for ctaplot.