### PR TITLE
NSB tunning : pre-generated NSB only waveforms and a new class 

### DIFF
--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -280,7 +280,8 @@
   "waveform_nsb_tuning":{
     "nsb_tuning": false,
     "nsb_tuning_ratio": 0.52,
-    "spe_location": null
+    "spe_location": null,
+    "pre_computed_multiplicity": 0
   },
   "lh_fit_config": {
     "sigma_s": [

--- a/lstchain/data/lstchain_lhfit_config.json
+++ b/lstchain/data/lstchain_lhfit_config.json
@@ -279,9 +279,9 @@
   },
   "waveform_nsb_tuning":{
     "nsb_tuning": false,
-    "nsb_tuning_ratio": 0.52,
+    "nsb_tuning_ratio": 0.5,
     "spe_location": null,
-    "pre_computed_multiplicity": 0
+    "pre_computed_multiplicity": 10
   },
   "lh_fit_config": {
     "sigma_s": [

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -274,8 +274,9 @@
   },
   "waveform_nsb_tuning":{
     "nsb_tuning": false,
-    "nsb_tuning_ratio": 0.52,
-    "spe_location": null
+    "nsb_tuning_ratio": 0.5,
+    "spe_location": null,
+    "pre_computed_multiplicity": 10
   },
   "write_interleaved_events":{
     "DataWriter": {

--- a/lstchain/image/modifier.py
+++ b/lstchain/image/modifier.py
@@ -411,6 +411,7 @@ def calculate_required_additional_nsb(simtel_filename, data_dl1_filename, config
     """
     Calculates the additional NSB needed in the MC waveforms
     to match a real data DL1 file
+
     Parameters
     ----------
     simtel_filename: a simtel file containing showers, from the production
@@ -424,11 +425,13 @@ def calculate_required_additional_nsb(simtel_filename, data_dl1_filename, config
     agreement of data and simulations.
     config: configuration containing the calibration
     settings used for processing both the data and the MC files above
+
     Returns
     -------
     extra_nsb: Fraction of the additional NSB in data compared to MC.
     data_ped_variance: Pedestal variance from data
     mc_ped_variance: Pedestal variance from MC
+
     """
 
     log.setLevel(logging.INFO)
@@ -556,6 +559,7 @@ class WaveformNsbTunner:
         pre_computed_multiplicity: `int`
             Multiplicative factor on the number of pixels used to determine the number of pre-generated, nsb-only,
             waveforms. Later used during event modification. Set to 0 to always compute the correction on the fly.
+
         """
         self.added_nsb_fraction = added_nsb_fraction
         self.original_nsb = original_nsb
@@ -574,14 +578,16 @@ class WaveformNsbTunner:
         """
         Creates an array of nsb only waveforms later used to inject additional nsb in events.
         Called once for each telescope id at first encounter in `self._tune_nsb_on_waveform_precomputed`.
+
         Parameters
         ----------
         waveform: ndarray
-            waveform used to know the number of pixels and time samples for a given telescope id
+            Waveform used to know the number of pixels and time samples for a given telescope id
         dt: `astropy.units.Quantity`
             Time between samples
         tel_id: `int`
-            telescope identifier for which nsb waveforms are generated
+            Telescope identifier for which nsb waveforms are generated
+
         """
         log.info(f"Pre-generating nsb waveforms for nsb tuning and telescope id {tel_id}.")
         n = 25
@@ -624,15 +630,17 @@ class WaveformNsbTunner:
     def _tune_nsb_on_waveform_precomputed(self, waveform, tel_id, is_high_gain, subarray):
         """
         Inject single photon pulses in existing R1 waveforms to increase NSB using pre-computed pure nsb waveforms.
+
         Parameters
         ----------
         waveform: ndarray
-            charge (p.e. / ns) in each pixel and sampled time
+            Charge (p.e. / ns) in each pixel and sampled time
         tel_id: `int`
             Telescope id associated to the waveform to tune
         is_high_gain: ndarray of boolean
             Gain channel used per pixel: True=hg, False=lg
         subarray: `ctapipe.instrument.subarray.SubarrayDescription`
+
         """
         if tel_id not in self.nsb_waveforms:
             readout = subarray.tel[tel_id].camera.readout
@@ -649,15 +657,17 @@ class WaveformNsbTunner:
     def _tune_nsb_on_waveform_direct(self, waveform, tel_id, is_high_gain, subarray):
         """
         Inject single photon pulses in existing R1 waveforms to increase NSB.
+
         Parameters
         ----------
         waveform: ndarray
-            charge (p.e. / ns) in each pixel and sampled time
+            Charge (p.e. / ns) in each pixel and sampled time
         tel_id: `int`
             Telescope id associated to the waveform to tune
         is_high_gain: ndarray of boolean
             Gain channel used per pixel: True=hg, False=lg
         subarray: `ctapipe.instrument.subarray.SubarrayDescription`
+
         """
         n = 25
         n_pixels, n_samples = waveform.shape

--- a/lstchain/io/io.py
+++ b/lstchain/io/io.py
@@ -1279,7 +1279,7 @@ def extract_simulation_nsb(filename):
         for _, line in f.history:
             line = line.decode('utf-8').strip().split(' ')
             if next_nsb and line[0] == 'NIGHTSKY_BACKGROUND':
-                nsb[tel_id] = float(line[1].strip('all:'))
+                nsb[tel_id] = float(line[1].strip('all:')) * u.GHz
                 tel_id = tel_id+1
             if line[0] == 'STORE_PHOTOELECTRONS':
                 next_nsb = True
@@ -1288,7 +1288,7 @@ def extract_simulation_nsb(filename):
     log.warning('Original MC night sky background extracted from the config history in the simtel file.\n'
                 'This is done for existing LST MC such as the one created using: '
                 'https://github.com/cta-observatory/lst-sim-config/tree/sim-tel_LSTProd2_MAGICST0316'
-                '\nExtracted values are: ' + str(np.asarray(nsb)) + 'GHz. Check that it corresponds to expectations.')
+                '\nExtracted values are: ' + str(np.asarray(nsb)) + '. Check that it corresponds to expectations.')
     return nsb
 
 

--- a/lstchain/io/tests/test_io.py
+++ b/lstchain/io/tests/test_io.py
@@ -154,9 +154,10 @@ def test_trigger_type_in_dl1_params(simulated_dl1_file):
 
 def test_extract_simulation_nsb(mc_gamma_testfile):
     from lstchain.io.io import extract_simulation_nsb
+    import astropy.units as u
 
     nsb = extract_simulation_nsb(mc_gamma_testfile)
-    assert np.isclose(nsb[1], 0.246, rtol=0.1)
+    assert np.isclose(nsb[1].to_value(u.GHz), 0.246, rtol=0.1)
 
 
 def test_remove_duplicated_events():

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -23,7 +23,7 @@ from ctapipe.image import (
     tailcuts_clean,
 )
 from ctapipe.image import number_of_islands, apply_time_delta_cleaning
-from ctapipe.io import EventSource, HDF5TableWriter, DataWriter 
+from ctapipe.io import EventSource, HDF5TableWriter, DataWriter
 from ctapipe.utils import get_dataset_path
 from traitlets.config import Config
 from ctapipe_io_lst.constants import (
@@ -37,7 +37,7 @@ from ..data import NormalizedPulseTemplate
 from ..calib.camera import load_calibrator_from_config
 from ..calib.camera.calibration_calculator import CalibrationCalculator
 from ..image.cleaning import apply_dynamic_cleaning
-from ..image.modifier import tune_nsb_on_waveform, calculate_required_additional_nsb
+from ..image.modifier import calculate_required_additional_nsb, WaveformNsbTunner
 from .reconstructor import TimeWaveformFitter
 from ..image.muon import analyze_muon_event, tag_pix_thr
 from ..image.muon import create_muon_table, fill_muon_event
@@ -59,7 +59,6 @@ from ..io import (
     write_subarray_tables
 )
 
-
 from ..io.io import add_column_table, extract_simulation_nsb, dl1_params_lstcam_key, get_resource_path
 from ..io.lstcontainers import ExtraImageInfo, DL1MonitoringEventIndexContainer
 from ..paths import parse_r0_filename, run_to_dl1_filename, r0_to_dl1_filename
@@ -67,14 +66,12 @@ from ..visualization.plot_reconstructor import plot_debug
 
 logger = logging.getLogger(__name__)
 
-
 __all__ = [
     'add_disp_to_parameters_table',
     'get_dl1',
     'apply_lh_fit',
     'r0_to_dl1',
 ]
-
 
 cleaning_method = tailcuts_clean
 
@@ -169,11 +166,11 @@ def parametrize_image(image, peak_time, signal_pixels, camera_geometry, focal_le
 
 
 def get_dl1(
-    calibrated_event,
-    subarray,
-    telescope_id,
-    dl1_container=None,
-    custom_config={}
+        calibrated_event,
+        subarray,
+        telescope_id,
+        dl1_container=None,
+        custom_config={}
 ):
     """
     Return a DL1ParametersContainer of extracted features from a calibrated event.
@@ -312,9 +309,9 @@ def apply_lh_fit(
 
 
 def r0_to_dl1(
-    input_filename=None,
-    output_filename=None,
-    custom_config={},
+        input_filename=None,
+        output_filename=None,
+        custom_config={},
 ):
     """
     Chain r0 to dl1
@@ -375,11 +372,10 @@ def r0_to_dl1(
     )
 
     if not is_simu:
-
         # Pulse extractor for muon ring analysis. Same parameters (window_width and _shift) as the one for showers, but
         # using GlobalPeakWindowSum, since the signal for the rings is expected to be very isochronous
-        r1_dl1_calibrator_for_muon_rings = CameraCalibrator(image_extractor_type = config['image_extractor_for_muons'],
-                                                            config=Config(config),subarray = subarray)
+        r1_dl1_calibrator_for_muon_rings = CameraCalibrator(image_extractor_type=config['image_extractor_for_muons'],
+                                                            config=Config(config), subarray=subarray)
 
         # Component to process interleaved pedestal and flat-fields
         calib_config = Config({config['calibration_product']: config[config['calibration_product']]})
@@ -407,15 +403,15 @@ def r0_to_dl1(
             metadata=metadata,
         )
     nsb_tuning = False
-    nsb_tuning_args = None
+    nsb_tunner = None
     if 'waveform_nsb_tuning' in config.keys():
         nsb_tuning = config['waveform_nsb_tuning']['nsb_tuning']
         if nsb_tuning:
             if is_simu:
                 nsb_original = extract_simulation_nsb(input_filename)
-                pulse_template = NormalizedPulseTemplate.load_from_eventsource(
-                    subarray.tel[1].camera.readout, resample=True
-                )
+                pulse_templates = {tel_id: NormalizedPulseTemplate.load_from_eventsource(
+                    subarray.tel[tel_id].camera.readout, resample=True)
+                    for tel_id in config['source_config']['LSTEventSource']['allowed_tels']}
                 if 'nsb_tuning_ratio' in config['waveform_nsb_tuning'].keys():
                     # get value from config to possibly extract it beforehand on multiple files for averaging purposes
                     # or gain time
@@ -426,18 +422,23 @@ def r0_to_dl1(
                     nsb_tuning_ratio = calculate_required_additional_nsb(input_filename,
                                                                          config['waveform_nsb_tuning']['target_data'],
                                                                          config=config)[0]
-
-                spe_location = config['waveform_nsb_tuning']['spe_location'] if 'spe_location' in config['waveform_nsb_tuning'] and config['waveform_nsb_tuning']['spe_location'] is not None else get_resource_path("data/SinglePhE_ResponseInPhE_expo2Gaus.dat")
+                spe_location = (config['waveform_nsb_tuning']['spe_location']
+                                or get_resource_path("data/SinglePhE_ResponseInPhE_expo2Gaus.dat"))
                 spe = np.loadtxt(spe_location).T
                 spe_integral = np.cumsum(spe[1])
                 charge_spe_cumulative_pdf = interp1d(spe_integral, spe[0], kind='cubic',
                                                      bounds_error=False, fill_value=0.,
                                                      assume_sorted=True)
+                pre_computed_multiplicity = config['waveform_nsb_tuning'].get('pre_computed_multiplicity', 10)
                 logger.info('Tuning NSB on MC waveform from '
                             + str(np.asarray(nsb_original))
-                            + 'GHz to {0:d}%'.format(int(nsb_tuning_ratio * 100 + 100.5))
+                            + ' to {0:d}%'.format(int(nsb_tuning_ratio * 100 + 100.5))
                             + ' for telescopes ids ' + str(config['source_config']['LSTEventSource']['allowed_tels']))
-                nsb_tuning_args = [nsb_tuning_ratio, nsb_original, pulse_template, charge_spe_cumulative_pdf]
+                nsb_tunner = WaveformNsbTunner(nsb_tuning_ratio,
+                                               nsb_original,
+                                               pulse_templates,
+                                               charge_spe_cumulative_pdf,
+                                               pre_computed_multiplicity)
             else:
                 logger.warning('NSB tuning on waveform active in config but file is real data, option will be ignored')
                 nsb_tuning = False
@@ -450,7 +451,7 @@ def r0_to_dl1(
             tmp_source = EventSource(input_url=input_filename,
                                      config=Config(config["source_config"]))
             if is_simu:
-                lhfit_fitter.get_ped_from_true_signal_less(tmp_source, nsb_tuning_args)
+                lhfit_fitter.get_ped_from_true_signal_less(tmp_source, nsb_tunner)
             else:
                 lhfit_fitter.get_ped_from_interleaved(tmp_source)
             del tmp_source
@@ -464,21 +465,22 @@ def r0_to_dl1(
         # create output dir in the data-tree if necessary
         dir = f"{dir}/interleaved"
         os.makedirs(dir, exist_ok=True)
-        if 'dl1' in name: 
+        if 'dl1' in name:
             name = name.replace('dl1', 'interleaved').replace('LST-1.1', 'LST-1')
         else:
             name = f"interleaved_{name}"
         interleaved_output_file = Path(dir, name)
-        interleaved_writer = DataWriter(event_source=source,output_path=interleaved_output_file,config=interleaved_writer_config)
+        interleaved_writer = DataWriter(event_source=source, output_path=interleaved_output_file,
+                                        config=interleaved_writer_config)
         interleaved_writer._writer.exclude("/r1/event/telescope/.*", "selected_gain_channel")
 
-    with HDF5TableWriter( 
-        filename=output_filename,
-        group_name='dl1/event',
-        mode='a',
-        filters=HDF5_ZSTD_FILTERS,
-        add_prefix=True,
-        # overwrite=True,
+    with HDF5TableWriter(
+            filename=output_filename,
+            group_name='dl1/event',
+            mode='a',
+            filters=HDF5_ZSTD_FILTERS,
+            add_prefix=True,
+            # overwrite=True,
     ) as writer:
 
         setup_writer(writer, source.subarray, is_simulation=is_simu)
@@ -512,10 +514,10 @@ def r0_to_dl1(
 
                     tel_id = calibration_calculator.tel_id
 
-
-                    #initialize the event monitoring data
+                    # initialize the event monitoring data
                     event.mon = deepcopy(source.r0_r1_calibrator.mon_data)
-                    for container in [event.mon.tel[tel_id].pedestal, event.mon.tel[tel_id].flatfield, event.mon.tel[tel_id].calibration]:
+                    for container in [event.mon.tel[tel_id].pedestal, event.mon.tel[tel_id].flatfield,
+                                      event.mon.tel[tel_id].calibration]:
                         add_global_metadata(container, metadata)
                         add_config_metadata(container, config)
 
@@ -537,42 +539,38 @@ def r0_to_dl1(
                     # these data a supposed to be replaced by the Cat_B data in a short future
                     if new_ped_event or new_ff_event:
                         write_calibration_data(writer,
-                                           calibration_index,
-                                           event.mon.tel[tel_id],
-                                           new_ped=new_ped_event, new_ff=new_ff_event)
-                    
+                                               calibration_index,
+                                               event.mon.tel[tel_id],
+                                               new_ped=new_ped_event, new_ff=new_ff_event)
+
                     # write the calibrated R1 waveform without gain selection
                     source.r0_r1_calibrator.select_gain = False
                     source.r0_r1_calibrator.calibrate(event)
-                
+
                     if interleaved_writer is not None:
                         interleaved_writer(event)
 
                     # gain select the events
                     source.r0_r1_calibrator.select_gain = True
 
-                    r1 = event.r1.tel[tel_id]                   
+                    r1 = event.r1.tel[tel_id]
                     r1.selected_gain_channel = source.r0_r1_calibrator.gain_selector(event.r0.tel[tel_id].waveform)
                     r1.waveform = r1.waveform[r1.selected_gain_channel, PIXEL_INDEX]
 
                     event.calibration.tel[tel_id].dl1.time_shift = \
-                    event.calibration.tel[tel_id].dl1.time_shift[r1.selected_gain_channel, PIXEL_INDEX]
-                    
+                        event.calibration.tel[tel_id].dl1.time_shift[r1.selected_gain_channel, PIXEL_INDEX]
+
                     event.calibration.tel[tel_id].dl1.relative_factor = \
-                    event.calibration.tel[tel_id].dl1.relative_factor[r1.selected_gain_channel, PIXEL_INDEX]
-                    
+                        event.calibration.tel[tel_id].dl1.relative_factor[r1.selected_gain_channel, PIXEL_INDEX]
+
             # Option to add nsb in waveforms
             if nsb_tuning:
                 # FIXME? assumes same correction ratio for all telescopes
                 for tel_id in config['source_config']['LSTEventSource']['allowed_tels']:
                     waveform = event.r1.tel[tel_id].waveform
-                    readout = subarray.tel[tel_id].camera.readout
-                    sampling_rate = readout.sampling_rate.to_value(u.GHz)
-                    dt = (1.0 / sampling_rate)
                     selected_gains = event.r1.tel[tel_id].selected_gain_channel
-                    mask_high = (selected_gains == 0)
-                    tune_nsb_on_waveform(waveform, nsb_tuning_ratio, nsb_original[tel_id] * u.GHz,
-                                         dt * u.ns, pulse_template, mask_high, charge_spe_cumulative_pdf)
+                    mask_high = selected_gains == 0
+                    nsb_tunner.tune_nsb_on_waveform(waveform, tel_id, mask_high, subarray)
 
             # create image for all events
             r1_dl1_calibrator(event)
@@ -604,7 +602,6 @@ def r0_to_dl1(
 
                 dl1_container.fill_event_info(event)
 
-
                 # Will determine whether this event has to be written to the
                 # DL1 output or not.
                 if is_simu:
@@ -629,7 +626,7 @@ def r0_to_dl1(
                 if not is_simu:
 
                     calibration_mon = source.r0_r1_calibrator.mon_data.tel[telescope_id].calibration
- 
+
                     dl1_container.ucts_time = 0
                     # convert Time to unix timestamp in (UTC) to keep compatibility
                     # with older lstchain
@@ -643,7 +640,6 @@ def r0_to_dl1(
                     dl1_container.trigger_type = event.lst.tel[telescope_id].evt.tib_masked_trigger
                 else:
                     dl1_container.trigger_type = event.trigger.event_type
-
 
                 dl1_container.az_tel = event.pointing.tel[telescope_id].azimuth
                 dl1_container.alt_tel = event.pointing.tel[telescope_id].altitude
@@ -682,7 +678,7 @@ def r0_to_dl1(
                     bad_pixels = calibration_mon.unusable_pixels[0]
 
                     # Set to 0 unreliable pixels:
-                    image = dl1_tel.image*(~bad_pixels)
+                    image = dl1_tel.image * (~bad_pixels)
 
                     # process only promising events, in terms of # of pixels with large signals:
                     if tag_pix_thr(image):
@@ -696,7 +692,7 @@ def r0_to_dl1(
                         # integrator in case of crazy pixels!  TBD: can this be done in a simpler
                         # way?
                         bad_pixels = bad_pixels_hg | bad_pixels_lg
-                        bad_waveform = np.transpose(np.array(numsamples*[bad_pixels]))
+                        bad_waveform = np.transpose(np.array(numsamples * [bad_pixels]))
 
                         # print('hg bad pixels:',np.where(bad_pixels_hg))
                         # print('lg bad pixels:',np.where(bad_pixels_lg))
@@ -714,10 +710,10 @@ def r0_to_dl1(
                             good_ring = False
                         else:
                             muonintensityparam, dist_mask, \
-                            ring_size, size_outside_ring, muonringparam, \
-                            good_ring, radial_distribution, \
-                            mean_pixel_charge_around_ring,\
-                            muonpars = \
+                                ring_size, size_outside_ring, muonringparam, \
+                                good_ring, radial_distribution, \
+                                mean_pixel_charge_around_ring, \
+                                muonpars = \
                                 analyze_muon_event(subarray,
                                                    tel_id, event.index.event_id,
                                                    image, good_ring_config=None,
@@ -758,10 +754,10 @@ def r0_to_dl1(
 
                 # writes mc information per telescope, including photo electron image
                 if (
-                    is_simu
-                    and config['write_pe_image']
-                    and event.simulation.tel[telescope_id].true_image is not None
-                    and event.simulation.tel[telescope_id].true_image.any()
+                        is_simu
+                        and config['write_pe_image']
+                        and event.simulation.tel[telescope_id].true_image is not None
+                        and event.simulation.tel[telescope_id].true_image.any()
                 ):
                     event.simulation.tel[telescope_id].prefix = ''
                     writer.write(
@@ -799,11 +795,10 @@ def r0_to_dl1(
         muon_output_filename = Path(dir, name)
         table = Table(muon_parameters)
         table.write(muon_output_filename, format='fits', overwrite=True)
-        
+
         # close the interleaved output file and write metadata
         if interleaved_writer is not None:
             interleaved_writer.finish()
-
 
 
 def add_disp_to_parameters_table(dl1_file, table_path, focal):

--- a/lstchain/reco/reconstructor.py
+++ b/lstchain/reco/reconstructor.py
@@ -9,7 +9,6 @@ from ctapipe.core import TelescopeComponent
 from ctapipe.core.traits import Bool, Float, FloatTelescopeParameter, Int, Unicode
 
 from lstchain.data.normalised_pulse_template import NormalizedPulseTemplate
-from lstchain.image.modifier import WaveformNsbTunner
 from lstchain.io.lstcontainers import DL1LikelihoodParametersContainer
 from lstchain.reco.reconstructorCC import log_pdf as log_pdf
 

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -129,6 +129,7 @@ def test_r0_to_dl1_lhfit_mc(tmp_path, mc_gamma_testfile):
     config['lh_fit_config']["spatial_selection"] = 'dvr'
     config['lh_fit_config']["use_interleaved"] = True
     config['waveform_nsb_tuning']['nsb_tuning'] = True
+    config['waveform_nsb_tuning']['pre_computed_multiplicity'] = 10  # default value
     r0_to_dl1(mc_gamma_testfile, custom_config=config, output_filename=tmp_path / "tmp.h5")
     os.remove(tmp_path / "tmp.h5")
     config['waveform_nsb_tuning']['pre_computed_multiplicity'] = 0

--- a/lstchain/tests/test_lstchain.py
+++ b/lstchain/tests/test_lstchain.py
@@ -130,6 +130,9 @@ def test_r0_to_dl1_lhfit_mc(tmp_path, mc_gamma_testfile):
     config['lh_fit_config']["use_interleaved"] = True
     config['waveform_nsb_tuning']['nsb_tuning'] = True
     r0_to_dl1(mc_gamma_testfile, custom_config=config, output_filename=tmp_path / "tmp.h5")
+    os.remove(tmp_path / "tmp.h5")
+    config['waveform_nsb_tuning']['pre_computed_multiplicity'] = 0
+    r0_to_dl1(mc_gamma_testfile, custom_config=config, output_filename=tmp_path / "tmp.h5")
 
 
 @pytest.mark.private_data


### PR DESCRIPTION
In order to implement the possibility to pre-generate nsb waveforms to add nsb to events instead of generating new nsb waveforms on the fly, a new class was added.

The class `WaveformNsbTunner` take a new config file entry `pre_computed_multiplicity` which can be set to 0 to generate nsb on the fly. Or to any int to pre-generate `pre_computed_multiplicity` X number of pixels X number of gains waveforms.

Closes #1273 

To do before removing draft : 

- [x] Add docstrings to function and class
- [x] Pass CI 
- [x] Quick result consistency check

Some processing duration to illustrate the gain on a single (proton) MC file : 
+50% NSB, no pre-generation : 1min 39s
+50% NSB, 10X pre-generation : 1min 28s
+1000% NSB, no pre-generation : 3min 18s
+1000% NSB, 10X pre-generation : 1min 31s

Results of the tuning are compatible between using pre-generated waveforms or on the fly generation. Results are also the same as the previous implementation. See the signal less pixel charges for a data runs vs MC without and with tuning. 
![image](https://github.com/cta-observatory/cta-lstchain/assets/35919817/a6526b42-2b3a-4f22-a34b-01bad0be538c)

Unrelated to this PR , but the injection of 55% nominal NSB here is a bit higher than automatically extracted using calculate_required_additional_nsb (~40%). This will need to be investigated independently.
