### PR TITLE
Patch PR: change default hg_lg_ratio

### DIFF
--- a/lstchain/calib/camera/calibration_calculator.py
+++ b/lstchain/calib/camera/calibration_calculator.py
@@ -76,8 +76,8 @@ class CalibrationCalculator(Component):
     ).tag(config=True)
 
     hg_lg_ratio = traits.Float(
-        17.4,
-        help='HG/LG ratio applied if use_scaled_low_gain is True'
+        1.,
+        help='HG/LG ratio applied if use_scaled_low_gain is True. In case of calibrated data the ratio should be 1.'
     ).tag(config=True)
 
     classes = (

--- a/lstchain/data/catB_camera_calibration_param.json
+++ b/lstchain/data/catB_camera_calibration_param.json
@@ -8,7 +8,6 @@
   "LSTCalibrationCalculator": {
     "squared_excess_noise_factor": 1.222,
     "use_scaled_low_gain": true,
-    "hg_lg_ratio": 17.4,
     "npe_median_cut_outliers": [-5,5],
     "flatfield_product": "FlasherFlatFieldCalculator",
     "pedestal_product": "PedestalIntegrator"


### PR DESCRIPTION
I recently [(PR 1142)](https://github.com/cta-observatory/cta-lstchain/pull/1142) changed the value in the json file equal to the default hg_lg_ratio trailet value (17.4), but that is correct  in the case of not calibrated data,  we instead recalibrate directly already calibrated data, so the correct ratio is supposed to be 1 as it was indeed in the json file (probably time to go on holidays ...).  