### PR TITLE
Set minimum intensity by default to 50 p.e. in example DL3 and IRF configs

### DIFF
--- a/docs/examples/dl3_tool_config.json
+++ b/docs/examples/dl3_tool_config.json
@@ -1,7 +1,7 @@
 {
   "EventSelector": {
     "filters": {
-      "intensity": [0, Infinity],
+      "intensity": [50, Infinity],
       "width": [0, Infinity],
       "length": [0, Infinity],
       "r": [0, 1],

--- a/docs/examples/irf_tool_config.json
+++ b/docs/examples/irf_tool_config.json
@@ -1,7 +1,7 @@
 {
   "EventSelector": {
     "filters": {
-      "intensity": [0, Infinity],
+      "intensity": [50, Infinity],
       "width": [0, Infinity],
       "length": [0, Infinity],
       "r": [0, 1],


### PR DESCRIPTION
Also, I still find it confusing that these config files are not in lstchain/data, together with the rest of lstchain config files.
Shouldn't they be placed in the same location?

Moreover, these example config files are not included in the package data in `setup.py`:

```
    package_data={
        'lstchain': [
            'data/*',
            'resources/*',
        ],
    },
```

