### PR TITLE
Pin micromamba 2.0.0-0 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Mamba setup
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '2.0.0-0'
           environment-file: environment.yml
           cache-downloads: true
 


### PR DESCRIPTION
There seems to be a problem with the latest release. See https://github.com/mamba-org/setup-micromamba/issues/225

Remember to remove the pin whenever it is fixed at the mamba side.