### PR TITLE
Fix issue with FoV offset binnning when using energy dependant theta cut and diffuse MC

### DIFF
--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -709,7 +709,8 @@ class IRFFITSWriter(Tool):
                 self.hdus.append(
                     create_rad_max_hdu(
                         self.theta_cuts["cut"][:, np.newaxis],
-                        reco_energy_bins, fov_offset_bins,
+                        reco_energy_bins, fov_offset_bins[[fov_offset_bins.argmin(),
+                                                           fov_offset_bins.argmax()]],
                         **extra_headers
                     )
                 )

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -401,11 +401,11 @@ class IRFFITSWriter(Tool):
         if self.mc_particle["gamma"]["mc_type"] in ["point_like", "ring_wobble"]:
             # The 4 is semi-arbitray. This keeps the same precision as the previous code
             mean_fov_offset = np.round(get_mc_fov_offset(self.mc_particle["gamma"]["file"]), 4)
-            self.log.info(f"Single offset for point like gamma MC with offset {mean_fov_offset}")
             fov_offset_bins = [mean_fov_offset - 0.1, mean_fov_offset + 0.1] * u.deg
+            self.log.info(f"Single offset for point like gamma MC with offset {mean_fov_offset}")
         else:
             fov_offset_bins = self.data_bin.fov_offset_bins()
-            self.log.info("Multiple offset for diffuse gamma MC")
+            self.log.info(f"Multiple offset for diffuse gamma MC : {fov_offset_bins}")
 
             if np.max(fov_offset_bins) > gammas["true_source_fov_offset"].max():
                 self.log.warning(f'The highest FoV offset bin ({np.max(fov_offset_bins)}) is larger than the maximum offset simulated ({gammas["true_source_fov_offset"].max()})')

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -410,9 +410,9 @@ class IRFFITSWriter(Tool):
             if np.max(fov_offset_bins) > gammas["true_source_fov_offset"].max():
                 self.log.warning(f'The highest FoV offset bin ({np.max(fov_offset_bins)}) is larger than the maximum offset simulated ({gammas["true_source_fov_offset"].max()})')
 
-
         gammas = self.event_sel.filter_cut(gammas)
         gammas = self.cuts.allowed_tels_filter(gammas)
+        gammas = gammas[gammas['true_source_fov_offset'] <= np.max(fov_offset_bins)]
 
         if self.energy_dependent_gh:
             self.gh_cuts_gamma = self.cuts.energy_dependent_gh_cuts(

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -407,6 +407,10 @@ class IRFFITSWriter(Tool):
             fov_offset_bins = self.data_bin.fov_offset_bins()
             self.log.info("Multiple offset for diffuse gamma MC")
 
+            if np.max(fov_offset_bins) > gammas["true_source_fov_offset"].max():
+                self.log.warning(f'The highest FoV offset bin ({np.max(fov_offset_bins)}) is larger than the maximum offset simulated ({gammas["true_source_fov_offset"].max()})')
+
+
         gammas = self.event_sel.filter_cut(gammas)
         gammas = self.cuts.allowed_tels_filter(gammas)
 


### PR DESCRIPTION
This PR fix the issue https://github.com/cta-observatory/cta-lstchain/issues/1322 . The bloc of code managing the FoV binning as been moved too.

The PR also add a warning message if the FoV binning is wider than the simulated FoV, and restrict the gammas used for the computation of energy dependant cuts (gh and theta) to the ones within the FoV range considered for the IRF.