### PR TITLE
ctaplot from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - astropy=5
   - pip
   - ctapipe=0.19.2
+  - ctaplot~=0.6.2
   - gammapy=1.1
   - h5py
   - ipython
@@ -33,5 +34,4 @@ dependencies:
   - ctapipe_io_lst=0.22
   - pytest
   - pyirf=0.8
-  - pip:
-      - ctaplot~=0.6.2
+


### PR DESCRIPTION
Related to #1138, update all dependencies to be downloaded from `conda-forge`