### PR TITLE
Pin matplotlib to 3.7.0 to avoid setting deprecated seaborn styles in matplotlib 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'h5py',
         'iminuit>=2',
         'joblib~=1.2.0',
-        'matplotlib~=3.7',
+        'matplotlib~=3.7.0',
         'numba',
         'numpy',
         'pandas',


### PR DESCRIPTION
fixes #1161 