### PR TITLE
Using the subrun index gives an error in the cherenkov transparency script for days in which some subruns failed and were discarded

### DIFF
--- a/lstchain/scripts/lstchain_cherenkov_transparency.py
+++ b/lstchain/scripts/lstchain_cherenkov_transparency.py
@@ -174,11 +174,12 @@ def main():
                 dummy = np.zeros(num_subruns)
                 dummy2 = np.zeros(num_subruns)
                 for jj, nn, nn2 in zip(
-                        np.arange(0,num_subruns),
+                        a.root.dl1datacheck.pedestals.col('subrun_index'),
                         a.root.dl1datacheck.pedestals.col('num_events'),
                         a.root.dl1datacheck.pedestals.col('num_cleaned_events')):
-                    dummy[jj] = nn
-                    dummy2[jj] = nn2
+                    new_index = np.where(a.root.dl1datacheck.cosmics.col('subrun_index') == jj)[0][0]
+                    dummy[new_index] = nn
+                    dummy2[new_index] = nn2
                 num_pedestals.append(dummy)
                 num_cleaned_pedestals.append(dummy2)
 
@@ -190,8 +191,9 @@ def main():
                         a.root.dl1datacheck.pedestals.col('charge_mean'),
                         a.root.dl1datacheck.pedestals.col('charge_stddev')):
                     starmask = nns < 1
-                    dummy[jj] = np.nanmean(np.where(starmask, ch1, np.nan))
-                    dummy2[jj] = np.nanmean(np.where(starmask, ch2, np.nan))
+                    new_index = np.where(a.root.dl1datacheck.cosmics.col('subrun_index') == jj)[0][0]
+                    dummy[new_index] = np.nanmean(np.where(starmask, ch1, np.nan))
+                    dummy2[new_index] = np.nanmean(np.where(starmask, ch2, np.nan))
                 diffuse_nsb_mean.append(dummy)
                 diffuse_nsb_std.append(dummy2)
 
@@ -212,11 +214,12 @@ def main():
                 dummy = np.zeros(num_subruns)
                 dummy2 = np.zeros(num_subruns)
                 for jj, nn, nn2 in zip(
-                        np.arange(0,num_subruns),
+                        a.root.dl1datacheck.flatfield.col('subrun_index'),
                         a.root.dl1datacheck.flatfield.col('num_events'),
                         a.root.dl1datacheck.flatfield.col('num_cleaned_events')):
-                    dummy[jj] = nn
-                    dummy2[jj] = nn2
+                    new_index = np.where(a.root.dl1datacheck.cosmics.col('subrun_index') == jj)[0][0]
+                    dummy[new_index] = nn
+                    dummy2[new_index] = nn2
                 num_flatfield.append(dummy)
                 num_cleaned_flatfield.append(dummy2)
 

--- a/lstchain/scripts/lstchain_cherenkov_transparency.py
+++ b/lstchain/scripts/lstchain_cherenkov_transparency.py
@@ -174,7 +174,7 @@ def main():
                 dummy = np.zeros(num_subruns)
                 dummy2 = np.zeros(num_subruns)
                 for jj, nn, nn2 in zip(
-                        a.root.dl1datacheck.pedestals.col('subrun_index'),
+                        np.arange(0,num_subruns),
                         a.root.dl1datacheck.pedestals.col('num_events'),
                         a.root.dl1datacheck.pedestals.col('num_cleaned_events')):
                     dummy[jj] = nn
@@ -212,7 +212,7 @@ def main():
                 dummy = np.zeros(num_subruns)
                 dummy2 = np.zeros(num_subruns)
                 for jj, nn, nn2 in zip(
-                        a.root.dl1datacheck.flatfield.col('subrun_index'),
+                        np.arange(0,num_subruns),
                         a.root.dl1datacheck.flatfield.col('num_events'),
                         a.root.dl1datacheck.flatfield.col('num_cleaned_events')):
                     dummy[jj] = nn


### PR DESCRIPTION
For example, for the day 20250823, in which several subruns of run 21523 had to be discarded, the cherenkov transparency script gives this error: 
```
Traceback (most recent call last):
  File "/var/spool/slurm//job48183790/slurm_script", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/fefs/aswg/software/conda/envs/osa-v0.11.3/lib/python3.11/site-packages/lstchain/scripts/lstchain_cherenkov_transparency.py", line 218, in main
    dummy[jj] = nn
    ~~~~~^^^^
IndexError: index 106 is out of bounds for axis 0 with size 83
/fefs/aswg/software/conda/envs/osa-v0.11.3/lib/python3.11/site-packages/tables/file.py:130: UnclosedFileWarning: Closing remaining open file: /fefs/onsite/data/lst-pipe/LSTN-01/DL1/20250823/v0.11/tailcut84/datacheck/datacheck_dl1_LST-1.Run21523.h5
  warnings.warn(UnclosedFileWarning(msg))
``` 
Using this fix I could correctly add the "cosmics_intensity_spectrum" table to the datacheck file. 