### PR TITLE
Fix original MC nsb reading

### DIFF
--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1263,14 +1263,16 @@ def remove_duplicated_events(data):
 
 def extract_simulation_nsb(filename):
     """
-    Get current run NSB from configuration in simtel file
+    Get current run NSB from configuration in simtel file.
+
+    WARNING : In current MC, correct NSB are logged after 'STORE_PHOTOELECTRONS' entries
+    In any new production, behaviour needs to be verified.
+    New version of simtel will allow to use better metadata.
+
     :param str filename: Input file name
     :return dict of `float` by tel_id: NSB rate
     """
     nsb = {}
-    # In current MC, correct NSB are logged after 'STORE_PHOTOELECTRONS' entries
-    # TODO In any new production, behaviour needs to be verified.
-    # New version of simtel will allow to use better metadata
     next_nsb = False
     tel_id = 1
     with SimTelFile(filename) as f:

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1278,7 +1278,7 @@ def extract_simulation_nsb(filename):
             for _, line in f.history:
                 line = line.decode('utf-8').strip().split(' ')
                 if next_nsb and line[0] == 'NIGHTSKY_BACKGROUND':
-                    nsb[tel_id] = line[1].strip('all:')
+                    nsb[tel_id] = float(line[1].strip('all:'))
                     tel_id = tel_id+1
                 if line[0] == 'STORE_PHOTOELECTRONS':
                     next_nsb = True

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1283,6 +1283,10 @@ def extract_simulation_nsb(filename):
                 next_nsb = True
             else:
                 next_nsb = False
+    log.warning('Original MC night sky background extracted from the config history in the simtel file.\n'
+                'This is done for existing LST MC such as the one created using: '
+                'https://github.com/cta-observatory/lst-sim-config/tree/sim-tel_LSTProd2_MAGICST0316'
+                '\nExtracted values are: ' + str(np.asarray(nsb)) + 'GHz. Check that it corresponds to expectations.')
     return nsb
 
 

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1274,19 +1274,15 @@ def extract_simulation_nsb(filename):
     next_nsb = False
     tel_id = 1
     with SimTelFile(filename) as f:
-        try:
-            for _, line in f.history:
-                line = line.decode('utf-8').strip().split(' ')
-                if next_nsb and line[0] == 'NIGHTSKY_BACKGROUND':
-                    nsb[tel_id] = float(line[1].strip('all:'))
-                    tel_id = tel_id+1
-                if line[0] == 'STORE_PHOTOELECTRONS':
-                    next_nsb = True
-                else:
-                    next_nsb = False
-        except Exception as e:
-            log.error('Unexpected end of %s,\n caught exception %s', filename, e)
-            raise e
+        for _, line in f.history:
+            line = line.decode('utf-8').strip().split(' ')
+            if next_nsb and line[0] == 'NIGHTSKY_BACKGROUND':
+                nsb[tel_id] = float(line[1].strip('all:'))
+                tel_id = tel_id+1
+            if line[0] == 'STORE_PHOTOELECTRONS':
+                next_nsb = True
+            else:
+                next_nsb = False
     return nsb
 
 

--- a/lstchain/io/tests/test_io.py
+++ b/lstchain/io/tests/test_io.py
@@ -156,8 +156,7 @@ def test_extract_simulation_nsb(mc_gamma_testfile):
     from lstchain.io.io import extract_simulation_nsb
 
     nsb = extract_simulation_nsb(mc_gamma_testfile)
-    assert np.isclose(nsb[0], 0.246, rtol=0.1)
-    assert np.isclose(nsb[1], 0.217, rtol=0.1)
+    assert np.isclose(nsb[1], 0.246, rtol=0.1)
 
 
 def test_remove_duplicated_events():

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -433,10 +433,8 @@ def r0_to_dl1(
                 charge_spe_cumulative_pdf = interp1d(spe_integral, spe[0], kind='cubic',
                                                      bounds_error=False, fill_value=0.,
                                                      assume_sorted=True)
-                allowed_tel = np.zeros(len(nsb_original), dtype=bool)
-                allowed_tel[np.array(config['source_config']['LSTEventSource']['allowed_tels'])] = True
                 logger.info('Tuning NSB on MC waveform from '
-                            + str(np.asarray(nsb_original)[allowed_tel])
+                            + str(np.asarray(nsb_original))
                             + 'GHz to {0:d}%'.format(int(nsb_tuning_ratio * 100 + 100.5))
                             + ' for telescopes ids ' + str(config['source_config']['LSTEventSource']['allowed_tels']))
                 nsb_tuning_args = [nsb_tuning_ratio, nsb_original, pulse_template, charge_spe_cumulative_pdf]


### PR DESCRIPTION
closes #1271 

Change the behaviour of `extract_simulation_nsb` to identify the nsb entries used with the telescopes and ignore other entries (for prod5 and LSTprod2). Return a dictionary to be accessed by tel_id.

Replace the access to simtel object by hand in favour of `SimTelFile.history`. 