### PR TITLE
Use provided muons directory

### DIFF
--- a/lstchain/datachecks/dl1_checker.py
+++ b/lstchain/datachecks/dl1_checker.py
@@ -50,7 +50,7 @@ from lstchain.paths import (
 )
 
 
-def check_dl1(filenames, output_path, max_cores=4, create_pdf=False, batch=False):
+def check_dl1(filenames, output_path, max_cores=4, create_pdf=False, batch=False, muons_dir=None):
     """
     Check DL1 files
 
@@ -177,15 +177,18 @@ def check_dl1(filenames, output_path, max_cores=4, create_pdf=False, batch=False
                         [trigger_source.encode('ascii')])
     file.close()
 
-    # do the plots and save them to a pdf file. We will look for the muons fits
-    # files in the same directory as the DL1 files (assuming all of them are
-    # in the same directory as the first one!)
+    # do the plots and save them to a pdf file
     if create_pdf:
+        if muons_dir is None:
+            # if not provided, assume muons .fits files are in the 
+            # same directory as the DL1 files:
+            muons_dir = os.path.dirname(filenames[0])
+        
         plot_datacheck(
             datacheck_filename,
             output_path,
             batch,
-            muons_dir=os.path.dirname(filenames[0]),
+            muons_dir=muons_dir,
             tel_id=first_file.tel_id
         )
 

--- a/lstchain/scripts/lstchain_check_dl1.py
+++ b/lstchain/scripts/lstchain_check_dl1.py
@@ -114,7 +114,8 @@ def main():
 
     # otherwise, do the full analysis to produce the dl1_datacheck h5 file
     # and the associated pdf:
-    check_dl1(filenames, args.output_dir, args.max_cores, not args.omit_pdf, args.batch)
+    check_dl1(filenames, args.output_dir, args.max_cores, not args.omit_pdf, 
+              args.batch, args.muons_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It did not work when the "pdf" option was used with subrun-wise DL1 files as input (as opposed to subrun-wise datacheck files)