### PR TITLE
Modify fov_offset parameters in irf_dl3_tool_config.json

### DIFF
--- a/docs/examples/irf_dl3_tool_config.json
+++ b/docs/examples/irf_dl3_tool_config.json
@@ -39,7 +39,7 @@
     "energy_migration_min": 0.2,
     "energy_migration_max": 5,
     "energy_migration_n_bins": 30,
-    "fov_offset_min": 0.,
+    "fov_offset_min": 0,
     "fov_offset_max": 2.5,
     "fov_offset_n_edges": 6,
     "bkg_fov_offset_min": 0,


### PR DESCRIPTION
Updated field values for fov_offset parameters in the configuration. The previous lower edge was >0, so it resulted in a hole in the effective are vs. offset. The proposed binning is relatively coarse (0.5 deg in offset angle) in order to have sufficient statistics from the existing diffuse gamma MC.