### PR TITLE
Compute cleaning thresholds in lstchain_dvr_pixselector

### DIFF
--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -520,15 +520,15 @@ def main():
             picture_threshold = np.floor(meanq)
             if picture_threshold % 2 != 0:
                 picture_threshold += 1  # We change picture_threshold in steps of 2 p.e.
-                boundary_threshold = picture_threshold / 2
-                newconfig = get_standard_config()['tailcuts_clean_with_pedestal_threshold']
-                newconfig['picture_thresh'] = picture_threshold
-                newconfig['boundary_thresh'] = boundary_threshold
-                run = int(file.name[file.name.find('Run')+3:-3])
-                json_filename = Path(output_dir, f'dl1ab_Run{run:05d}.json')
-                dump_config({'tailcuts_clean_with_pedestal_threshold': 
+            boundary_threshold = picture_threshold / 2
+            newconfig = get_standard_config()['tailcuts_clean_with_pedestal_threshold']
+            newconfig['picture_thresh'] = picture_threshold
+            newconfig['boundary_thresh'] = boundary_threshold
+            run = int(file.name[file.name.find('Run')+3:-3])
+            json_filename = Path(output_dir, f'dl1ab_Run{run:05d}.json')
+            dump_config({'tailcuts_clean_with_pedestal_threshold': 
                              newconfig}, json_filename, overwrite=True)
-                log.info(json_filename)
+            log.info(json_filename)
 
     log.info('lstchain_dvr_pixselector finished successfully!')
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -505,8 +505,19 @@ def main():
                 continue
 
     log.info('Output files:')
+    # We now create also .json files with recommended image cleaning
+    # settings for lstchain_dl1ab. We determine the picture threshold 
+    # from the values of min_charge_for_certain_selection:
+    #
     for file in list_of_output_files:
         log.info(file)
+        dvr_settings = read_table(file, '/run_summary'))
+        meanq = dvr_settings['mean_charge_for_certain_selection'].mean()
+        picture_threshold = np.floor(meanq)
+        if picture_threshold % 2 != 0:
+            picture_threshold += 1
+        
+
     log.info('lstchain_dvr_pixselector finished successfully!')
 
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -163,6 +163,8 @@ def main():
     if args.action == 'compute_dvr_settings':
         log.info('I will calculate the Data Volume Reduction parameters from '
                  'the input DL1 files, and write them to the output file')
+        log.info('A maximum of %d subruns per run will be processed',
+                 max_number_of_processed_subruns)
     elif args.action == 'create_pixel_masks':
         write_pixel_masks = True
         log.info('Option to write pixel masks in output file selected. I will '
@@ -613,16 +615,17 @@ def find_DVR_threshold(charges_cosmics, max_pix_survival_fraction,
 
 
 def get_input_files(all_dl1_files, max_number_of_processed_subruns):
-"""
-Reduce the number of DL1 files in all_dl1_files to a maximum of
-max_number_of_processed_subruns per run
-"""
+    """
+    Reduce the number of DL1 files in all_dl1_files to a maximum of
+    max_number_of_processed_subruns per run
+    """
 
     runlist = np.unique([parse_dl1_filename(f).run for f in all_dl1_files])
 
     dl1_files = []
     for run in runlist:
-        file_list = [f for f in fnames if f.find(f'dl1_LST-1.Run{run:05d}')>0]
+        file_list = [f for f in all_dl1_files 
+                     if f.find(f'dl1_LST-1.Run{run:05d}')>0]
         step = len(file_list) / max_number_of_processed_subruns
         k = 0
         while np.round(k) < len(file_list):

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -672,7 +672,7 @@ def get_input_files(all_dl1_files, max_number_of_processed_subruns):
 
     return dl1_files
 
-def get_typical_dvr_min_charge(dvrtable)
+def get_typical_dvr_min_charge(dvrtable):
     """
     From a DVR_settings table determine the typical (most frequent) 
     value of the "min_charge_for_certain_selection" for the subruns stored 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -505,19 +505,26 @@ def main():
                 continue
 
     log.info('Output files:')
+  
     # We now create also .json files with recommended image cleaning
     # settings for lstchain_dl1ab. We determine the picture threshold 
     # from the values of min_charge_for_certain_selection:
-    #
+  
     for file in list_of_output_files:
         log.info(file)
         dvr_settings = read_table(file, '/run_summary'))
         meanq = dvr_settings['mean_charge_for_certain_selection'].mean()
         picture_threshold = np.floor(meanq)
         if picture_threshold % 2 != 0:
-            picture_threshold += 1
-        
-
+            picture_threshold += 1  # We change picture_threshold in steps of 2 p.e.
+        boundary_threshold = picture_threshold / 2
+        newconfig = get_standard_config()['tailcuts_clean_with_pedestal_threshold']
+        newconfig['picture_thresh'] = picture_threshold
+        newconfig['boundary_thresh'] = boundary_threshold
+        json_filename = Path(output_dir, f'dl1ab_Run{parse_dl1_filename(file).run:05d}.json')
+        dump_config({'tailcuts_clean_with_pedestal_threshold': newconfig}, 
+                    json_filename, overwrite=True)
+        log.info('     %s', json_filename)
     log.info('lstchain_dvr_pixselector finished successfully!')
 
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -688,7 +688,7 @@ def get_typical_dvr_min_charge(dvrtable):
     # if less than the above fraction of subruns have the same value
     # of min_charge_for_certain_selection a warning will be issued.
     
-    allqs = dvr_table['min_charge_for_certain_selection'] 
+    allqs = dvrtable['min_charge_for_certain_selection'] 
     sortedqs = np.sort(allqs)
     # these are integer numbers pf p.e.'s
 

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -226,7 +226,7 @@ def main():
 
     # Cuts to identify muon rings candidates (in order to save them fully)
     # These are conservative cuts which are fulfilled comfortable by all "good
-    # quality" rigs that are actually used for calibration:
+    # quality" rings that are actually used for calibration:
     muon_ring_min_intensity = 1000
     muon_ring_min_length = 0.5
     muon_ring_min_n_pixels = 50

--- a/lstchain/scripts/lstchain_dvr_pixselector.py
+++ b/lstchain/scripts/lstchain_dvr_pixselector.py
@@ -644,6 +644,9 @@ def get_input_files(all_dl1_files, max_number_of_processed_subruns):
     for run in runlist:
         file_list = [f for f in all_dl1_files 
                      if f.find(f'dl1_LST-1.Run{run:05d}')>0]
+        if len(file_list) <= max_number_of_processed_subruns:
+            dl1_files.extend(file_list)
+            continue
         step = len(file_list) / max_number_of_processed_subruns
         k = 0
         while np.round(k) < len(file_list):


### PR DESCRIPTION
When used for determining the settings for the Data Volume Reduction (DVR) of a given run, the program now outputs also a .json file (adapted to the NSB conditions) for use in the lstchain_dl1ab step 