### PR TITLE
Sort `runsummary` df before the assert

### DIFF
--- a/notebooks/data_quality.ipynb
+++ b/notebooks/data_quality.ipynb
@@ -529,7 +529,8 @@
     "        continue\n",
     "    print('Removing run', r, 'from runsummary table!')\n",
     "    runsummary.drop(np.where(runsummary['runnumber']==r)[0], inplace=True)\n",
-    "    runsummary.reset_index(inplace=True, drop=True)"
+    "    runsummary.reset_index(inplace=True, drop=True)\n",
+    "runsummary=runsummary.sort_values(\"runnumber\")"
    ]
   },
   {


### PR DESCRIPTION
If runs are removed, the assertion `assert(np.allclose(runlist, runsummary['runnumber']))` sometimes fails because the order is not the same, despite having the same number of runs in `runlist` and `runsummary['runnumber']`. For example, one can reproduce this error if the `data_quality` Jupyter Notebook is run selecting all datachecks.

This PR sorts the `runsummary` before the assertion to make sure the order is the same in both objects.

This PR is ready for review.