### PR TITLE
Pin scikit-learn to 1.2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'pyirf~=0.10.0',
         'scipy>=1.8,<1.12',
         'seaborn',
-        'scikit-learn~=1.2',
+        'scikit-learn~=1.2.2',
         'tables',
         'toml',
         'protozfits>=2.5,<3',


### PR DESCRIPTION
When doing a new lstchain installation, usually the sklearn version ends up being later than 1.2.x (setup.py requires `=~1.2`, which will install the latest 1.x version), the one used to produce existing RF models. One needs to use the same sklearn version in dl1 to dl2 as the one used to produce the models.