### PR TITLE
Interpolation of RF predictions with cosZD, for homogeneous performance

### DIFF
--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -69,6 +69,13 @@
     "pointing_wise_weights": true
   },
 
+  "random_forest_zd_interpolation": {
+    "interpolate_energy": true,
+    "interpolate_gammaness": true,
+    "interpolate_direction": true,
+    "DL1_training_dir": null
+  },
+
   "random_forest_energy_regressor_args": {
     "max_depth": 30,
     "min_samples_leaf": 10,

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -72,8 +72,7 @@
   "random_forest_zd_interpolation": {
     "interpolate_energy": true,
     "interpolate_gammaness": true,
-    "interpolate_direction": true,
-    "DL1_training_dir": null
+    "interpolate_direction": true
   },
 
   "random_forest_energy_regressor_args": {

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -60,22 +60,25 @@ def add_zd_interpolation_info(dl2table, training_pointings):
     between the zenith pointings of the MC data in the training sample on
     which the RFs were trained.
 
-    Parameters:
-    -----------
-    dl2table: pandas dataframe. Four columns will be added: alt0, alt1, w0, w1
-    alt0 and alt1 are the alt_tel values (telescope elevation, in radians) of
-    the closest and second-closest training MC pointings (closest in elevation,
-    on the same side of culmination) for each event in the table. The values
-    w0 and w1 are the corresponding weights that, multiplied by the RF
-    predictions at those two pointings, provide the interpolated result for
-    each event's pointing
+    Parameters
+    ----------
+    dl2table : pandas.DataFrame
+        DataFrame containing DL2 information, including 'alt_tel' and 'az_tel'.
+        Four columns will be added: alt0, alt1, w0, w1.
+        alt0 and alt1 are the alt_tel values (telescope elevation, in radians) of
+        the closest and second-closest training MC pointings (closest in elevation,
+        on the same side of culmination) for each event in the table. The values
+        w0 and w1 are the corresponding weights that, multiplied by the RF
+        predictions at those two pointings, provide the interpolated result for
+        each event's pointing.
 
-    training_pointings: astropy Table containing the pointings (zd,
-    az) of the MC training nodes
+    training_pointings : astropy.table.Table 
+        Table containing the pointings (zd, az) of the MC training nodes.
 
-    Returns:
+    Returns
     -------
-    DL2 pandas dataframe with additional columns alt0, alt1, w0, w1
+    pandas.DataFrame
+        Updated DL2 pandas dataframe with additional columns alt0, alt1, w0, w1.
 
     """
 
@@ -143,25 +146,30 @@ def predict_with_zd_interpolation(rf, param_array, features):
     sceond-closest pointing. Then the values are interpolated (linearly in
     cos(zenith)) to the actual zenith pointing (90 deg - alt_tel) of the event.
 
-    rf: sklearn.ensemble.RandomForestRegressor or RandomForestClassifier,
-    the random forest we want to apply (must contain alt_tel among the
-    training parameters)
+    Parameters
+    ----------
+    rf : sklearn.ensemble.RandomForestRegressor or RandomForestClassifier,
+        The random forest we want to apply (must contain alt_tel among the
+        training parameters).
+    param_array : pandas.DataFrame
+        Dataframe containing the features needed by the RF.
+        It must also contain four additional columns: alt0, alt1, w0, w1, which
+        can be added with the function add_zd_interpolation_info. These are the
+        event-wise telescope elevations for the closest and 2nd-closest training
+        pointings (alt0 and alt1), and the event-wise weights (w0 and w1) which
+        must be applied to the RF prediction at the two pointings to obtain the
+        interpolated value at the actual telescope pointing. Since the weights
+        are the same (for a given event) for different RFs, it does not make
+        sense to compute them here - they are pre-calculated by
+        `add_zd_interpolation_info`.
+    features : list of str
+        List of the names of the image features used by the RF.
 
-    param_array: pandas dataframe containing the features needed by theRF
-    It must also contain four additional columns: alt0, alt1, w0, w1, which
-    can be added with the function add_zd_interpolation_info. These are the
-    event-wise telescope elevations for the closest and 2nd-closest training
-    pointings (alt0 and alt1), and the event-wise weights (w0 and w1) which
-    must be applied to the RF prediction at the two pointings to obtain the
-    interpolated value at the actual telescope pointing. Since the weights
-    are the same (for a given event) for different RFs, it does not make
-    sense to compute them here - they are pre-calculated by
-    add_zd_interpolation_info
-
-    features: list of the names of the image features used by the RF
-
-    Return: interpolated RF predictions. 1D array for regressors (log energy,
-    or disp_norm), 2D (events, # of classes) for classifiers
+    Return
+    ------
+    numpy.ndarray
+        Interpolated RF predictions. 1D array for regressors (log energy,
+        or disp_norm), 2D (events, # of classes) for classifiers.
 
     """
 
@@ -207,7 +215,7 @@ def train_energy(train, custom_config=None):
     Parameters
     ----------
     train: `pandas.DataFrame`
-    custom_config: dictionary
+    custom_config : dict
         Modified configuration to update the standard one
 
     Returns
@@ -780,12 +788,13 @@ def apply_models(dl1,
     effective_focal_length: `astropy.unit`
     custom_config: dictionary
         Modified configuration to update the standard one
-    interpolate_rf: dictionary. Contains three booleans, 'energy_regression',
+    interpolate_rf : dict
+        Contains three booleans, 'energy_regression',
         'particle_classification', 'disp', indicating which RF predictions
-        should be interpolated linearly in cos(zenith)
-    training_pointings: astropy Table azimuth (az), zenith (zd)
-         pointings of the MC sample used in the training. Needed for the
-         interpolation of RF predictions.
+        should be interpolated linearly in cos(zenith).
+    training_pointings : astropy.table.Table 
+        Table with azimuth (az), zenith (zd) pointings of the MC sample used
+        in the training. Needed for the interpolation of RF predictions.
 
     Returns
     -------

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -791,7 +791,7 @@ def apply_models(dl1,
     interpolate_rf: dictionary. Contains three booleans, 'energy_regression',
         'particle_classification', 'disp', indicating which RF predictions
         should be interpolated linearly in cos(zenith)
-    training_pointings: array (# of pointings, 2) azimuth, zenith in degrees;
+    training_pointings: astropy Table azimuth (az), zenith (zd)
          pointings of the MC sample used in the training. Needed for the
          interpolation of RF predictions.
 
@@ -830,8 +830,8 @@ def apply_models(dl1,
 
     if True in interpolate_rf.values():
         # Interpolation of RF predictions is switched on
-        training_az_deg = training_pointings[:, 0]
-        training_zd_deg = training_pointings[:, 1]
+        training_az_deg = training_pointings['az'].to(u.deg).value
+        training_zd_deg = training_pointings['zd'].to(u.deg).value
         dl2 = add_zd_interpolation_info(dl2, training_zd_deg, training_az_deg)
 
     # Reconstruction of Energy and disp_norm distance

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -44,7 +44,6 @@ __all__ = [
     'build_models',
     'get_expected_source_pos',
     'get_source_dependent_parameters',
-    'get_training_directions',
     'predict_with_zd_interpolation',
     'train_disp_norm',
     'train_disp_sign',
@@ -54,45 +53,6 @@ __all__ = [
     'train_sep',
     'update_disp_with_effective_focal_length'
 ]
-
-
-def get_training_directions(training_dirs):
-    """
-    This function obtains the pointings of the telescope in the RF training
-    sample.
-
-    Parameters:
-    -----------
-    training_dirs: array of strings, each element is the name of one of the
-    folders containing the DL1 files used in the training. Order is
-    irrelevant. The folders' names are assumed to follow this pattern:
-
-    node_corsika_theta_34.367_az_69.537_
-
-    (theta is zenith; az is azimuth. Units are degrees, note that the values'
-    field lengths are not fixed)
-
-    Returns: training_az_deg, training_zd_deg arrays containing the azimuth and
-    zenith of the training nodes (in degrees)
-
-    """
-
-    training_zd_deg = []
-    training_az_deg = []
-
-    for dir in training_dirs:
-        c1 = dir.find('_theta_') + 7
-        c2 = dir.find('_az_', c1) + 4
-        c3 = dir.find('_', c2)
-        training_zd_deg.append(float(dir[c1:c2 - 4]))
-        training_az_deg.append(float(dir[c2:c3]))
-
-    training_zd_deg = np.array(training_zd_deg)
-    training_az_deg = np.array(training_az_deg)
-    # The order of the pointings is irrelevant
-
-    return training_az_deg, training_zd_deg
-
 
 def add_zd_interpolation_info(dl2table, training_zd_deg, training_az_deg):
     """

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -215,7 +215,7 @@ def train_energy(train, custom_config=None):
     Parameters
     ----------
     train: `pandas.DataFrame`
-    custom_config: dictionnary
+    custom_config: dictionary
         Modified configuration to update the standard one
 
     Returns

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -7,7 +7,6 @@ Usage:
 "import dl1_to_dl2"
 """
 
-import glob
 import os
 import logging
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -199,8 +199,8 @@ def predict_with_zd_interpolation(rf, param_array, features):
 
     features: list of the names of the image features used by the RF
 
-    Return: event-wise 1d array of interpolated RF predictions (e.g. log
-    energy, or gammaness, etc depending on the RF)
+    Return: interpolated RF predictions. 1D array for regressors (log energy,
+    or disp_norm), 2D (events, # of classes) for classifiers
 
     """
 
@@ -233,7 +233,7 @@ def predict_with_zd_interpolation(rf, param_array, features):
 
     # Interpolated RF prediction:
     if is_classifier:
-        prediction = (prediction_0.T * param_array['w0'].values+
+        prediction = (prediction_0.T * param_array['w0'].values +
                       prediction_1.T * param_array['w1'].values).T
     else:
         prediction = (prediction_0 * param_array['w0'] +

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -757,9 +757,7 @@ def apply_models(dl1,
                  cls_disp_sign=None,
                  effective_focal_length=29.30565 * u.m,
                  custom_config=None,
-                 interpolate_rf={'energy_regression': False,
-                                 'particle_classification': False,
-                                 'disp': False},
+                 interpolate_rf=None,
                  training_pointings=None
                  ):
     """
@@ -809,6 +807,11 @@ def apply_models(dl1,
     classification_features = config["particle_classification_features"]
     events_filters = config["events_filters"]
 
+    # If no settings are provided for RF interpolation, it is switched off:
+    if interpolate_rf is None:
+        interpolate_rf = {'energy_regression': False,
+                          'particle_classification': False,
+                          'disp': False}
 
     dl2 = utils.filter_events(dl1,
                               filters=events_filters,

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -232,13 +232,13 @@ def predict_with_zd_interpolation(rf, param_array, features, is_proba=False):
     # Interpolated RF prediction:
 
     if is_proba:
-        prediction = (prediction_0.T * param_array['w0'] +
-                      prediction_1.T * param_array['w1']).T
+        prediction = (prediction_0.T * param_array['w0'].values+
+                      prediction_1.T * param_array['w1'].values).T
     else:
         prediction = (prediction_0 * param_array['w0'] +
-                      prediction_1 * param_array['w1'])
+                      prediction_1 * param_array['w1']).values
 
-    return prediction.values
+    return prediction
 
 def train_energy(train, custom_config=None):
     """

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -53,7 +53,7 @@ __all__ = [
     'update_disp_with_effective_focal_length'
 ]
 
-def add_zd_interpolation_info(dl2table, training_zd_deg, training_az_deg):
+def add_zd_interpolation_info(dl2table, training_pointings):
     """
     Compute necessary parameters for the interpolation of RF predictions
     between the zenith pointings of the MC data in the training sample on
@@ -69,8 +69,8 @@ def add_zd_interpolation_info(dl2table, training_zd_deg, training_az_deg):
     predictions at those two pointings, provide the interpolated result for
     each event's pointing
 
-    training_zd_deg: array containing the zenith distances (in deg) for the
-    MC training nodes
+    training_pointings: astropy Table containing the pointings (zd,
+    az) of the MC training nodes
 
     training_az_deg: array containing the azimuth angles (in deg) for the
     MC training nodes (a given index in bith arrays corresponds to a given MC
@@ -86,8 +86,8 @@ def add_zd_interpolation_info(dl2table, training_zd_deg, training_az_deg):
     alt_tel = dl2table['alt_tel']
     az_tel  = dl2table['az_tel']
 
-    training_alt_rad = np.pi / 2 - np.deg2rad(training_zd_deg)
-    training_az_rad = np.deg2rad(training_az_deg)
+    training_alt_rad = np.pi / 2 - training_pointings['zd'].to(u.rad).value
+    training_az_rad = training_pointings['az'].to(u.rad).value
 
     tiled_az = np.tile(az_tel,
                        len(training_az_rad)).reshape(len(training_az_rad),
@@ -830,9 +830,7 @@ def apply_models(dl1,
 
     if True in interpolate_rf.values():
         # Interpolation of RF predictions is switched on
-        training_az_deg = training_pointings['az'].to(u.deg).value
-        training_zd_deg = training_pointings['zd'].to(u.deg).value
-        dl2 = add_zd_interpolation_info(dl2, training_zd_deg, training_az_deg)
+        dl2 = add_zd_interpolation_info(dl2, training_pointings)
 
     # Reconstruction of Energy and disp_norm distance
     if isinstance(reg_energy, (str, bytes, Path)):

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -102,7 +102,6 @@ def add_zd_interpolation_info(dl2table, training_zd_deg, training_az_deg):
     between the zenith pointings of the MC data in the training sample on
     which the RFs were trained.
 
-
     Parameters:
     -----------
     dl2table: pandas dataframe. Four columns will be added: alt0, alt1, w0, w1
@@ -114,12 +113,16 @@ def add_zd_interpolation_info(dl2table, training_zd_deg, training_az_deg):
 
     training_zd_deg: array containing the zenith distances (in deg) for the
     MC training nodes
+
     training_az_deg: array containing the azimuth angles (in deg) for the
     MC training nodes (a given index in bith arrays corresponds to a given MC
     pointing)
 
-    """
+    Returns:
+    -------
+    DL2 pandas dataframe with additional columns alt0, alt1, w0, w1
 
+    """
     pd.options.mode.copy_on_write = True
 
     alt_tel = dl2table['alt_tel']
@@ -158,10 +161,10 @@ def add_zd_interpolation_info(dl2table, training_zd_deg, training_az_deg):
                                w0=pd.Series(w0).values,
                                w1=pd.Series(w1).values)
 
-    return dl2table, ['alt0', 'alt1', 'w0', 'w1']
+    return dl2table
 
 
-def predict_with_zd_interpolation(rf, param_array, features):
+def predict_with_zd_interpolation(rf, param_array, features, is_proba=False):
     """
     Obtain a RF prediction which takes into account the difference between
     the telescope elevation (alt_tel, i.e. 90 deg - zenith) and those of the
@@ -195,6 +198,8 @@ def predict_with_zd_interpolation(rf, param_array, features):
     add_zd_interpolation_info
 
     features: list of the names of the image features used by the RF
+
+    is_proba: if True predict_proba will be called instead of predict 
 
     Return: event-wise 1d array of interpolated RF predictions (e.g. log
     energy, or gammaness, etc depending on the RF)
@@ -838,13 +843,13 @@ def apply_models(dl1,
 
     # If dl1_training_dir was provided (containing folders for each fo the MC
     # training pointing nodes), obtain the training pointings, and update the
-    # DL2 table with the additiona info needed for the interpolation:
+    # DL2 table with the additional info needed for the interpolation:
 
     coszd_interpolated_RF = False
     if dl1_training_dir is not None:
         coszd_interpolated_RF = True
         training_az_deg, training_zd_deg = get_training_directions(dl1_training_dir)
-        add_zd_interpolation_info(dl2, training_zd_deg, training_az_deg)
+        dl2 = add_zd_interpolation_info(dl2, training_zd_deg, training_az_deg)
 
     # Reconstruction of Energy and disp_norm distance
     if isinstance(reg_energy, (str, bytes, Path)):

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -860,17 +860,16 @@ def apply_models(dl1,
     # taking into account of the abrration effect using effective focal length
     is_simu = 'disp_norm' in dl2.columns
     if is_simu:
-        dl2 = update_disp_with_effective_focal_length(dl2, effective_focal_length = effective_focal_length)
+        dl2 = update_disp_with_effective_focal_length(dl2,
+                                                      effective_focal_length=effective_focal_length)
 
     # If dl1_training_dir was provided (containing folders for each fo the MC
     # training pointing nodes), obtain the training pointings, and update the
     # DL2 table with the additional info needed for the interpolation:
-
-    if dl1_training_dir is not None:
+    if dl1_training_dir is not None and dl1_training_dir.is_dir():
         training_az_deg, training_zd_deg = get_training_directions(dl1_training_dir)
         dl2 = add_zd_interpolation_info(dl2, training_zd_deg, training_az_deg)
-
-    if not dl1_training_dir.is_dir():
+    else:
         logger.warning('DL1 training directory not found...')
         logger.warning('Switching off RF interpolation with zenith!')
         interpolate_rf['energy_regression'] = False

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -117,10 +117,10 @@ def add_zd_interpolation_info(dl2table, training_pointings):
 
     # Update the dataframe:
     with pd.option_context('mode.copy_on_write', True):
-        dl2table = dl2table.assign(alt0=pd.Series(closest_alt).values,
-                                   alt1=pd.Series(second_closest_alt).values,
-                                   w0=pd.Series(w0).values,
-                                   w1=pd.Series(w1).values)
+        dl2table = dl2table.assign(alt0=closest_alt,
+                                   alt1=second_closest_alt,
+                                   w0=w0,
+                                   w1=w1)
 
     return dl2table
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -231,8 +231,12 @@ def predict_with_zd_interpolation(rf, param_array, features, is_proba=False):
 
     # Interpolated RF prediction:
 
-    prediction = (prediction_0 * param_array['w0'] +
-                  prediction_1 * param_array['w1'])
+    if is_proba:
+        prediction = (prediction_0.T * param_array['w0'] +
+                      prediction_1.T * param_array['w1']).T
+    else:
+        prediction = (prediction_0 * param_array['w0'] +
+                      prediction_1 * param_array['w1'])
 
     return prediction.values
 

--- a/lstchain/reco/dl1_to_dl2.py
+++ b/lstchain/reco/dl1_to_dl2.py
@@ -89,12 +89,10 @@ def add_zd_interpolation_info(dl2table, training_pointings):
     training_alt_rad = np.pi / 2 - training_pointings['zd'].to(u.rad).value
     training_az_rad = training_pointings['az'].to(u.rad).value
 
-    tiled_az = np.tile(az_tel,
-                       len(training_az_rad)).reshape(len(training_az_rad),
-                                                     len(dl2table)).T
-    tiled_alt = np.tile(alt_tel,
-                       len(training_alt_rad)).reshape(len(training_alt_rad),
-                                                      len(dl2table)).T
+    tiled_az = np.broadcast_to(az_tel[:, np.newaxis],
+                               (len(dl2table), len(training_az_rad)))
+    tiled_alt = np.broadcast_to(alt_tel[:, np.newaxis],
+                                (len(dl2table), len(training_az_rad)))
 
     delta_alt = np.abs(training_alt_rad - tiled_alt)
     # mask to select training nodes only on the same side of the source

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -74,7 +74,7 @@ parser.add_argument('--config', '-c',
                     default=None,
                     required=False)
 
-def apply_to_file(filename, models_dict, output_dir, config):
+def apply_to_file(filename, models_dict, output_dir, config, models_path):
 
     data = pd.read_hdf(filename, key=dl1_params_lstcam_key)
 
@@ -102,8 +102,7 @@ def apply_to_file(filename, models_dict, output_dir, config):
                       }
     if dl1_training_dir is None:
         # Build name of DL1 MC training files assuming standard pattern:
-        models_dir = models_dict['reg_energy'].parent()
-        dummy = models_dir.as_posix().replace('/data/models', '/data/mc/DL1')
+        dummy = models_path.as_posix().replace('/data/models', '/data/mc/DL1')
         dl1_training_dir = Path(dummy[:dummy.rfind('/dec')] +
                                 '/TrainingDataset/GammaDiffuse/' +
                                 dummy[dummy.rfind('/dec')+1:])
@@ -337,8 +336,9 @@ def main():
         else:
             models_dict[models_key] = joblib.load(models_path)
 
-    for filename in args.input_files:
-        apply_to_file(filename, models_dict, args.output_dir, config)
+    for filename in args.input_files:pply_to_file
+        apply_to_file(filename, models_dict, args.output_dir, config,
+                      args.path_models)
 
 
 if __name__ == '__main__':

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -165,8 +165,8 @@ def apply_to_file(filename, models_dict, output_dir, config, models_path):
             dirs = glob.glob(str(dl1_training_dir) + '/node_corsika*')
             training_az_deg, training_zd_deg = get_training_directions(dirs)
             training_pointings = np.array([training_az_deg, training_zd_deg]).T
-            logger.warning('RF training pointings (az_deg, zd_deg):')
-            logger.warning(training_pointings)
+            logger.info('RF training pointings (az_deg, zd_deg):')
+            logger.info(training_pointings)
         else:
             logger.warning('DL1 training directory not found...')
             logger.warning('Switching off RF interpolation with zenith!')

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -164,6 +164,7 @@ def apply_to_file(filename, models_dict, output_dir, config, models_path):
         if dl1_training_dir.is_dir():
             dirs = glob.glob(str(dl1_training_dir) + '/node_corsika*')
             training_az_deg, training_zd_deg = get_training_directions(dirs)
+            training_pointings = np.array([training_az_deg, training_zd_deg]).T
         else:
             logger.warning('DL1 training directory not found...')
             logger.warning('Switching off RF interpolation with zenith!')
@@ -171,7 +172,6 @@ def apply_to_file(filename, models_dict, output_dir, config, models_path):
             interpolate_rf['particle_classification'] = False
             interpolate_rf['disp'] = False
 
-        training_pointings = np.array([training_az_deg, training_zd_deg]).T
 
 
     if 'lh_fit_config' in config.keys():

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -7,6 +7,7 @@ Run lstchain_dl1_to_dl2 --help to see the options.
 """
 
 import argparse
+import glob
 from pathlib import Path
 import joblib
 import logging

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -82,7 +82,7 @@ def apply_to_file(filename, models_dict, output_dir, config, models_path):
     # Read in the settings for the interpolation of Random Forest predictions
     # in cos(zd). If activated this avoids the jumps of performance produced
     # by the discrete set of pointings in the RF training sample.
-    if 'random_forest_zd_interpolation' in config.keys():
+    if 'random_forest_zd_interpolation' in config:
         zdinter = config['random_forest_zd_interpolation']
         interpolate_energy = zdinter.get('interpolate_energy', False)
         interpolate_gammaness = zdinter.get('interpolate_gammaness', False)

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -336,7 +336,7 @@ def main():
         else:
             models_dict[models_key] = joblib.load(models_path)
 
-    for filename in args.input_files:pply_to_file
+    for filename in args.input_files:
         apply_to_file(filename, models_dict, args.output_dir, config,
                       args.path_models)
 

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -286,8 +286,9 @@ def main():
             pass
 
     if args.dl1_training_dir is not None:
-        logger.info('Cos(zenith) interpolation will be used in Random Forests')
-        logger.info('DL1 training directory:', args.dl1_training_dir)
+        logger.warning('Cos(zenith) interpolation will be used in Random '
+                       'Forests')
+        logger.warning('DL1 training directory: ' + str(args.dl1_training_dir))
 
     config = replace_config(standard_config, custom_config)
 

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -79,20 +79,14 @@ def apply_to_file(filename, models_dict, output_dir, config, models_path):
 
     data = pd.read_hdf(filename, key=dl1_params_lstcam_key)
 
-    interpolate_energy = False
-    interpolate_gammaness = False
-    interpolate_direction = False
     # Read in the settings for the interpolation of Random Forest predictions
     # in cos(zd). If activated this avoids the jumps of performance produced
     # by the discrete set of pointings in the RF training sample.
     if 'random_forest_zd_interpolation' in config.keys():
         zdinter = config['random_forest_zd_interpolation']
-        if 'interpolate_energy' in zdinter.keys():
-            interpolate_energy = zdinter['interpolate_energy']
-        if 'interpolate_gammaness' in zdinter.keys():
-            interpolate_gammaness = zdinter['interpolate_gammaness']
-        if 'interpolate_direction' in zdinter.keys():
-            interpolate_direction = zdinter['interpolate_direction']
+        interpolate_energy = zdinter.get('interpolate_energy', False)
+        interpolate_gammaness = zdinter.get('interpolate_gammaness', False)
+        interpolate_direction = zdinter.get('interpolate_direction', False)
 
     interpolate_rf = {'energy_regression': interpolate_energy,
                       'particle_classification': interpolate_gammaness,

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -140,13 +140,13 @@ def apply_to_file(filename, models_dict, output_dir, config, models_path):
     dl1_training_dir = None
     training_pointings = None
     if True in interpolate_rf.values():
-        logger.warning('Cos(zenith) interpolation will be used in:')
+        logger.info('Cos(zenith) interpolation will be used in:')
         if interpolate_energy:
-            logger.warning('   energy reconstruction Random Forest')
+            logger.info('   energy reconstruction Random Forest')
         if interpolate_gammaness:
-            logger.warning('   g/h classification Random Forest')
+            logger.info('   g/h classification Random Forest')
         if interpolate_direction:
-            logger.warning('   direction reconstruction Random Forest')
+            logger.info('   direction reconstruction Random Forest')
 
         if 'random_forest_zd_interpolation' in config.keys():
             zdinter = config['random_forest_zd_interpolation']

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -7,7 +7,6 @@ Run lstchain_dl1_to_dl2 --help to see the options.
 """
 
 import argparse
-import glob
 from pathlib import Path
 import joblib
 import logging

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -78,7 +78,11 @@ parser.add_argument('--dl1_training_dir', '-t',
                     action='store',
                     type=Path,
                     dest='dl1_training_dir',
-                    help='Path to parent directory of DL1 training folders',
+                    help='Path to parent directory of DL1 training folders. '
+                         'If given, the pointings of the training sample will be '
+                         'obtained, and RF predictions will be interpolated '
+                         '(lineary in cos(zenith) to the instantaneous '
+                         'telescope pointing for each event',
                     default=None,
                     required=False)
 

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -165,6 +165,8 @@ def apply_to_file(filename, models_dict, output_dir, config, models_path):
             dirs = glob.glob(str(dl1_training_dir) + '/node_corsika*')
             training_az_deg, training_zd_deg = get_training_directions(dirs)
             training_pointings = np.array([training_az_deg, training_zd_deg]).T
+            logger.warning('RF training pointings (az_deg, zd_deg):')
+            logger.warning(training_pointings)
         else:
             logger.warning('DL1 training directory not found...')
             logger.warning('Switching off RF interpolation with zenith!')

--- a/lstchain/scripts/lstchain_dl1_to_dl2.py
+++ b/lstchain/scripts/lstchain_dl1_to_dl2.py
@@ -74,6 +74,44 @@ parser.add_argument('--config', '-c',
                     default=None,
                     required=False)
 
+def get_training_directions(training_dirs):
+    """
+    This function obtains the pointings of the telescope in the RF training
+    sample.
+
+    Parameters:
+    -----------
+    training_dirs: array of strings, each element is the name of one of the
+    folders containing the DL1 files used in the training. Order is
+    irrelevant. The folders' names are assumed to follow this pattern:
+
+    node_corsika_theta_34.367_az_69.537_
+
+    (theta is zenith; az is azimuth. Units are degrees, note that the values'
+    field lengths are not fixed)
+
+    Returns: training_az_deg, training_zd_deg arrays containing the azimuth and
+    zenith of the training nodes (in degrees)
+
+    """
+
+    training_zd_deg = []
+    training_az_deg = []
+
+    for dir in training_dirs:
+        c1 = dir.find('_theta_') + 7
+        c2 = dir.find('_az_', c1) + 4
+        c3 = dir.find('_', c2)
+        training_zd_deg.append(float(dir[c1:c2 - 4]))
+        training_az_deg.append(float(dir[c2:c3]))
+
+    training_zd_deg = np.array(training_zd_deg)
+    training_az_deg = np.array(training_az_deg)
+    # The order of the pointings is irrelevant
+
+    return training_az_deg, training_zd_deg
+
+
 def apply_to_file(filename, models_dict, output_dir, config, models_path):
 
     data = pd.read_hdf(filename, key=dl1_params_lstcam_key)


### PR DESCRIPTION
This should solve the issue of RF "performance jumps" at high zenith angles, when the pointing goes through the middle points between training nodes. See #1317

**NOTE: this is a different implementation of the interpolation approach proposed by @gabemery, see branch https://github.com/cta-observatory/cta-lstchain/tree/dl2_RF_interpolate)**

If the interpolation option is activated we call the RF predictors twice, for each of the two closest MC training nodes, then interpolate (or extrapolate) the values to the actual telescope pointing for each event.

Currently the training sample pointings are obtained from the path to the training sample(provided via config file). A better solution would be to add to the .sav files an array with the zenith and azimuth values of the MC training nodes.