### PR TITLE
Ensure consistency between the cis and runsummary tables

### DIFF
--- a/notebooks/data_quality.ipynb
+++ b/notebooks/data_quality.ipynb
@@ -125,7 +125,7 @@
     "# files = glob.glob(\"/fefs/aswg/data/real/OSA/DL1DataCheck_LongTerm/v0.10/2023????/DL1_datacheck_2023*.h5\")\n",
     "# \n",
     "# Example: load all the 2023 files processed (with any version - the latest available for each night): \n",
-    "files = glob.glob(\"/fefs/aswg/data/real/OSA/DL1DataCheck_LongTerm/night_wise/all/DL1_datacheck_2023*.h5\n",
+    "files = glob.glob(\"/fefs/aswg/data/real/OSA/DL1DataCheck_LongTerm/night_wise/all/DL1_datacheck_202[1-4]*.h5\")\n",
     "\n",
     "files.sort()"
    ]
@@ -501,8 +501,8 @@
     "    if r in runlist:\n",
     "        continue\n",
     "    print('Removing run', r, 'from runsummary table!')\n",
-    "    \n",
-    "    runsummary = runsummary.drop(np.where(runsummary['runnumber']==r)[0])"
+    "    runsummary.drop(np.where(runsummary['runnumber']==r)[0], inplace=True)\n",
+    "    runsummary.reset_index(inplace=True, drop=True)"
    ]
   },
   {
@@ -1820,6 +1820,14 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0101cc95",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1838,7 +1846,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This was not working for >1  different runs between the tables because of improper use of panda's "drop"
Fixes #1277 