### PR TITLE
Set info logging level in find_tailcuts

### DIFF
--- a/lstchain/image/cleaning.py
+++ b/lstchain/image/cleaning.py
@@ -86,7 +86,9 @@ def find_tailcuts(input_dir, run_number):
     newconfig : dict
         cleaning configuration for running the DL1ab stage
     """
-
+    
+    log.setLevel(logging.INFO)
+       
     # subrun-wise dl1 file names:
     dl1_filenames = Path(input_dir,
                          run_to_dl1_filename(1, run_number, 0).replace(


### PR DESCRIPTION
Not sure if there is a better way to set it. Doing it in the script which calls the function did not work. 