### PR TITLE
Make run_summary script work with ctar1 data, store format string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'astropy~=5.0',
         'bokeh~=2.0',
         'ctapipe~=0.19.2',
-        'ctapipe_io_lst~=0.22.0',
+        'ctapipe_io_lst~=0.22.3',
         'ctaplot~=0.6.4',
         'eventio>=1.9.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=1.1',


### PR DESCRIPTION
Counters are not used in case of CTA R1 input, so just don't compute them.

We rely on the `event_time_s`, `event_time_qns` and the `event_type` reported by EVB for this.

