### PR TITLE
Functions to obtain recommended intensity cut

### DIFF
--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -905,6 +905,9 @@ def get_intensity_cut(data):
     _, _, intensity_at_50pc_peak_rate, _, _, _ = get_intensity_threshold(data)
     intensity_cut = max(default_cut, factor * intensity_at_50pc_peak_rate)
 
+    if intensity_cut == default_cut:
+        log.info(f'The default cut of {default_cut} p.e. is fine for these data!')
+
     return intensity_cut
 
 

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -829,14 +829,15 @@ def get_intensity_threshold(data):
     binwidth = np.diff(bins)
     nevents, _ = np.histogram(data['intensity'], bins=bins)
     nevents = nevents.astype('float') / (binwidth*efftime.to_value(u.s))
-
+    bincenters = (bins[1:]*bins[:-1])**0.5 # geometrical mean (log bin center)
+ 
     peaks, properties = find_peaks(np.log10(nevents), 
                                    prominence=0.04, # ~10% in log10 scale
                                    width=int(0.1/step)) # ~25% in log10 scale
-    if len(peaks) == 0:
-        return np.nan, np.nan, x, y
 
-    bincenters = (bins[1:]*bins[:-1])**0.5 # geometrical mean (log bin center)
+    # If no peak is found, nans are returned (except for the histogram data):
+    if len(peaks) == 0:
+        return np.nan, np.nan, np.nan, np.nan, bincenters, nevents
     
     xmax = bincenters[peaks.max()] # The peak at highest intensity (spurious peaks sometimes at low values)
     ymax = nevents[peaks.max()]

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -896,7 +896,7 @@ def get_intensity_cut(data):
     # We return the default of 50 p.e., if factor * intensity_threshold is below it. 
     
     _, _, intensity_at_50pc_peak_rate, _, _, _ = get_intensity_threshold(data)
-    intensity_cut = max(50, 1.3 * intensity_at_50pc_peak_rate)
+    intensity_cut = max(default_cut, factor * intensity_at_50pc_peak_rate)
 
     return intensity_cut
 

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -870,7 +870,7 @@ def get_intensity_threshold(data):
     # serious problem, that should be determined elsewhere.
 
     if np.isnan(x50):
-        log.warning('Rising edge of intensity spectrum peak not found in expected range!')
+        log.warning('Rising edge (50%) of intensity spectrum peak not found in the expected range!')
         log.warning('Perhaps the peak overlaps with an anomalous peak at lower intensity?')
     
     return xmax, ymax, x50, y50, bincenters, drdi

--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -838,6 +838,7 @@ def get_intensity_threshold(data):
 
     # If no peak is found, nans are returned (except for the histogram data):
     if len(peaks) == 0:
+        log.warning('Peak of the intensity spectrum not found!')
         return np.nan, np.nan, np.nan, np.nan, bincenters, drdi
     
     xmax = bincenters[peaks.max()] # The peak at highest intensity (spurious peaks sometimes at low values)
@@ -867,6 +868,10 @@ def get_intensity_threshold(data):
     # The data may still be usable, and in that case we should probably apply the
     # default low intensity cut (50 p.e.). If data turn out to have some more 
     # serious problem, that should be determined elsewhere.
+
+    if np.isnan(x50):
+        log.warning('Rising edge of intensity spectrum peak not found in expected range!')
+        log.warning('Perhaps the peak overlaps with an anomalous peak at lower intensity?')
     
     return xmax, ymax, x50, y50, bincenters, drdi
 


### PR DESCRIPTION
The cut is based on the intensity spectrum (dR/dI) obtained from a DL2 table.
The idea is to use the cut as a "software threshold" which improves the agreement between data and MC by removing events too close to trigger threshold (whose configuration is fixed in MC but variable in data). 

The proposed intensity cut is just a fixed factor (1.3) above the intensity for which 50% of the peak rate (dR/dI) of the intensity spectrum is reached. The factor is chosen such that the bulk of the good-quality data taken in dark conditions (hence processed with 8-4 p.e. cleaning) have a cut around 50 p.e. 

![image](https://github.com/user-attachments/assets/1cbd087f-009c-4058-8589-1ac86e2a3ae8)

50 p.e. is close to the peak of the intensity spectrum for such data, and hence will mostly remove the low-energy events close to threshold for which we may expect trigger-induced differences between data and MC. A few example dR/dI spectra from high-rate low-zenith runs:

![image](https://github.com/user-attachments/assets/b4576eb7-e895-4979-98ce-0ce26161e3a8)
