### PR TITLE
test environment with sklearn 1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,23 @@ jobs:
       run:
         shell: bash -leo pipefail {0}
 
+    # Note about scikit-learn versions (09/07/2025):
+    # - scikit-learn 1.2 is required to load previous models - see https://github.com/cta-observatory/cta-lstchain/issues/1366
+    # - it requires python 3.11 
+    # - at the moment we test that this version can still be installed but this should be removed in the future, when new models are available
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-        ctapipe-version: ["v0.25.1"]
+        include:
+          - python-version: "3.11"
+            ctapipe-version: "v0.25.1"
+          - python-version: "3.12"
+            ctapipe-version: "v0.25.1"
+          - python-version: "3.13"
+            ctapipe-version: "v0.25.1"
+          - python-version: "3.11"
+            ctapipe-version: "v0.25.1"
+            sklearn-version: "1.2"
+            name: "scikit-learn 1.2"
 
     steps:
       - uses: actions/checkout@v4
@@ -50,14 +63,25 @@ jobs:
       - name: Prepare mamba installation
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
+          SKLEARN_VERSION: ${{ matrix.sklearn-version }}
         run: |
+          ENV_FILE="environment.yml"
+          if [ -n "$SKLEARN_VERSION" ]; then
+            echo "Running with scikit-learn $SKLEARN_VERSION"
+            NEW_ENV_FILE="environment-sklearn-$SKLEARN_VERSION.yml"
+            cp environment.yml "$NEW_ENV_FILE"
+            sed -i -e "s/scikit-learn>=1.2/scikit-learn=$SKLEARN_VERSION/g" "$NEW_ENV_FILE"
+            ENV_FILE="$NEW_ENV_FILE"
+          fi
+
           # setup correct python version
-          sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
+          sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" "$ENV_FILE"
+          echo "environment-file=$ENV_FILE" >> $GITHUB_ENV
 
       - name: Mamba setup
         uses: mamba-org/setup-micromamba@v2
         with:
-          environment-file: environment.yml
+          environment-file: ${{ env.environment-file }}
           cache-downloads: true
 
       - name: Install dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: lst-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.13
+  - python>=3.11
   - numpy
   - astropy>=6.1,<8
   - pip
@@ -21,7 +21,7 @@ dependencies:
   - protozfits=2.7
   - pyparsing
   - scipy
-  - scikit-learn=1.6
+  - scikit-learn>=1.2
   - sphinx
   - sphinx-automodapi
   - sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'pyirf~=0.12.0',
         'scipy>=1.8',
         'seaborn',
-        'scikit-learn~=1.6',
+        'scikit-learn>=1.2',
         'tables',
         'toml',
         'protozfits>=2.6.1,<3',


### PR DESCRIPTION
This is a continuation of https://github.com/cta-observatory/cta-lstchain/issues/1366

This PRs releases the requiremetns on sklearn and python versions and test that sklearn v1.2 can still be supported.
The idea is to continue developments with more recent versions but still support v1.2 to use trained models on the cluster.
To use former models, a specific environment must be created (the same one that is tested here) by manually pinning `python=3.11` and `scikit-learn=1.2` in `environment.yml` file (note this is done automatically in CI).