### PR TITLE
Clean lstchain_check_dl1.py logging

### DIFF
--- a/lstchain/scripts/lstchain_check_dl1.py
+++ b/lstchain/scripts/lstchain_check_dl1.py
@@ -97,6 +97,7 @@ def main():
         logger.error('Unknown options: ' + ukn)
         exit(-1)
 
+    logger.info('Executing {}'.format(__name__))
     logger.info('input files: {}'.format(args.input_file))
     logger.info('output directory: {}'.format(args.output_dir))
 

--- a/lstchain/scripts/lstchain_check_dl1.py
+++ b/lstchain/scripts/lstchain_check_dl1.py
@@ -85,8 +85,8 @@ def main():
     geomlogger = logging.getLogger('ctapipe.instrument.camera')
     geomlogger.setLevel(logging.ERROR)
 
-    # Avoid provenance info messages ("call start_activity") from call 
-    # to load_camera_geometry:
+    # Avoid provenance info messages ("No activity has been explicitly 
+    # started..."), which come from call to load_camera_geometry():
     provlogger = logging.getLogger('ctapipe.core.provenance')
     provlogger.setLevel(logging.WARNING)
 

--- a/lstchain/scripts/lstchain_check_dl1.py
+++ b/lstchain/scripts/lstchain_check_dl1.py
@@ -85,6 +85,11 @@ def main():
     geomlogger = logging.getLogger('ctapipe.instrument.camera')
     geomlogger.setLevel(logging.ERROR)
 
+    # Avoid provenance info messages ("call start_activity") from call 
+    # to load_camera_geometry:
+    provlogger = logging.getLogger('ctapipe.core.provenance')
+    provlogger.setLevel(logging.WARNING)
+
     if len(unknown) > 0:
         ukn = ''
         for s in unknown:


### PR DESCRIPTION
Just to get rid of messages

`No activity has been explicitly started, starting new default activity. Consider calling Provenance().start_activity(<name>) explicitly.`

which come from a call to load_camera_geometry()