### PR TITLE
Improve calibration "info" and "warning" messages 

### DIFF
--- a/lstchain/calib/camera/flatfield.py
+++ b/lstchain/calib/camera/flatfield.py
@@ -183,6 +183,7 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
         self.collect_sample(charge, pixel_mask, arrival_time)
 
         sample_age = (self.trigger_time - self.time_start).to_value(u.s)
+
         # check if to create a calibration event
         if (self.num_events_seen > 0 and
                 (sample_age > self.sample_duration or

--- a/lstchain/data/onsite_camera_calibration_param.json
+++ b/lstchain/data/onsite_camera_calibration_param.json
@@ -7,6 +7,9 @@
     "log_level": "INFO"
   },
   "LSTEventSource": {
+    "MultiFiles": {
+      "all_subruns": true
+     },
     "allowed_tels": [
       1
     ],

--- a/lstchain/scripts/onsite/onsite_create_calibration_file.py
+++ b/lstchain/scripts/onsite/onsite_create_calibration_file.py
@@ -236,7 +236,7 @@ def main():
         f"--PedestalCalculator.sample_size={stat_events}",
         f"--config={config_file}",
         f"--log-file={log_file}",
-        "--log-file-level=DEBUG",
+        "--log-file-level=INFO",
         *remaining_args,
     ]
 

--- a/lstchain/tools/lstchain_create_calibration_file.py
+++ b/lstchain/tools/lstchain_create_calibration_file.py
@@ -238,8 +238,8 @@ class CalibrationHDF5Writer(Tool):
 
         self.log.info(f"Written {self.n_calib} calibration events")
         if self.n_calib == 0:
-             self.log.critical(f"!!! No calibration events in the output file !!! : ")
-             self.log.critical(f"flatfiels collected statistics = {self.processor.flatfield.num_events_seen} events")
+             self.log.critical("!!! No calibration events in the output file !!! : ")
+             self.log.critical(f"flatfield collected statistics = {self.processor.flatfield.num_events_seen} events")
              self.log.critical(f"pedestal collected statistics = {self.processor.pedestal.num_events_seen} events")
              self.exit(1)
 

--- a/lstchain/tools/lstchain_create_calibration_file.py
+++ b/lstchain/tools/lstchain_create_calibration_file.py
@@ -103,10 +103,11 @@ class CalibrationHDF5Writer(Tool):
         self.processor = None
         self.writer = None
         self.simulation = False
+        self.n_calib = 0
 
     def setup(self):
 
-        self.log.debug("Opening file")
+        self.log.info("Opening file")
         self.eventsource = EventSource.from_config(parent=self)
 
         self.processor = CalibrationCalculator.from_name(
@@ -130,7 +131,7 @@ class CalibrationHDF5Writer(Tool):
 
         group_name = 'tel_' + str(tel_id)
 
-        self.log.debug(f"Open output file {self.output_file}")
+        self.log.info(f"Open output file {self.output_file}")
 
         self.writer = HDF5TableWriter(
             filename=self.output_file, group_name=group_name, overwrite=True
@@ -202,16 +203,16 @@ class CalibrationHDF5Writer(Tool):
 
             # write flatfield results when enough statistics (also for pedestals)
             if (new_ff and new_ped):
-                self.log.debug(f"Write calibration at event n. {count+1}, event id {event.index.event_id} ")
+                self.log.info(f"Write calibration at event n. {count+1}, event id {event.index.event_id} ")
 
-                self.log.debug(f"Ready flatfield data at event n. {count_ff} "
-                                f"stat = {ff_data.n_events} events")
+                self.log.info(f"Ready flatfield data at event n. {count_ff} "
+                              f"stat = {ff_data.n_events} events")
 
                 # write on file
                 self.writer.write('flatfield', ff_data)
 
-                self.log.debug(f"Ready pedestal data at event n. {count_ped}"
-                                f"stat = {ped_data.n_events} events")
+                self.log.info(f"Ready pedestal data at event n. {count_ped} "
+                              f"stat = {ped_data.n_events} events")
 
                 # write only pedestal data used for calibration
                 self.writer.write('pedestal', ped_data)
@@ -223,15 +224,24 @@ class CalibrationHDF5Writer(Tool):
                 self.processor.calculate_calibration_coefficients(event)
 
                 # write calib and pixel status
-                self.log.debug("Write pixel_status data")
+                self.log.info("Write pixel_status data")
                 self.writer.write('pixel_status', status_data)
 
-                self.log.debug("Write calibration data")
+                self.log.info("Write calibration data")
                 self.writer.write('calibration', calib_data)
+                self.n_calib += 1
+
                 if self.one_event:
                     break
 
     def finish(self):
+
+        self.log.info(f"Written {self.n_calib} calibration events")
+        if self.n_calib == 0:
+             self.log.warning(f"!!! No calibration events in the output file !!! : ")
+             self.log.warning(f"flatfiels collected statistics = {self.processor.flatfield.num_events_seen} events")
+             self.log.warning(f"pedestal collected statistics = {self.processor.pedestal.num_events_seen} events")
+
         Provenance().add_output_file(
             self.output_file,
             role='mon.tel.calibration'

--- a/lstchain/tools/lstchain_create_calibration_file.py
+++ b/lstchain/tools/lstchain_create_calibration_file.py
@@ -238,9 +238,10 @@ class CalibrationHDF5Writer(Tool):
 
         self.log.info(f"Written {self.n_calib} calibration events")
         if self.n_calib == 0:
-             self.log.warning(f"!!! No calibration events in the output file !!! : ")
-             self.log.warning(f"flatfiels collected statistics = {self.processor.flatfield.num_events_seen} events")
-             self.log.warning(f"pedestal collected statistics = {self.processor.pedestal.num_events_seen} events")
+             self.log.critical(f"!!! No calibration events in the output file !!! : ")
+             self.log.critical(f"flatfiels collected statistics = {self.processor.flatfield.num_events_seen} events")
+             self.log.critical(f"pedestal collected statistics = {self.processor.pedestal.num_events_seen} events")
+             self.exit(1)
 
         Provenance().add_output_file(
             self.output_file,


### PR DESCRIPTION
This PR add the option to read more than a sub_run file if necessary and improves the calibration out messages. In particular, add a warning in case there is not enough events statistics in the run (as it happened for run 13653)
