### PR TITLE
Bump to ctapipe_io_lst 0.24

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,6 @@ dependencies:
   - pandas>=2
   - pymongo
   - seaborn
-  - ctapipe_io_lst=0.23
+  - ctapipe_io_lst=0.24
   - pytest
   - pyirf~=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'astropy~=5.0',
         'bokeh~=2.0',
         'ctapipe~=0.19.2',
-        'ctapipe_io_lst~=0.23.0',
+        'ctapipe_io_lst~=0.24.0',
         'ctaplot~=0.6.4',
         'eventio>=1.9.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=1.1',


### PR DESCRIPTION
To be compatible with the new LST calibration library, we must require ctapipe_io_lst >= 0.24.0.

From 0.23 to 0.24 there was only the addition of ctapipe 0.21 compatibility as a major change