### PR TITLE
unpin sphinx version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - protobuf=3.20
   - pyparsing
   - scikit-learn=1.2
-  - sphinx=4
+  - sphinx
   - sphinx-automodapi
   - sphinx_rtd_theme
   - sphinx-argparse

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ entry_points["console_scripts"] = lstchain_list + onsite_list + tools_list
 
 tests_require = ["pytest"]
 docs_require = [
-    "sphinx~=4.2",
+    "sphinx",
     "sphinx-automodapi",
     "sphinx_argparse",
     "sphinx_rtd_theme",


### PR DESCRIPTION
Latest doc builds complain that sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0