### PR TITLE
Correct the search of interleaved files in the official tree

### DIFF
--- a/lstchain/onsite.py
+++ b/lstchain/onsite.py
@@ -243,7 +243,7 @@ def find_DL1_subrun(run, sub_run, dl1_dir=DEFAULT_DL1_PATH):
 
 def find_interleaved_subruns(run, interleaved_dir):
     '''
-    Find the given subrun of interleaved files
+    Return the list of interleaved files for a given run
     '''
 
     file_list = sorted(interleaved_dir.rglob(f'interleaved_LST-1.Run{run:05d}.*.h5'))

--- a/lstchain/onsite.py
+++ b/lstchain/onsite.py
@@ -241,17 +241,10 @@ def find_DL1_subrun(run, sub_run, dl1_dir=DEFAULT_DL1_PATH):
 
     return file_list[0]
 
-def find_interleaved_subruns(run, r0_dir=DEFAULT_R0_PATH, dl1_dir=DEFAULT_DL1_PATH):
+def find_interleaved_subruns(run, interleaved_dir):
     '''
-    Find the given subrun of interleaved file in onsite tree (dir [dl1_dir]/interleaved)
+    Find the given subrun of interleaved files
     '''
-    
-    # look in R0 to find the date
-    r0_list = find_r0_subrun(run,0,r0_dir)
-    date = r0_list.parent.name
-
-    # search the files 
-    interleaved_dir =  Path(f"{dl1_dir}/{date}/interleaved")
 
     file_list = sorted(interleaved_dir.rglob(f'interleaved_LST-1.Run{run:05d}.*.h5'))
     

--- a/lstchain/scripts/onsite/onsite_create_cat_B_calibration_file.py
+++ b/lstchain/scripts/onsite/onsite_create_cat_B_calibration_file.py
@@ -41,13 +41,10 @@ optional = parser.add_argument_group('optional arguments')
 required.add_argument('-r', '--run_number', help="Run number of interleaved data",
                       type=int, required=True)
 
-version = lstchain.__version__
-
 optional.add_argument('-c', '--catA_calibration_run',
                       help="Cat-A calibration run to be used. If None, it looks for the calibration run of the date of the interleaved data.",
                       type=int)
-optional.add_argument('-v', '--prod_version', help="Version of the production",
-                      default=f"v{version}")
+
 optional.add_argument('-s', '--statistics', help="Number of events for the flat-field and pedestal statistics",
                       type=int, default=2500)
 optional.add_argument('-b', '--base_dir', help="Root dir for the output directory tree", type=Path,
@@ -89,7 +86,7 @@ def main():
     args, remaining_args = parser.parse_known_args()
     run = args.run_number
     n_subruns = args.n_subruns
-    prod_id = args.prod_version
+    prod_id = f"v{lstchain.__version__}"
     stat_events = args.statistics
     
     sys_date = args.sys_date
@@ -122,8 +119,8 @@ def main():
     date = r0_list.parent.name
 
     # find input path
-    ver=version.rsplit(".")
-    input_path = args.interleaved_dir or args.base_dir / 'DL1'/ f"{date}/v{ver[0]}.{ver[1]}/interleaved" 
+    ver = prod_id.rsplit(".")
+    input_path = args.interleaved_dir or args.base_dir / 'DL1'/ f"{date}/{ver[0]}.{ver[1]}/interleaved" 
 
     # verify input file
     input_files = find_interleaved_subruns(run, input_path)

--- a/lstchain/scripts/onsite/onsite_create_cat_B_calibration_files_with_batch.py
+++ b/lstchain/scripts/onsite/onsite_create_cat_B_calibration_files_with_batch.py
@@ -36,10 +36,7 @@ required.add_argument('-r', '--run_list', help="Run numbers of intereleaved data
                       type=int, nargs="+")
 optional.add_argument('-f', '--filters_list', help="Filter list (same order as run list)",
                       type=int, nargs="+")
-version = lstchain.__version__
-optional.add_argument('-v', '--prod_version',
-                      help="Version of the production",
-                      default=f"v{version}")
+
 optional.add_argument('-s', '--statistics',
                       help="Number of events for the flat-field and pedestal statistics",
                       type=int,
@@ -81,7 +78,7 @@ def main():
     
     filters_list = args.filters_list
     
-    prod_id = args.prod_version
+    prod_id = f"v{lstchain.__version__}"
     stat_events = args.statistics
     base_dir = args.base_dir
 
@@ -121,8 +118,8 @@ def main():
         date = r0_list.parent.name
 
         # find input path
-        ver=version.rsplit(".")
-        input_path = args.interleaved_dir or args.base_dir / 'DL1'/ f"{date}/v{ver[0]}.{ver[1]}/interleaved" 
+        ver = prod_id.rsplit(".")
+        input_path = args.interleaved_dir or args.base_dir / 'DL1'/ f"{date}/{ver[0]}.{ver[1]}/interleaved" 
 
         input_files = find_interleaved_subruns(run, input_path)
 


### PR DESCRIPTION
The present official tree path for DL1 files contains also the "short" code version: E.g.
`/fefs/aswg/data/real/DL1/[date]/v0.10`

This was not considered in the  interleaved  search function, this PR correct the search. 

