### PR TITLE
Update codecov version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           pytest -n auto --dist loadscope --cov --cov-report=xml -m 'private_data or not private_data' lstchain
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           # disable gcov, not needed
           functionalities: gcov


### PR DESCRIPTION
It seems that coverage reports are not being uploaded to codecov, maybe because the old version