### PR TITLE
Attempt to solve issues with new version of Bokeh.

### DIFF
--- a/lstchain/scripts/lstchain_longterm_dl1_check.py
+++ b/lstchain/scripts/lstchain_longterm_dl1_check.py
@@ -1297,7 +1297,7 @@ def plot(filename='longterm_dl1_check.h5', batch=False, tel_id=1):
     # of the plots):
     row1[0].children[1].value=(1e-6, 0.5)
 
-    grid4c = gridplot([row1], width=pad_width, height=pad_height)
+    grid4c = gridplot([row1])
     page4c.child = grid4c
     page4c.title = 'Pixel problems'
 

--- a/lstchain/visualization/bokeh.py
+++ b/lstchain/visualization/bokeh.py
@@ -2,7 +2,7 @@ import logging
 from bokeh.layouts import gridplot, column
 from bokeh.models import HoverTool
 from bokeh.models import ColumnDataSource, CustomJS, Slider
-from bokeh.models import Range1d, RangeSlider, Div
+from bokeh.models import Range1d, RangeSlider
 from bokeh.models.annotations import Title
 from bokeh.models.layouts import TabPanel, Tabs
 from bokeh.plotting import figure
@@ -510,7 +510,7 @@ def plot_mean_and_stddev_bokeh(table, camgeom, columns, labels):
     row2 = show_camera(stddev, camgeom, pad_width, pad_height,
                        labels[1])
 
-    grid = gridplot([row1, row2], sizing_mode=fixed,
+    grid = gridplot([row1, row2],
                     width=pad_width, height=pad_height)
     return grid
 


### PR DESCRIPTION
Basically, vertical sliders still do not work, and the workaround that was working in bokeh 2.4 is no longer working.
So I now use horizontal sliders, which required some re-ordering of panels.