### PR TITLE
Require .py extension for identifying scripts in install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@ from setuptools import setup, find_packages
 import os
 
 
-def find_scripts(script_dir, prefix):
+def find_scripts(script_dir, prefix, suffix='.py'):
     script_list = [
-        os.path.splitext(f)[0] for f in os.listdir(script_dir) if f.startswith(prefix)
+        os.path.splitext(f)[0] for f in os.listdir(script_dir) 
+        if (f.startswith(prefix) and f.endswith(suffix))
     ]
     script_dir = script_dir.replace("/", ".")
     point_list = []


### PR DESCRIPTION
Require .py extension for identifying scripts.
Solves "error in setup command: Duplicate element EntryPoint" issue that comes up when executing pip install if the scripts directory contains e.g. an emacs backup file of one of the scripts (lstchain_***.py~)