### PR TITLE
Keep all peak times in DL1a

### DIFF
--- a/lstchain/scripts/lstchain_dl1ab.py
+++ b/lstchain/scripts/lstchain_dl1ab.py
@@ -406,13 +406,9 @@ def main():
                     # if delta_time has been set, we require at least one
                     # neighbor within delta_time to accept a pixel in the image:
                     if delta_time is not None:
-                        # make sure only signal pixels are used in the time
-                        # check:
-                        cleaned_pixel_times = np.where(signal_pixels,
-                                                       peak_time, np.nan)
                         new_mask = apply_time_delta_cleaning(camera_geom,
                                                              signal_pixels,
-                                                             cleaned_pixel_times,
+                                                             peak_time,
                                                              1,
                                                              delta_time)
                         signal_pixels = new_mask


### PR DESCRIPTION
Currently the output DL1 file keeps only the times of pixels that fulfill all cleaning conditions, except the time condition. This change makes that all pixel times are kept. This is relevant e.g. if one wants to apply lower tailcuts to re-generate DL1b. Equivalently, if one wants to re-generate DL1b with a scaling (>1) of the pixel charges and the same tailcuts (because times will be missing  for the additional pixels which survive the cleaning charge-wise)