### PR TITLE
Limit scipy to version before 1.12 which introduces a breaking change

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - toml
   - protobuf=3.20
   - pyparsing
+  - scipy~=1.11.4
   - scikit-learn=1.2
   - sphinx=4
   - sphinx-automodapi
@@ -34,4 +35,3 @@ dependencies:
   - ctapipe_io_lst=0.22
   - pytest
   - pyirf~=0.10.0
-

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'pandas',
         'protobuf~=3.20.0',
         'pyirf~=0.10.0',
-        'scipy>=1.8',
+        'scipy>=1.8,<1.12',
         'seaborn',
         'scikit-learn~=1.2',
         'tables',


### PR DESCRIPTION
The breaking change I encountered is fixed in gammapy main branch but not in a release yet.

Error during lstchain tests with the latest scipy : 

 ```
../../../micromamba-root/envs/lst-dev/lib/python3.10/site-packages/gammapy/utils/roots.py:9: in <module>
    BAD_RES = RootResults(root=np.nan, iterations=0, function_calls=0, flag=0)
E   TypeError: RootResults.__init__() missing 1 required positional argument: 'method'
```
'method' is introduced in scipy 1.12.0
