### PR TITLE
Computation of pointing-dependent weights for MC events 

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -65,6 +65,10 @@
     "fraction_cleaning_intensity": 0.03
   },
 
+  "random_forest_weight_settings": {
+    "pointing_wise_weights": true
+  },
+
   "random_forest_energy_regressor_args": {
     "max_depth": 30,
     "min_samples_leaf": 10,
@@ -79,8 +83,7 @@
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
-    "warm_start": false,
-    "pointing_wise_weights": true
+    "warm_start": false
   },
 
   "random_forest_disp_regressor_args": {
@@ -97,8 +100,7 @@
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
-    "warm_start": false,
-    "pointing_wise_weights": true
+    "warm_start": false
   },
 
   "random_forest_disp_classifier_args": {
@@ -116,8 +118,7 @@
     "oob_score": false,
     "random_state": 42,
     "warm_start": false,
-    "class_weight": null,
-    "pointing_wise_weights": true
+    "class_weight": null
   },
 
   "random_forest_particle_classifier_args": {
@@ -135,8 +136,7 @@
     "oob_score": false,
     "random_state": 42,
     "warm_start": false,
-    "class_weight": null,
-    "pointing_wise_weights": true
+    "class_weight": null
   },
 
 

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -79,7 +79,8 @@
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
-    "warm_start": false
+    "warm_start": false,
+    "pointing_wise_weights": true
   },
 
   "random_forest_disp_regressor_args": {
@@ -96,7 +97,8 @@
     "min_weight_fraction_leaf": 0.0,
     "oob_score": false,
     "random_state": 42,
-    "warm_start": false
+    "warm_start": false,
+    "pointing_wise_weights": true
   },
 
   "random_forest_disp_classifier_args": {
@@ -114,7 +116,8 @@
     "oob_score": false,
     "random_state": 42,
     "warm_start": false,
-    "class_weight": null
+    "class_weight": null,
+    "pointing_wise_weights": true
   },
 
   "random_forest_particle_classifier_args": {
@@ -132,7 +135,8 @@
     "oob_score": false,
     "random_state": 42,
     "warm_start": false,
-    "class_weight": null
+    "class_weight": null,
+    "pointing_wise_weights": true
   },
 
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -119,7 +119,7 @@ def train_disp_vector(train, custom_config=None, predict_features=None):
     reg = model(**disp_regression_args)
     x = train[features]
     y = np.transpose([train[f] for f in predict_features])
-    reg.fit(x, y)
+    reg.fit(x, y, sample_weight=train['weight'])
 
     logger.info("Model {} trained!".format(model))
 
@@ -153,7 +153,7 @@ def train_disp_norm(train, custom_config=None, predict_feature='disp_norm'):
     reg = model(**disp_regression_args)
     x = train[features]
     y = np.transpose(train[predict_feature])
-    reg.fit(x, y)
+    reg.fit(x, y, sample_weight=train['weight'])
 
     logger.info("Model {} trained!".format(model))
 
@@ -187,7 +187,7 @@ def train_disp_sign(train, custom_config=None, predict_feature='disp_sign'):
     clf = model(**classification_args)
     x = train[features]
     y = np.transpose(train[predict_feature])
-    clf.fit(x, y)
+    clf.fit(x, y, sample_weight=train['weight'])
 
     logger.info("Model {} trained!".format(model))
 
@@ -224,7 +224,8 @@ def train_reco(train, custom_config=None):
 
     reg_energy = model(**energy_regression_args)
     reg_energy.fit(train[energy_features],
-                   train['log_mc_energy'])
+                   train['log_mc_energy'], sample_weight = train['weight']
+    )
 
     logger.info("Random Forest trained!")
     logger.info("Given disp_features: ", disp_features)
@@ -232,7 +233,8 @@ def train_reco(train, custom_config=None):
 
     reg_disp = RandomForestRegressor(**disp_regression_args)
     reg_disp.fit(train[disp_features],
-                 train['disp_norm'])
+                 train['disp_norm'],
+                 sample_weight=train['weight'])
 
     logger.info("Random Forest trained!")
     logger.info("Done!")
@@ -268,7 +270,8 @@ def train_sep(train, custom_config=None):
     clf = model(**classification_args)
 
     clf.fit(train[features],
-            train['mc_type'])
+            train['mc_type'],
+            sample_weight=train['weight'])
     logger.info("Random Forest trained!")
     return clf
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -444,6 +444,7 @@ def build_models(filegammas, fileprotons,
     if pointing_wise_weights:
         # Give same total weight to all events in every pointing node, by
         # applying event-wise weights which depend on the statistics per node
+        # The weight is written to a new column of df_gamma, called 'weight'
         _, _ = utils.compute_rf_event_weights(df_gamma)
     else:
         df_gamma['weight'] = np.ones(len(df_gamma))
@@ -511,6 +512,7 @@ def build_models(filegammas, fileprotons,
     if pointing_wise_weights:
         # Give same total weight to all events in every pointing node, by
         # applying event-wise weights which depend on the statistics per node
+        # The weight is written to a new column of df_gamma, called 'weight'
         _, _ = utils.compute_rf_event_weights(df_proton)
     else:
         df_proton['weight'] = np.ones(len(df_proton))

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -78,8 +78,16 @@ def train_energy(train, custom_config=None):
     logger.info("Training Random Forest Regressor for Energy Reconstruction...")
 
     reg = model(**energy_regression_args)
-    reg.fit(train[features],
-            train['log_mc_energy'])
+
+    if 'pointing_wise_weights' in energy_regression_args:
+        logger.info("Pointing-wise event weighting activated")
+        _, _ = utils.compute_rf_event_weights(train)
+        reg.fit(train[features],
+                train['log_mc_energy'],
+                sample_weight=train['weight'])
+    else:
+        reg.fit(train[features],
+                train['log_mc_energy'])
 
     logger.info("Model {} trained!".format(model))
     return reg

--- a/lstchain/reco/tests/test_utils.py
+++ b/lstchain/reco/tests/test_utils.py
@@ -237,3 +237,14 @@ def test_apply_src_r_cut(simulated_dl1_file):
     src_r_max = srcdep_config['train_gamma_src_r_deg'][1]
     params = apply_src_r_cut(params, src_r_min, src_r_max)
     assert (params.event_id.values == np.arange(100, 110, 1)).all()
+
+def test_compute_rf_event_weights():
+    from lstchain.reco.utils import compute_rf_event_weights
+
+    alt_tel = np.append(3*[0.41109], 6*[0.53508])
+    az_tel = np.append(3*[1.32615], 6*[1.38195])
+
+    df = pd.DataFrame({"alt_tel": alt_tel, "az_tel": az_tel})
+    _, _ = compute_rf_event_weights(df)
+    np.testing.assert_array_equal(df['weight'],
+                                  np.append(3*[4.5/3], 6*[4.5/6]))

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -881,7 +881,7 @@ def compute_rf_event_weights(events):
     # rounding issues:
     alt = np.round(events['alt_tel'], decimals=5)
     az = np.round(events['az_tel'], decimals=5)
-    pointings = np.unique(np.array([alt, az]).T, axis=1)
+    pointings = np.unique([alt, az], axis=1)
 
     # Find the total statistics in each of the pointings:
     stats = []

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -882,7 +882,7 @@ Parameters
     -------
 
     pointings: ndarray of shape (number_of_pointings, 2) Alt Az (in radians)
-    for each of the identified telescope pointings in the input MC sample
+        for each of the identified telescope pointings in the input MC sample
 
     weight_per_pointing: ndarray [number_of_pointings] weight for each of the
     identified pointings. The weight is equal to the mean number of training

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -870,8 +870,29 @@ def compute_rf_event_weights(events):
     statistics present in each pointing node of the MC training sample,
     to avoid "jumps" in the performance of the random forests
 
-    events: a DL1 parameters dataframe
+    events: a DL1 parameters dataframe. The table is modified in place by the
+    addition of a column called 'weight' (unless it exists already). The
+    column contains an event-wise weight to be used in the Random Forest
+    training, to give each of the telescope pointings in the training sample
+    the same overall weight in the training.
+
+    Returns: pointings, weight_per_pointing
+
+    pointings: ndarray of shape (number_of_pointings, 2) Alt Az (in radians)
+    for each of the identified telescope pointings in the input MC sample
+
+    weight_per_pointing: ndarray [number_of_pointings] weight for each of the
+    identified pointings. The weight is equal to the mean number of training
+    events per node divided by the number of training events in the specific
+    node. If used as sample_weight in scikit-learn, each node will have the
+    same total weight in the training of the Random Forests
+
     """
+
+    if 'weight' in events.columns:
+        log.warning("compute_rf_event_weights: DL2 table already contains")
+        log.warning("a column called weight. It will NOT be overwritten!")
+        return None, None
 
     # Add a 'weight' column to the input table
     weights = np.array(np.ones(len(events)))
@@ -907,5 +928,5 @@ def compute_rf_event_weights(events):
 
     events['weight'] = weights
 
-    # return the indetified pointings and weights set (for checks)
+    # return the identified pointings and weights set (for checks)
     return pointings, weight_per_pointing

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -869,8 +869,9 @@ def compute_rf_event_weights(events):
     Compute event-wise weights. Can be used for correcting for the different
     statistics present in each pointing node of the MC training sample,
     to avoid "jumps" in the performance of the random forests
-Parameters
-----------
+
+    Parameters
+    ----------
     events : `~pd.DataFrame`
         DL1 parameters dataframe. The table is modified in place by the
     addition of a column called 'weight' (unless it exists already). The

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -877,7 +877,8 @@ Parameters
     training, to give each of the telescope pointings in the training sample
     the same overall weight in the training.
 
-    Returns: pointings, weight_per_pointing
+    Returns
+    -------
 
     pointings: ndarray of shape (number_of_pointings, 2) Alt Az (in radians)
     for each of the identified telescope pointings in the input MC sample

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -881,9 +881,7 @@ def compute_rf_event_weights(events):
     # rounding issues:
     alt = np.round(events['alt_tel'], decimals=5)
     az = np.round(events['az_tel'], decimals=5)
-    dummy = np.unique(np.array([alt, az]).T, axis=0)
-    # sort in azimuth:
-    pointings = dummy[np.argsort(dummy[:,1])]
+    pointings = np.unique(np.array([alt, az]).T, axis=1)
 
     # Find the total statistics in each of the pointings:
     stats = []

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -869,7 +869,8 @@ def compute_rf_event_weights(events):
     Compute event-wise weights. Can be used for correcting for the different
     statistics present in each pointing node of the MC training sample,
     to avoid "jumps" in the performance of the random forests
-
+Parameters
+----------
     events: a DL1 parameters dataframe. The table is modified in place by the
     addition of a column called 'weight' (unless it exists already). The
     column contains an event-wise weight to be used in the Random Forest

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -871,7 +871,8 @@ def compute_rf_event_weights(events):
     to avoid "jumps" in the performance of the random forests
 Parameters
 ----------
-    events: a DL1 parameters dataframe. The table is modified in place by the
+    events : `~pd.DataFrame`
+        DL1 parameters dataframe. The table is modified in place by the
     addition of a column called 'weight' (unless it exists already). The
     column contains an event-wise weight to be used in the Random Forest
     training, to give each of the telescope pointings in the training sample

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -881,7 +881,7 @@ def compute_rf_event_weights(events):
     # rounding issues:
     alt = np.round(events['alt_tel'], decimals=5)
     az = np.round(events['az_tel'], decimals=5)
-    pointings = np.unique([alt, az], axis=1)
+    pointings = np.unique([alt, az], axis=1).T
 
     # Find the total statistics in each of the pointings:
     stats = []


### PR DESCRIPTION
This is to avoid jumps in RF performance in the "mid-points" between training pointing nodes, just because the event statistics occasionally have jumps between neighboring nodes. 

The idea is to  use "sample_weight", i.e. a weight for each event in the training set, calculated such that each of the pointing nodes has the same total weight.

The calculation is done with all events that are passed to the RFs.  Of course, the energy (and impact) range of those events between culmination and high zenith change a lot, so "same number of events" does not mean much when comparing such extremes, but the point here is to avoid steps between _neighboring_ bins (and for those, indeed, the numbers of events are comparable quantities). Only if the impact and energy ranges were poorly chosen (and distributions truncated) would this normalization result in performance jumps like the ones we have without it.

