### PR TITLE
fix scikit-learn v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11"]
         ctapipe-version: ["v0.25.1"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
         ctapipe-version: ["v0.25.1"]
 
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: lst-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.13
+  - python=3.12
   - numpy
   - astropy>=6.1,<8
   - pip
@@ -21,7 +21,7 @@ dependencies:
   - protozfits=2.7
   - pyparsing
   - scipy
-  - scikit-learn=1.6
+  - scikit-learn=1.3
   - sphinx
   - sphinx-automodapi
   - sphinx_rtd_theme

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: lst-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.11
   - numpy
   - astropy>=6.1,<8
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - protozfits=2.7
   - pyparsing
   - scipy
-  - scikit-learn=1.3
+  - scikit-learn=1.2
   - sphinx
   - sphinx-automodapi
   - sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'pyirf~=0.12.0',
         'scipy>=1.8',
         'seaborn',
-        'scikit-learn~=1.3',
+        'scikit-learn~=1.2',
         'tables',
         'toml',
         'protozfits>=2.6.1,<3',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'pyirf~=0.12.0',
         'scipy>=1.8',
         'seaborn',
-        'scikit-learn~=1.6',
+        'scikit-learn~=1.3',
         'tables',
         'toml',
         'protozfits>=2.6.1,<3',


### PR DESCRIPTION
This solution is only to keep track of the current solution applied on the cluster to load former models.

Fixes https://github.com/cta-observatory/cta-lstchain/issues/1366