### PR TITLE
Small update source-dependent DL3 step

### DIFF
--- a/lstchain/tools/lstchain_create_dl3_file.py
+++ b/lstchain/tools/lstchain_create_dl3_file.py
@@ -476,6 +476,9 @@ class DataReductionFITSWriter(Tool):
                 "Remove duplicated events: a ratio of duplicated events is "
                 f"{duplicated_events_ratio}"
             )
+        
+        # Sort the data frame based on event_id
+        self.data.sort('event_id')
 
     def start(self):
 


### PR DESCRIPTION
There are two small updates in this PR.
1. Sort DL3 file based on event_id after stacking data frame for each assumed source position (on, off_180 etc), just not to confuse analyzers
2. Use the same reco position (derived from the first event) for all events. The reconstructed position fields were filled with the assumed source positions (ON and OFF) for each event. ON and OFF positions were selected based on the camera frame with respect to the source position on the camera. So the assumed OFF positions in ICRS frame differed for each event in principle. But, sometimes not all OFF events are extracted for higher analysis (gammapy) mostly with pre-defined region cut (0.1 degrees, stored in the header) mostly because of the telescope tracking condition. This PR solves such issue.
![image](https://github.com/cta-observatory/cta-lstchain/assets/31307823/1192c5a9-4e55-4c30-9165-e7caa5719845)
