### PR TITLE
Correct Subarray info in output DL1 files

### DIFF
--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -27,7 +27,7 @@ from ctapipe.image import (
     apply_time_delta_cleaning,
 )
 from ctapipe.instrument import SubarrayDescription
-from ctapipe_io_lst import constants, OPTICS, LSTEventSource
+from ctapipe_io_lst import constants, LSTEventSource
 
 
 from lstchain.calib.camera.pixel_threshold_estimation import get_threshold_from_dl1_file


### PR DESCRIPTION
If an outdated Subarray info is found in input file, it is not propagated to the output. A new one is created and saved instead.
This makes that even for v0.9 DL1 input files, the output DL1 file contains v0.10-compliant Subarray info. 