### PR TITLE
Fix issue with FoV offset binnning when using energy dependant theta cut and diffuse MC

### DIFF
--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -410,9 +410,9 @@ class IRFFITSWriter(Tool):
             if np.max(fov_offset_bins) > gammas["true_source_fov_offset"].max():
                 self.log.warning(f'The highest FoV offset bin ({np.max(fov_offset_bins)}) is larger than the maximum offset simulated ({gammas["true_source_fov_offset"].max()})')
 
-
         gammas = self.event_sel.filter_cut(gammas)
         gammas = self.cuts.allowed_tels_filter(gammas)
+        gammas = gammas[gammas['true_source_fov_offset'] <= np.max(fov_offset_bins)]
 
         if self.energy_dependent_gh:
             self.gh_cuts_gamma = self.cuts.energy_dependent_gh_cuts(

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -407,6 +407,10 @@ class IRFFITSWriter(Tool):
             fov_offset_bins = self.data_bin.fov_offset_bins()
             self.log.info("Multiple offset for diffuse gamma MC")
 
+            if np.max(fov_offset_bins) > gammas["true_source_fov_offset"].max():
+                self.log.warning(f'The highest FoV offset bin ({np.max(fov_offset_bins)}) is larger than the maximum offset simulated ({gammas["true_source_fov_offset"].max()})')
+
+
         gammas = self.event_sel.filter_cut(gammas)
         gammas = self.cuts.allowed_tels_filter(gammas)
 


### PR DESCRIPTION
This PR fix the issue #1322 . The bloc of code managing the FoV binning as been moved too.

The PR also add a warning message if the FoV binning is wider than the simulated FoV, and restrict the gammas used for the computation of energy dependant cuts (gh and theta) to the ones within the FoV range considered for the IRF.