### PR TITLE
Computing the run pointing in sky coordinates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ todo_include_todos = False
 #
 import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/lstchain/high_level/hdu_table.py
+++ b/lstchain/high_level/hdu_table.py
@@ -264,7 +264,7 @@ def get_pointing_params(data, source_pos, time_utc, exclude_fraction=0.2):
     and average them for the run (excluding the first events, for which there
     may be some mispointing due to not-yet-stable tracking).
 
-    exclude_fraction: fraction of the run that will me excluded from the 
+    exclude_fraction: fraction of the events that will be excluded from the 
     averaging (the excluded events are the ones at the beginning of the run)
 
     Note: The angular difference from the source is just used for logging here.

--- a/lstchain/high_level/hdu_table.py
+++ b/lstchain/high_level/hdu_table.py
@@ -297,7 +297,7 @@ def get_pointing_params(data, source_pos, time_utc, exclude_fraction=0.2):
     log.info("Median of angle between pointing direction and mean pointing:")
     log.info(f"  All events: {median_angle_wrt_mean_pointing:.3f}")
     if median_angle_wrt_mean_pointing > max_median_angle:
-        log.warn(f"   ==> The telescope pointing seems to be unstable during the Run!")
+        log.warn("   ==> The telescope pointing seems to be unstable during the Run!")
     log.info(f"  Excluding the first {100*exclude_fraction:.1f}% of events: {median_angle_wrt_mean_pointing_2:.3f}")
 
     source_pointing_diff = source_pos.separation(pnt_icrs)

--- a/lstchain/high_level/hdu_table.py
+++ b/lstchain/high_level/hdu_table.py
@@ -297,7 +297,7 @@ def get_pointing_params(data, source_pos, time_utc, exclude_fraction=0.2):
     log.info("Median of angle between pointing direction and mean pointing:")
     log.info(f"  All events: {median_angle_wrt_mean_pointing:.3f}")
     if median_angle_wrt_mean_pointing > max_median_angle:
-        log.warn("   ==> The telescope pointing seems to be unstable during the Run!")
+        log.warning("   ==> The telescope pointing seems to be unstable during the Run!")
     log.info(f"  Excluding the first {100*exclude_fraction:.1f}% of events: {median_angle_wrt_mean_pointing_2:.3f}")
 
     source_pointing_diff = source_pos.separation(pnt_icrs)

--- a/lstchain/high_level/hdu_table.py
+++ b/lstchain/high_level/hdu_table.py
@@ -276,8 +276,8 @@ def get_pointing_params(data, source_pos, time_utc, exclude_fraction=0.2):
     pointing_az = data["pointing_az"]
 
     max_off_angle = 0.05 * u.deg 
-    # Keep track of how often pointing is beyond max_off_angle w.r.t. the median
-    # run pointing
+    # Keep track of how often pointing is beyond max_off_angle w.r.t. the mean
+    # run pointing (computed excluding the beginning of run - see exclude_fraction)
     
     # If median of the angle between the pointing directions and their mean in the run
     # is larger than max_median_angle a warning will be displayed about unstable pointing.

--- a/lstchain/high_level/hdu_table.py
+++ b/lstchain/high_level/hdu_table.py
@@ -298,7 +298,7 @@ def get_pointing_params(data, source_pos, time_utc, exclude_fraction=0.2):
     log.info(f"  All events: {median_angle_wrt_mean_pointing:.3f}")
     if median_angle_wrt_mean_pointing > max_median_angle:
         log.warning("   ==> The telescope pointing seems to be unstable during the Run!")
-    log.info(f"  Excluding the first {100*exclude_fraction:.1f}% of events: {median_angle_wrt_mean_pointing_2:.3f}")
+    log.info(f"  Excluding the first {exclude_fraction:.1%} of events: {median_angle_wrt_mean_pointing_2:.3f}")
 
     source_pointing_diff = source_pos.separation(pnt_icrs)
 

--- a/lstchain/high_level/hdu_table.py
+++ b/lstchain/high_level/hdu_table.py
@@ -279,9 +279,6 @@ def get_pointing_params(data, source_pos, time_utc, exclude_fraction=0.2):
     # Keep track of how often pointing is beyond max_off_angle w.r.t. the mean
     # run pointing (computed excluding the beginning of run - see exclude_fraction)
     
-    # If median of the angle between the pointing directions and their mean in the run
-    # is larger than max_median_angle a warning will be displayed about unstable pointing.
-    
     first_event = int(exclude_fraction * len(data))
     with erfa_astrom.set(ErfaAstromInterpolator(300 * u.s)):
         evtwise_pnt_icrs = SkyCoord(


### PR DESCRIPTION
Addresses #1293 
So far the first event's pointing was used. This is problematic for runs in which the pointing is unstable at the beginning.