### PR TITLE
Energy dependent cuts for IRFs and DL3

### DIFF
--- a/docs/examples/irf_dl3_tool_config_edepcuts.json
+++ b/docs/examples/irf_dl3_tool_config_edepcuts.json
@@ -1,0 +1,56 @@
+{
+  "EventSelector": {
+    "filters": {
+      "intensity": [50, Infinity],
+      "width": [0, Infinity],
+      "length": [0, Infinity],
+      "r": [0, 1],
+      "wl": [0.01, 1],
+      "leakage_intensity_width_2": [0, 1],
+      "event_type": [32, 32]
+    }
+  },
+  "IRFFITSWriter": {
+    "cut_strategy_gh": "edep_custom",
+    "cut_strategy_theta": "edep_custom",
+    "cut_strategy_alpha": "edep_custom",
+    "interpolate_custom": "nearest"
+  },
+  "DL3Cuts": {
+    "min_event_p_en_bin": 100,
+    "energy_dependent_gh_cut": {
+      "energy_bins": [0.01, 0.1, 1, 10, 100],
+      "cut": [0.4, 0.45, 0.50, 0.55]
+    },
+    "energy_dependent_theta_cut": {
+      "energy_bins": [0.01, 0.1, 1, 10, 100],
+      "cut": [0.37, 0.35, 0.3, 0.25]
+    },
+    "energy_dependent_alpha_cut": {
+      "energy_bins": [0.01, 0.1, 1, 10, 100],
+      "cut": [4, 4.5, 5, 5.5]
+    },
+    "allowed_tels": [1]
+  },
+  "DataBinning": {
+    "true_energy_min": 0.005,
+    "true_energy_max": 500,
+    "true_energy_n_bins": 25,
+    "scale_true_energy": 1.0,
+    "reco_energy_min": 0.005,
+    "reco_energy_max": 500,
+    "reco_energy_n_bins": 25,
+    "energy_migration_min": 0.2,
+    "energy_migration_max": 5,
+    "energy_migration_n_bins": 30,
+    "fov_offset_min": 0.1,
+    "fov_offset_max": 1.1,
+    "fov_offset_n_edges": 9,
+    "bkg_fov_offset_min": 0,
+    "bkg_fov_offset_max": 10,
+    "bkg_fov_offset_n_edges": 21,
+    "source_offset_min": 0,
+    "source_offset_max": 1,
+    "source_offset_n_edges": 101
+  }
+}

--- a/lstchain/io/event_selection.py
+++ b/lstchain/io/event_selection.py
@@ -1,5 +1,6 @@
 import numpy as np
 import operator
+from astropy.table import QTable
 import astropy.units as u
 
 from ctapipe.core import Component
@@ -9,6 +10,8 @@ from lstchain.reco.utils import filter_events
 
 
 from pyirf.cuts import calculate_percentile_cut, evaluate_binned_cut
+
+from scipy.interpolate import interp1d
 
 
 __all__ = ["EventSelector", "DL3Cuts", "DataBinning"]
@@ -67,6 +70,11 @@ class DL3Cuts(Component):
         default_value=0.95,
     ).tag(config=True)
 
+    energy_dependent_gh_cut = Dict(
+        help="Energy dependent selection cuts for gh_score (gammaness)",
+        default_value={},
+    ).tag(config=True)
+
     min_gh_cut = Float(
         help="Minimum gh_score (gammaness) cut in an energy bin",
         default_value=0.1,
@@ -105,6 +113,11 @@ class DL3Cuts(Component):
         default_value=0.2,
     ).tag(config=True)
 
+    energy_dependent_theta_cut = Dict(
+        help="Energy dependent selection cuts (deg) for theta",
+        default_value={},
+    ).tag(config=True)
+
     min_alpha_cut = Float(
         help="Minimum alpha cut (deg) in an energy bin",
         default_value=1,
@@ -131,6 +144,11 @@ class DL3Cuts(Component):
     global_alpha_cut = Float(
         help="Global selection cut (deg) for alpha",
         default_value=20,
+    ).tag(config=True)
+
+    energy_dependent_alpha_cut = Dict(
+        help="Energy dependent selection cuts (deg) for alpha",
+        default_value={},
     ).tag(config=True)
 
     allowed_tels = List(
@@ -332,6 +350,46 @@ class DL3Cuts(Component):
             operator.le,
         )
         return data[data["selected_alpha"]]
+
+
+    def from_dict(self, parameter, energy_bins, interpolate_kind='nearest'):
+        """
+        Convert the cut dictionary to a QTable for the requested parameter.
+        Parameters
+        ----------
+        parameter: string
+            'gh', 'theta' or 'alpha'
+        energy_bins: `astropy.units.quantity.Quantity`
+            energy bins used for the IRFs
+        interpolate_kind: string
+            Interpolation strategy for `scipy.interpolate.interp1d`
+
+        Returns
+        -------
+        cut_table: QTable
+            Energy dependent cuts for the requested parameter.
+
+        """
+        cut_table = QTable()
+
+        cuts_dict = {"gh": self.energy_dependent_gh_cut,
+                     "theta": self.energy_dependent_theta_cut,
+                     "alpha":self.energy_dependent_alpha_cut}[parameter]
+
+        unit = {"gh": 1,
+                "theta": u.deg,
+                "alpha": u.deg}[parameter]
+
+        input_ebins_center = (cuts_dict["energy_bins"][:-1]* u.TeV + cuts_dict["energy_bins"][1:] * u.TeV) * 0.5
+
+        cut_table["low"] =energy_bins[:-1]
+        cut_table["high"] = energy_bins[1:]
+        cut_table["center"] = 0.5 * (cut_table["low"] + cut_table["high"])
+        f_cut=interp1d(input_ebins_center, cuts_dict["cut"], kind=interpolate_kind, bounds_error=False,
+                       fill_value=(cuts_dict["cut"][0], cuts_dict["cut"][-1]), assume_sorted=True)
+        cut_table["cut"] = f_cut(cut_table["center"]) * unit
+
+        return cut_table
 
     def allowed_tels_filter(self, data):
         """

--- a/lstchain/tools/lstchain_create_dl3_file.py
+++ b/lstchain/tools/lstchain_create_dl3_file.py
@@ -361,10 +361,16 @@ class DataReductionFITSWriter(Tool):
             self.data = self.cuts.apply_energy_dependent_gh_cuts(
                 self.data, self.energy_dependent_gh_cuts
             )
-            self.log.info(
-                "Using gamma efficiency of "
-                f"{self.energy_dependent_gh_cuts.meta['GH_EFF']}"
-            )
+            if 'GH_EFF' in self.energy_dependent_gh_cuts.meta.keys():
+                self.log.info(
+                    "Using gamma efficiency of "
+                    f"{self.energy_dependent_gh_cuts.meta['GH_EFF']}"
+                )
+            else:
+                self.log.info(
+                    "Using energy dependent gamma efficiency : "
+                    f"{self.energy_dependent_gh_cuts.meta['GH_CUTS']}"
+                )
         else:
             self.cuts.global_gh_cut = self.irf_final_hdu[1].header["GH_CUT"]
             self.data = self.cuts.apply_global_gh_cut(self.data)

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -137,8 +137,8 @@ class IRFFITSWriter(Tool):
         -g /path/to/DL2_MC_gamma_file.h5
         -o /path/to/irf.fits.gz
         --point-like (Only for point_like IRFs)
-        --cut_strategy-gh efficiency
-        --cut_strategy-theta efficiency
+        --cut_strategy-gh edep_efficiency
+        --cut_strategy-theta edep_efficiency
         --gh-efficiency 0.95
         --theta-containment 0.68
 
@@ -147,8 +147,8 @@ class IRFFITSWriter(Tool):
         -g /path/to/DL2_MC_gamma_file.h5
         -o /path/to/irf.fits.gz
         --point-like (Only for point_like IRFs)
-        --cut_strategy-gh custom
-        --cut_strategy-theta custom
+        --cut_strategy-gh edep_custom
+        --cut_strategy-theta edep_custom
         --config /path/to/config.json (Must contain the custom cuts, see
         example provided in docs/examples/irf_dl3_tool_config_edepcuts.json)
 

--- a/lstchain/tools/lstchain_create_irf_files.py
+++ b/lstchain/tools/lstchain_create_irf_files.py
@@ -11,12 +11,18 @@ The default values are written in the EventSelector, DL3Cuts and
 DataBinning Component and also given in some example configs in docs/examples/
 
 By default, the Tool uses global cuts for gammaness and theta.
+To use an alternative strategy use the argument cut_strategy_X, with X being
+gh, theta or alpha, depending on which parameter is considered.
+Values for these arguments are global, edep_efficiency and edep_custom.
 
-For using energy-dependent gammaness cuts, use the argument gh_efficiency
-for passing the gamma efficiency value to calculate the gammaness cuts for
-each reco energy bin and the flag energy-dependent-gh.
-Similarly, for energy-dependent theta cuts, use the argument
-theta_containment and the flag energy-dependent-theta.
+When using energy-dependent gammaness cuts based on gamma efficiency,
+the gamma efficiency value to calculate the gammaness cuts for each reco
+energy bin can be passed using the argument gh-efficiency.
+Similarly, for energy-dependent theta cuts, use the argument theta_containment.
+
+To provide externally computed energy dependent cuts, fill in a config file the
+energy_dependent_X_cut, X being gh, theta or alpha, with the energy binning
+and cuts in a dictionary.
 
 The energy-dependent cuts are stored as HDUs - GH_CUTS and RAD_MAX,
 and saved with other IRFs.
@@ -131,10 +137,20 @@ class IRFFITSWriter(Tool):
         -g /path/to/DL2_MC_gamma_file.h5
         -o /path/to/irf.fits.gz
         --point-like (Only for point_like IRFs)
-        --energy-dependent-gh
-        --energy-dependent-theta
+        --cut_strategy-gh efficiency
+        --cut_strategy-theta efficiency
         --gh-efficiency 0.95
         --theta-containment 0.68
+
+    To use energy-dependent cuts obtained before:
+    > lstchain_create_irf_files
+        -g /path/to/DL2_MC_gamma_file.h5
+        -o /path/to/irf.fits.gz
+        --point-like (Only for point_like IRFs)
+        --cut_strategy-gh custom
+        --cut_strategy-theta custom
+        --config /path/to/config.json (Must contain the custom cuts, see
+        example provided in docs/examples/irf_dl3_tool_config_edepcuts.json)
 
     Or generate source-dependent IRFs
     > lstchain_create_irf_files
@@ -194,19 +210,28 @@ class IRFFITSWriter(Tool):
         default_value=False,
     ).tag(config=True)
 
-    energy_dependent_gh = traits.Bool(
-        help="True for applying energy-dependent gammaness cuts",
-        default_value=False,
+    cut_strategy_gh = traits.Unicode(
+        help="Define the strategy used for the gammaness cut."
+             "Possible values are global, edep_efficiency or edep_custom.",
+        default_value="global",
     ).tag(config=True)
 
-    energy_dependent_theta = traits.Bool(
-        help="True for applying energy-dependent theta cuts",
-        default_value=False,
+    cut_strategy_theta = traits.Unicode(
+        help="Define the strategy used for the theta cut."
+             "Possible values are global, edep_efficiency or edep_custom.",
+        default_value="global",
     ).tag(config=True)
 
-    energy_dependent_alpha = traits.Bool(
-        help="True for applying energy-dependent alpha cuts",
-        default_value=False,
+    cut_strategy_alpha = traits.Unicode(
+        help="Define the strategy used for the alpha cut."
+             "Possible values are global, edep_efficiency or edep_custom.",
+        default_value="global",
+    ).tag(config=True)
+
+    interpolate_custom = traits.Unicode(
+        help="Interpolation option for scipy.interpolate.interp1d used with "
+             "custom, energy dependent cuts.",
+        default_value="global",
     ).tag(config=True)
 
     overwrite = traits.Bool(
@@ -229,10 +254,13 @@ class IRFFITSWriter(Tool):
         "irf-obs-time": "IRFFITSWriter.irf_obs_time",
         "global-gh-cut": "DL3Cuts.global_gh_cut",
         "gh-efficiency": "DL3Cuts.gh_efficiency",
+        "energy_dependent_gh_cut": "DL3Cuts.energy_dependent_gh_cut",
         "theta-containment": "DL3Cuts.theta_containment",
         "global-theta-cut": "DL3Cuts.global_theta_cut",
+        "energy_dependent_theta_cut": "DL3Cuts.energy_dependent_theta_cut",
         "alpha-containment": "DL3Cuts.alpha_containment",
         "global-alpha-cut": "DL3Cuts.global_alpha_cut",
+        "energy_dependent_alpha_cut": "DL3Cuts.energy_dependent_alpha_cut",
         "allowed-tels": "DL3Cuts.allowed_tels",
         "overwrite": "IRFFITSWriter.overwrite",
         "scale-true-energy": "DataBinning.scale_true_energy"
@@ -250,18 +278,6 @@ class IRFFITSWriter(Tool):
         "source-dep": (
             {"IRFFITSWriter": {"source_dep": True}},
             "Source-dependent analysis will be performed",
-        ),
-        "energy-dependent-gh": (
-            {"IRFFITSWriter": {"energy_dependent_gh": True}},
-            "Uses energy-dependent cuts for gammaness",
-        ),
-        "energy-dependent-theta": (
-            {"IRFFITSWriter": {"energy_dependent_theta": True}},
-            "Uses energy-dependent cuts for theta",
-        ),
-        "energy-dependent-alpha": (
-            {"IRFFITSWriter": {"energy_dependent_alpha": True}},
-            "Uses energy-dependent cuts for alpha",
         ),
     }
 
@@ -414,17 +430,23 @@ class IRFFITSWriter(Tool):
         gammas = self.cuts.allowed_tels_filter(gammas)
         gammas = gammas[gammas['true_source_fov_offset'] <= np.max(fov_offset_bins)]
 
-        if self.energy_dependent_gh:
-            self.gh_cuts_gamma = self.cuts.energy_dependent_gh_cuts(
-                gammas, reco_energy_bins
-            )
+        if self.cut_strategy_gh[:4] == "edep":
+            if self.cut_strategy_gh == "edep_efficiency":
+                self.gh_cuts_gamma = self.cuts.energy_dependent_gh_cuts(
+                    gammas, reco_energy_bins
+                )
+                self.log.info(
+                    f"Using gamma efficiency of {self.cuts.gh_efficiency}"
+                )
+            if self.cut_strategy_gh == "edep_custom":
+                self.gh_cuts_gamma = self.cuts.from_dict("gh", reco_energy_bins, self.interpolate_custom)
+                self.log.info(
+                    f"Using provided energy dependent gammaness cuts"
+                )
             gammas = self.cuts.apply_energy_dependent_gh_cuts(
                 gammas, self.gh_cuts_gamma
             )
-            self.log.info(
-                f"Using gamma efficiency of {self.cuts.gh_efficiency}"
-            )
-        else:
+        elif self.cut_strategy_gh == "global":
             gammas = self.cuts.apply_global_gh_cut(gammas)
             self.log.info(
                 "Using a global gammaness cut of "
@@ -433,16 +455,22 @@ class IRFFITSWriter(Tool):
 
         if self.point_like:
             if not self.source_dep:
-                if self.energy_dependent_theta:
-                    self.theta_cuts = self.cuts.energy_dependent_theta_cuts(
-                        gammas, reco_energy_bins,
-                    )
+                if self.cut_strategy_theta[:4] == "edep":
+                    if self.cut_strategy_theta == "edep_efficiency":
+                        self.theta_cuts = self.cuts.energy_dependent_theta_cuts(
+                            gammas, reco_energy_bins,
+                        )
+                        self.log.info(
+                            "Using a containment region for theta of "
+                            f"{self.cuts.theta_containment}"
+                        )
+                    if self.cut_strategy_theta == "edep_custom":
+                        self.theta_cuts = self.cuts.from_dict("theta", reco_energy_bins, self.interpolate_custom)
+                        self.log.info(
+                            f"Using provided energy dependent theta cuts"
+                        )
                     gammas = self.cuts.apply_energy_dependent_theta_cuts(
                         gammas, self.theta_cuts
-                    )
-                    self.log.info(
-                        "Using a containment region for theta of "
-                        f"{self.cuts.theta_containment}"
                     )
                 else:
                     gammas = self.cuts.apply_global_theta_cut(gammas)
@@ -451,16 +479,22 @@ class IRFFITSWriter(Tool):
                         f"{self.cuts.global_theta_cut} for point-like IRF"
                     )
             else:
-                if self.energy_dependent_alpha:
-                    self.alpha_cuts = self.cuts.energy_dependent_alpha_cuts(
-                        gammas, reco_energy_bins,
-                    )
+                if self.cut_strategy_alpha[:4] == "edep":
+                    if self.cut_strategy_alpha == "edep_efficiency":
+                        self.alpha_cuts = self.cuts.energy_dependent_alpha_cuts(
+                            gammas, reco_energy_bins,
+                        )
+                        self.log.info(
+                            "Using a containment region for alpha of "
+                            f"{self.cuts.alpha_containment} %"
+                        )
+                    if self.cut_strategy_alpha == "edep_custom":
+                        self.alpha_cuts = self.cuts.from_dict("alpha", reco_energy_bins, self.interpolate_custom)
+                        self.log.info(
+                            f"Using provided energy dependent alpha cuts"
+                        )
                     gammas = self.cuts.apply_energy_dependent_alpha_cuts(
                         gammas, self.alpha_cuts
-                    )
-                    self.log.info(
-                        "Using a containment region for alpha of "
-                        f"{self.cuts.alpha_containment} %"
                     )
                 else:
                     gammas = self.cuts.apply_global_alpha_cut(gammas)
@@ -490,7 +524,7 @@ class IRFFITSWriter(Tool):
                         "Use MCs with same zenith pointing."
                     )
 
-            if self.energy_dependent_gh:
+            if self.cut_strategy_gh[:4] == "edep":
                 background = self.cuts.apply_energy_dependent_gh_cuts(
                     background, self.gh_cuts_gamma
                 )
@@ -551,21 +585,31 @@ class IRFFITSWriter(Tool):
             self.log.info("Generating Full-Enclosure IRF HDUs")
 
         # Updating the HDU headers with the gammaness and theta cuts/efficiency
-        if not self.energy_dependent_gh:
+        if self.cut_strategy_gh == "global":
             extra_headers["GH_CUT"] = self.cuts.global_gh_cut
 
-        else:
+        elif self.cut_strategy_gh == "edep_efficiency":
             extra_headers["GH_EFF"] = (
                 self.cuts.gh_efficiency,
                 "gamma/hadron efficiency",
             )
+        elif self.cut_strategy_gh == "edep_custom":
+            extra_headers["GH_CUTS"] = (
+                "custom energy dependent",
+                "gamma/hadron selection cuts",
+            )
 
         if self.point_like:
             if not self.source_dep:
-                if self.energy_dependent_theta:
+                if self.cut_strategy_theta == "edep_efficiency":
                     extra_headers["TH_CONT"] = (
                         self.cuts.theta_containment,
                         "Theta containment region in percentage",
+                    )
+                elif self.cut_strategy_theta == "edep_custom":
+                    extra_headers["TH_CUTS"] = (
+                        "custom energy dependent",
+                        "theta selection cuts",
                     )
                 else:
                     extra_headers["RAD_MAX"] = (
@@ -579,10 +623,15 @@ class IRFFITSWriter(Tool):
                     'deg'
                 )
 
-                if self.energy_dependent_alpha:
+                if self.cut_strategy_alpha == "edep_efficiency":
                     extra_headers["AL_CONT"] = (
                         self.cuts.alpha_containment,
                         "Alpha containment region in percentage",
+                    )
+                elif self.cut_strategy_alpha == "edep_custom":
+                    extra_headers["AL_CUTS"] = (
+                        "custom energy dependent",
+                        "alpha selection cuts",
                     )
                 else:
                     extra_headers["AL_CUT"] = (
@@ -688,7 +737,7 @@ class IRFFITSWriter(Tool):
             )
             self.log.info("PSF HDU created")
 
-        if self.energy_dependent_gh:
+        if self.cut_strategy_gh[:4] == "edep":
             # Create a separate temporary header
             gh_header = fits.Header()
             gh_header["CREATOR"] = f"lstchain v{__version__}"
@@ -704,7 +753,7 @@ class IRFFITSWriter(Tool):
             )
             self.log.info("GH CUTS HDU added")
 
-        if self.energy_dependent_theta and self.point_like:
+        if self.cut_strategy_theta[:4] == "edep" and self.point_like:
             if not self.source_dep:
                 self.hdus.append(
                     create_rad_max_hdu(
@@ -716,7 +765,7 @@ class IRFFITSWriter(Tool):
                 )
                 self.log.info("RAD MAX HDU added")
 
-        if self.energy_dependent_alpha and self.source_dep:
+        if self.cut_strategy_alpha[:4] == "edep" and self.source_dep:
             # Create a separate temporary header
             alpha_header = fits.Header()
             alpha_header["CREATOR"] = f"lstchain v{__version__}"


### PR DESCRIPTION
These changes introduce the option to provide energy-dependent cuts on gammaness, theta or alpha during the IRFs creation. And provides associated metadata in the IRFs and DL3 files.

Why is it needed : Allows to provide energy dependent cuts based on criteria different from gamma efficiency. Such as best sensitivity.

Tool usage change with the new implementation :
Removed flags  --energy-dependent-gh,  --energy-dependent-theta and  --energy-dependent-alpha and replaced them by a --cut_strategy-{gh, theta, alpha} which receive the technique used as a string input.

The implementation is near complete and can be reviewed, but some points need discussion/further work.
To do before merging :

- [ ] Decide how to store the energy dependent cuts : Should the input be stored in the metadata? Before or after re-binning? Other strategy?
- [ ] Implement tests