### PR TITLE
Add missing wild card in pedestal search function to allow looking for symlinks in glob

### DIFF
--- a/lstchain/onsite.py
+++ b/lstchain/onsite.py
@@ -116,7 +116,7 @@ def find_pedestal_file(pro, pedestal_run=None, date=None, base_dir=DEFAULT_BASE_
 
     if pedestal_run is not None:
         # search a specific pedestal run
-        file_list = sorted(ped_dir.rglob(f'{pro}/drs4_pedestal.Run{pedestal_run:05d}.0000.h5'))
+        file_list = sorted(ped_dir.rglob(f'*/{pro}/drs4_pedestal.Run{pedestal_run:05d}.0000.h5'))
 
         if len(file_list) == 0:
             raise IOError(f"Pedestal file from run {pedestal_run} not found\n")


### PR DESCRIPTION
The problem is that without the wildcard rglob/glob from pathlib do not look for symlinks. 