### PR TITLE
get_intensity_cut behavior

### DIFF
--- a/lstchain/reco/utils.py
+++ b/lstchain/reco/utils.py
@@ -905,7 +905,7 @@ def get_intensity_cut(data):
     # We return the default of 50 p.e., if factor * intensity_threshold is below it. 
     
     _, _, intensity_at_50pc_peak_rate, _, _, _ = get_intensity_threshold(data)
-    intensity_cut = max(default_cut, factor * intensity_at_50pc_peak_rate)
+    intensity_cut = np.maximum(default_cut, factor * intensity_at_50pc_peak_rate)
 
     if intensity_cut == default_cut:
         log.info(f'The default cut of {default_cut} p.e. is fine for these data!')


### PR DESCRIPTION
Until now, if finding of the intensity peak failed, a log message was shown telling so, but the returned value was 50 p.e. Besides, another message was shown indicating that 50 p.e. was an adequate cut for the run... So it was confusing. 

This was just due to the behaviour of the max function when the second argument is nan. Now, in case the peak is not found, the function returns nan. This should however happen rarely.