### PR TITLE
Better R0g r0v compression, drop python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install doc dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         ctapipe-version: ["v0.19.2"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install doc dependencies
         run: |

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - iminuit>=2
   - joblib~=1.2.0
   - toml
-  - protozfits=2.5
+  - protozfits=2.6
   - pyparsing
   - scipy~=1.11.4
   - scikit-learn=1.2

--- a/lstchain/scripts/lstchain_r0_to_r0g.py
+++ b/lstchain/scripts/lstchain_r0_to_r0g.py
@@ -118,7 +118,7 @@ def main():
                     n_tiles=n_tiles,
                     rows_per_tile=rows_per_tile,
                     compression_block_size_kb=64*1024,
-                    defaul_compression="zstd9"))
+                    defaul_compression="lst-r1v1-uncalibrated"))
             stream.open(str(name))
 
             stream.move_to_new_table("DataStream")

--- a/lstchain/scripts/lstchain_r0g_to_r0v.py
+++ b/lstchain/scripts/lstchain_r0g_to_r0v.py
@@ -118,7 +118,7 @@ def main():
                     n_tiles=n_tiles,
                     rows_per_tile=rows_per_tile,
                     compression_block_size_kb=64*1024,
-                    defaul_compression="zstd9"))
+                    defaul_compression="lst-r1v1-uncalibrated"))
             stream.open(str(name))
 
             stream.move_to_new_table("DataStream")

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,4 +10,4 @@ long_description_content_type = text/markdown
 github_project = cta-observatory/cta-lstchain
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.10

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'scikit-learn~=1.2',
         'tables',
         'toml',
-        'protozfits>=2.5,<3',
+        'protozfits>=2.6.1,<3',
         'pymongo',
         'pyparsing',
         'setuptools_scm',


### PR DESCRIPTION
This is intended to enable a more efficient lossless compression for R0G and R0V files

It uses protozfits 2.6.1. Since that version only supports python >= 3.10, we have had to raise lstchain's minimal requirement to python >=3.10


 