### PR TITLE
Added command-line option to fix R0V files which lack pixel status info

### DIFF
--- a/lstchain/scripts/lstchain_r0g_to_r0v.py
+++ b/lstchain/scripts/lstchain_r0g_to_r0v.py
@@ -127,11 +127,7 @@ def main():
             rows_per_tile = header["ZTILELEN"]
 
             if args.fix_pixel_status:
-                r0v_input = True
-                if "LSTDVR" in header:
-                    r0v_input = header["LSTDVR"]
-                else:
-                    r0v_input = False
+                r0v_input = header.get("LSTDVR", False)
                 if not r0v_input:
                     raise RuntimeError('Input file must be R0V if --fix-pixel-status option is used!')
 

--- a/lstchain/scripts/lstchain_r0g_to_r0v.py
+++ b/lstchain/scripts/lstchain_r0g_to_r0v.py
@@ -8,6 +8,11 @@ In principle it can work on R0 data (2 gains), but no gain selection will be
 applied, and it does not make much sense to keep both gains on reduced 
 (pixel-selected) data!
 
+If the option --fix-pixel-status is used, then the input file has to be an R0V
+file, and the pixel selection file must be the same that was used to produce 
+it. this is a special option to fix R0V that were created with wrong pixel 
+status (but correct waveform selection).
+
 """
 import logging
 import protozfits

--- a/lstchain/scripts/lstchain_r0g_to_r0v.py
+++ b/lstchain/scripts/lstchain_r0g_to_r0v.py
@@ -41,6 +41,11 @@ parser.add_argument('--log', dest='log_file',
                     type=Path, default=None,
                     help='Log file name')
 
+parser.add_argument('--fix-pixel-status', dest='fix_pixel_status',
+                    action='store_true', required=False, 
+                    default=False,
+                    help='Just set the pixel status flags (input file should be R0V)')
+
 # Events for which gain selection will be applied:
 EVENT_TYPES_TO_REDUCE = [EventType.SUBARRAY, EventType.UNKNOWN]
 UNSET_DVR_BIT_MASK = ~np.uint8(PixelStatus.DVR_STATUS_0 | PixelStatus.DVR_STATUS_1)
@@ -48,7 +53,7 @@ SET_DVR_BIT_0 = np.uint8(PixelStatus.DVR_STATUS_0)
 
 def main():
     args = parser.parse_args()
-  
+
     input_file = args.input_file
     output_dir = args.output_dir
 
@@ -116,6 +121,15 @@ def main():
             n_tiles = header["NAXIS2"]
             rows_per_tile = header["ZTILELEN"]
 
+            if args.fix_pixel_status:
+                r0v_input = True
+                if "LSTDVR" in header:
+                    r0v_input = header["LSTDVR"]
+                else:
+                    r0v_input = False
+                if not r0v_input:
+                    raise RuntimeError('Input file must be R0V if --fix-pixel-status option is used!')
+
             stream = stack.enter_context(protozfits.ProtobufZOFits(
                     n_tiles=n_tiles,
                     rows_per_tile=rows_per_tile,
@@ -146,8 +160,6 @@ def main():
                     continue
 
                 num_gains = event.num_channels
-                wf = protozfits.any_array_to_numpy(event.waveform)
-                wf = wf.reshape((num_gains, num_pixels, num_samples))
 
                 evtype = event_type[event.event_id]
                 pixel_status = protozfits.any_array_to_numpy(event.pixel_status)
@@ -156,9 +168,23 @@ def main():
                 if evtype in EVENT_TYPES_TO_REDUCE:
                     pixmask = pixel_mask[event.event_id]
                     ordered_pix_mask = pixmask[pixel_id_map]
-                    new_wf = wf[:, ordered_pix_mask, :]
-                    event.waveform.data = new_wf.tobytes()
-                  
+
+                    wf = protozfits.any_array_to_numpy(event.waveform)
+                    # Keep only selected waveforms - unless the option
+                    # --fix-pixel-status has been selected, in which case
+                    # it is not needed because input file is already R0V:
+                    if not args.fix_pixel_status:
+                        wf = wf.reshape((num_gains, num_pixels, num_samples))
+                        new_wf = wf[:, ordered_pix_mask, :]
+                        event.waveform.data = new_wf.tobytes()
+                    else:
+                        # Check that the number of saved pixels in the mask 
+                        # is consistent with the size of the waveform (will
+                        # be the case, if the pixel selection file is the same
+                        # that was used in the creation of the input R0V file
+                        if len(wf) != num_gains * num_samples * ordered_pix_mask.sum():
+                            raise RuntimeError('The pixel selection file is not consistent with the input R0V file!')
+
                 # Modify pixel status as needed
                 new_status = np.where(ordered_pix_mask,
                                       pixel_status | SET_DVR_BIT_0,


### PR DESCRIPTION
Option to correct R0V files that were created correctly, except for the pixel status bits (see #1376)
This PR is to correct _already existing_ R0V files (whereas #1376 solves the original problem in the R0V production)