### PR TITLE
Fix unsupported operand type in existing DL2 file

### DIFF
--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -178,7 +178,7 @@ def apply_to_file(filename, models_dict, output_dir, config):
     output_file = output_dir.joinpath(filename.name.replace('dl1', 'dl2', 1))
 
     if output_file.exists():
-        raise IOError(output_file + ' exists, exiting.')
+        raise IOError(str(output_file) + ' exists, exiting.')
 
     dl1_keys = get_dataset_keys(filename)
 


### PR DESCRIPTION
This PR solves the operand type error when raising an error because the output file already exists.