### PR TITLE
Update dl1 to dl2 script (Less required memory and less required step)

### DIFF
--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -728,10 +728,11 @@ def apply_models(dl1,
                          "the predicted probabilty to assign as gammaness is unclear."
                          "Please check training data")
 
-    # gammaness is the prediction probability for the first class (0)
-    dl2['gammaness'] = probs[:, 0]
-    col = list(classifier.classes_).index(0)
-    dl2['reco_type'] = np.where(probs[:, col] > 0.5, 0, 101)
+    # gammaness is the prediction probability for the class 0 (proton: class 101)
+    mc_type_gamma, mc_type_proton = 0, 101
+    col = list(classifier.classes_).index(mc_type_gamma)
+    dl2['gammaness'] = probs[:, col]
+    dl2['reco_type'] = np.where(probs[:, col] > 0.5, mc_type_gamma, mc_type_proton)
     del classifier
 
     return dl2

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -720,9 +720,7 @@ def apply_models(dl1,
     
     if isinstance(classifier, (str, bytes, Path)):
         classifier = joblib.load(classifier)
-    dl2['reco_type'] = classifier.predict(dl2[classification_features]).astype(int)
     probs = classifier.predict_proba(dl2[classification_features])
-    del classifier
 
     # This check is valid as long as we train on only two classes (gammas and protons)
     if probs.shape[1] > 2:
@@ -732,6 +730,9 @@ def apply_models(dl1,
 
     # gammaness is the prediction probability for the first class (0)
     dl2['gammaness'] = probs[:, 0]
+    col = list(classifier.classes_).index(0)
+    dl2['reco_type'] = np.where(probs[:, col] > 0.5, 0, 101)
+    del classifier
 
     return dl2
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -649,15 +649,16 @@ def apply_models(dl1,
     elif config['disp_method'] == 'disp_norm_sign':
         if isinstance(reg_disp_norm, (str, bytes, Path)):
             reg_disp_norm = joblib.load(reg_disp_norm)
+        disp_norm = reg_disp_norm.predict(dl2[disp_regression_features])
+        del reg_disp_norm
+
         if isinstance(cls_disp_sign, (str, bytes, Path)):
             cls_disp_sign = joblib.load(cls_disp_sign)
-        disp_norm = reg_disp_norm.predict(dl2[disp_regression_features])
         disp_sign_proba = cls_disp_sign.predict_proba(dl2[disp_classification_features])
         col = list(cls_disp_sign.classes_).index(1)
         disp_sign = np.where(disp_sign_proba[:, col] > 0.5, 1, -1)
-
-        del reg_disp_norm
         del cls_disp_sign
+
         dl2['reco_disp_norm'] = disp_norm
         dl2['reco_disp_sign'] = disp_sign
         dl2['reco_disp_sign_proba'] = disp_sign_proba[:, 0]

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -8,7 +8,6 @@ Run lstchain_dl1_to_dl2 --help to see the options.
 
 import argparse
 from pathlib import Path
-import joblib
 import logging
 import numpy as np
 import pandas as pd

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -75,7 +75,7 @@ parser.add_argument('--config', '-c',
                     required=False)
 
 
-def apply_to_file(filename, models_dict, output_dir, config):
+def apply_to_file(filename, models_path_dict, output_dir, config):
 
     data = pd.read_hdf(filename, key=dl1_params_lstcam_key)
 
@@ -130,17 +130,17 @@ def apply_to_file(filename, models_dict, output_dir, config):
 
         if config['disp_method'] == 'disp_vector':
             dl2 = dl1_to_dl2.apply_models(data,
-                                          models_dict['cls_gh'],
-                                          models_dict['reg_energy'],
-                                          reg_disp_vector=models_dict['disp_vector'],
+                                          models_path_dict['cls_gh'],
+                                          models_path_dict['reg_energy'],
+                                          reg_disp_vector=models_path_dict['disp_vector'],
                                           effective_focal_length=effective_focal_length,
                                           custom_config=config)
         elif config['disp_method'] == 'disp_norm_sign':
             dl2 = dl1_to_dl2.apply_models(data,
-                                          models_dict['cls_gh'],
-                                          models_dict['reg_energy'],
-                                          reg_disp_norm=models_dict['disp_norm'],
-                                          cls_disp_sign=models_dict['disp_sign'],
+                                          models_path_dict['cls_gh'],
+                                          models_path_dict['reg_energy'],
+                                          reg_disp_norm=models_path_dict['disp_norm'],
+                                          cls_disp_sign=models_path_dict['disp_sign'],
                                           effective_focal_length=effective_focal_length,
                                           custom_config=config)
 
@@ -171,17 +171,17 @@ def apply_to_file(filename, models_dict, output_dir, config):
 
             if config['disp_method'] == 'disp_vector':
                 dl2 = dl1_to_dl2.apply_models(data_with_srcdep_param,
-                                                 models_dict['cls_gh'],
-                                                 models_dict['reg_energy'],
-                                                 reg_disp_vector=models_dict['disp_vector'],
+                                                 models_path_dict['cls_gh'],
+                                                 models_path_dict['reg_energy'],
+                                                 reg_disp_vector=models_path_dict['disp_vector'],
                                                  effective_focal_length=effective_focal_length,
                                                  custom_config=config)
             elif config['disp_method'] == 'disp_norm_sign':
                 dl2 = dl1_to_dl2.apply_models(data_with_srcdep_param,
-                                                 models_dict['cls_gh'],
-                                                 models_dict['reg_energy'],
-                                                 reg_disp_norm=models_dict['disp_norm'],
-                                                 cls_disp_sign=models_dict['disp_sign'],
+                                                 models_path_dict['cls_gh'],
+                                                 models_path_dict['reg_energy'],
+                                                 reg_disp_norm=models_path_dict['disp_norm'],
+                                                 cls_disp_sign=models_path_dict['disp_sign'],
                                                  effective_focal_length=effective_focal_length,
                                                  custom_config=config)
 
@@ -266,17 +266,16 @@ def main():
 
     config = replace_config(standard_config, custom_config)
 
-    # load models once and for all
-    models_dict = {'reg_energy': joblib.load(Path(args.path_models, 'reg_energy.sav'))}
-    models_dict['cls_gh'] = joblib.load(Path(args.path_models, 'cls_gh.sav'))
+    models_path_dict = {'reg_energy': Path(args.path_models, 'reg_energy.sav')}
+    models_path_dict['cls_gh'] = Path(args.path_models, 'cls_gh.sav')
     if config['disp_method'] == 'disp_vector':
-        models_dict['disp_vector'] = joblib.load(Path(args.path_models, 'reg_disp_vector.sav'))
+        models_path_dict['disp_vector'] = Path(args.path_models, 'reg_disp_vector.sav')
     elif config['disp_method'] == 'disp_norm_sign':
-        models_dict['disp_norm'] = joblib.load(Path(args.path_models, 'reg_disp_norm.sav'))
-        models_dict['disp_sign'] = joblib.load(Path(args.path_models, 'cls_disp_sign.sav'))
+        models_path_dict['disp_norm'] = Path(args.path_models, 'reg_disp_norm.sav')
+        models_path_dict['disp_sign'] = Path(args.path_models, 'cls_disp_sign.sav')
 
     for filename in args.input_files:
-        apply_to_file(filename, models_dict, args.output_dir, config)
+        apply_to_file(filename, models_path_dict, args.output_dir, config)
 
 
 


### PR DESCRIPTION
This PR updates the dl1 to dl2 step:

- Load each random forest model just before using it. Now the script loads all models at the beginning of the script and it consumes much memory. Just pass the model path to `apply_models`. This option was already implemented in `apply_models`, but not used for the script before.
- This script applies the particle classification models to the data twice for `gammaness` and `reco_type`. But `reco_type` can be set based on `gammaness` as suggested by @maxnoe here. Even, we can remove `reco_type` which will not be used for the analysis.
https://github.com/cta-observatory/cta-lstchain/pull/1077#discussion_r1104715136