### PR TITLE
Require ctapipe_io_lst 0.23, add evb preprocessing to run summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   pyflakes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -43,7 +43,7 @@ jobs:
         ctapipe-version: ["v0.19.2"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
     needs: pyflakes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/environment.yml
+++ b/environment.yml
@@ -33,6 +33,6 @@ dependencies:
   - pandas>=2
   - pymongo
   - seaborn
-  - ctapipe_io_lst=0.22
+  - ctapipe_io_lst=0.23
   - pytest
   - pyirf~=0.10.0

--- a/lstchain/tools/lstchain_create_drs4_pedestal_file.py
+++ b/lstchain/tools/lstchain_create_drs4_pedestal_file.py
@@ -14,7 +14,7 @@ from ctapipe.core.traits import (
     flag,
 )
 from ctapipe.io.hdf5tableio import HDF5TableWriter
-from ctapipe_io_lst import LSTEventSource, EVBPreprocessing, TriggerBits
+from ctapipe_io_lst import LSTEventSource, EVBPreprocessingFlag, TriggerBits
 from ctapipe_io_lst.calibration import get_spike_A_positions
 from ctapipe_io_lst.constants import (
     N_CAPACITORS_PIXEL,
@@ -273,10 +273,10 @@ class DRS4PedestalAndSpikeHeight(Tool):
         check_large_values = False
         check_negative = True
         check_small = True
-        
+
         if self.source.cta_r1:
             preprocessing = self.source.evb_preprocessing[TriggerBits.MONO]
-            if EVBPreprocessing.BASELINE_SUBTRACTION in preprocessing:
+            if EVBPreprocessingFlag.BASELINE_SUBTRACTION in preprocessing:
                 check_large_values = True
                 check_negative = False
                 check_small = False

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'astropy~=5.0',
         'bokeh~=2.0',
         'ctapipe~=0.19.2',
-        'ctapipe_io_lst~=0.22.3',
+        'ctapipe_io_lst~=0.23.0',
         'ctaplot~=0.6.4',
         'eventio>=1.9.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=1.1',


### PR DESCRIPTION
This updates to ctapipe_io_lst, which includes the parsing of the EVB preprocessing steps.

This is also stored into the runsummary.

To not completely dominate the run summary with the string representation, I put the integer value and only for MONO events.

Here is how you can get something more human readable from that:

```
In [1]: from ctapipe_io_lst.evb_preprocessing import EVBPreprocessingFlag

In [2]: EVBPreprocessingFlag(103)
Out[2]: <EVBPreprocessingFlag.GAIN_SELECTION|BASELINE_SUBTRACTION|DELTA_T_CORRECTION|PEDESTAL_SUBTRACTION|PE_CALIBRATION: 103>

In [3]: EVBPreprocessingFlag(3)
Out[3]: <EVBPreprocessingFlag.GAIN_SELECTION|BASELINE_SUBTRACTION: 3>

In [4]: EVBPreprocessingFlag(2)
Out[4]: <EVBPreprocessingFlag.BASELINE_SUBTRACTION: 2>
```