### PR TITLE
Store & use DL1a images in interleaved*.h5 files

### DIFF
--- a/lstchain/calib/camera/flatfield.py
+++ b/lstchain/calib/camera/flatfield.py
@@ -161,7 +161,8 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
 
         return charge, peak_pos
 
-    def calculate_relative_gain(self, event):
+    def calculate_relative_gain(self, event,
+                                use_existing_dl1a_pix_times=False):
         """
          calculate the flatfield statistical values
          and fill mon.tel[tel_id].flatfield container
@@ -194,6 +195,11 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
         # extract the charge of the event and
         # the peak position (assumed as time for the moment)
         charge, arrival_time = self._extract_charge(event)
+        if use_existing_dl1a_pix_times:
+            if event.dl1.tel[self.tel_id].peak_time is None:
+                raise IOError("DL1 image not found in event!")
+            else:
+                arrival_time = event.dl1.tel[self.tel_id].peak_time
 
         missing_gain_mask = np.zeros((N_GAINS, N_PIXELS))
 

--- a/lstchain/data/lstchain_standard_config.json
+++ b/lstchain/data/lstchain_standard_config.json
@@ -287,7 +287,7 @@
   "write_interleaved_events":{
     "DataWriter": {
       "overwrite":  true,
-      "write_dl1_images": false,
+      "write_dl1_images": true,
       "write_dl1_parameters": false,
       "write_r0_waveforms": false,
       "write_r1_waveforms": true,

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -604,7 +604,7 @@ def r0_to_dl1(
                                 r1.pixel_time_shift[0] = event.calibration.tel[tel_id].dl1.time_shift.astype('float32')[r1.selected_gain_channel, PIXEL_INDEX]
 
 
-                    interleaved_writer(event)
+                    # interleaved_writer(event)
 
                     # gain select the events if not done already:
                     if r1.selected_gain_channel is None:
@@ -625,6 +625,11 @@ def r0_to_dl1(
 
             # create image for all events
             r1_dl1_calibrator(event)
+
+            if interleaved_writer:
+                if ((event.trigger.event_type == EventType.FLATFIELD) or
+                    (event.trigger.event_type == EventType.SKY_PEDESTAL)):
+                    interleaved_writer(event)
 
             if is_simu:
                 # Scale all integrated charges in all pixels if requested by user:

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -8,7 +8,6 @@ import logging
 import os
 from copy import deepcopy
 from pathlib import Path
-import sys
 
 import astropy.units as u
 import numpy as np

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -486,8 +486,6 @@ def r0_to_dl1(
         interleaved_output_file = Path(dir, name)
         interleaved_writer = DataWriter(event_source=source, output_path=interleaved_output_file,
                                         config=interleaved_writer_config)
-        # interleaved_writer._writer.exclude("/r1/event/telescope/.*",
-        # "selected_gain_channel")
 
     with HDF5TableWriter(
             filename=output_filename,
@@ -603,8 +601,6 @@ def r0_to_dl1(
                                                            dtype='float32')
                                 r1.pixel_time_shift[0] = event.calibration.tel[tel_id].dl1.time_shift.astype('float32')[r1.selected_gain_channel, PIXEL_INDEX]
 
-
-                    # interleaved_writer(event)
 
                     # gain select the events if not done already:
                     if r1.selected_gain_channel is None:

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -8,6 +8,7 @@ import logging
 import os
 from copy import deepcopy
 from pathlib import Path
+import sys
 
 import astropy.units as u
 import numpy as np
@@ -588,19 +589,16 @@ def r0_to_dl1(
                         source.r0_r1_calibrator.select_gain = False
                         source.r0_r1_calibrator.calibrate(event)
 
-                    r1 = event.r1.tel[tel_id]
-
                     if interleaved_writer is not None:
-                        # Include pixel time calibration in r1, if field
-                        # pixel_time_shift exists:
-                        if 'pixel_time_shift' in r1.keys():
-                            if r1.selected_gain_channel is None:
-                                r1.pixel_time_shift = event.calibration.tel[tel_id].dl1.time_shift.astype('float32')
-                            else:
-                                r1.pixel_time_shift = np.zeros((1, N_PIXELS),
-                                                           dtype='float32')
-                                r1.pixel_time_shift[0] = event.calibration.tel[tel_id].dl1.time_shift.astype('float32')[r1.selected_gain_channel, PIXEL_INDEX]
+                        if interleaved_writer.write_dl1_images:
+                            # Get the DL1 for the interleaved event here, so 
+                            # that it is done for both gains (if present). 
+                            # Will be done later for all events (including 
+                            # interleaved) for the selected gain only
+                            r1_dl1_calibrator(event)
+                        interleaved_writer(event)
 
+                    r1 = event.r1.tel[tel_id]
 
                     # gain select the events if not done already:
                     if r1.selected_gain_channel is None:
@@ -621,11 +619,6 @@ def r0_to_dl1(
 
             # create image for all events
             r1_dl1_calibrator(event)
-
-            if interleaved_writer:
-                if ((event.trigger.event_type == EventType.FLATFIELD) or
-                    (event.trigger.event_type == EventType.SKY_PEDESTAL)):
-                    interleaved_writer(event)
 
             if is_simu:
                 # Scale all integrated charges in all pixels if requested by user:

--- a/lstchain/reco/r0_to_dl1.py
+++ b/lstchain/reco/r0_to_dl1.py
@@ -391,6 +391,9 @@ def r0_to_dl1(
     # Write extra information to the DL1 file
     subarray.to_hdf(output_filename)
 
+    allowed_tels = config['source_config']['LSTEventSource'][
+        'allowed_tels']
+
     if is_simu:
         write_mcheader(
             source.simulation_config[source.obs_ids[0]],
@@ -430,8 +433,6 @@ def r0_to_dl1(
                                                      assume_sorted=True)
                 pre_computed_multiplicity = config['waveform_nsb_tuning'].get('pre_computed_multiplicity', 10)
 
-                allowed_tels = config['source_config']['LSTEventSource'][
-                    'allowed_tels']
                 logger.info('Tuning NSB on MC waveform by adding ')
                 logger.info(f'{nsb_tuning_rate:.3f} GHz for telescope ids:')
                 logger.info(f'{allowed_tels}')
@@ -486,6 +487,11 @@ def r0_to_dl1(
         interleaved_output_file = Path(dir, name)
         interleaved_writer = DataWriter(event_source=source, output_path=interleaved_output_file,
                                         config=interleaved_writer_config)
+        # We do not need the DL1a charges (only the times). So we save a bit 
+        # of space by not writing them out:
+        for tel_id in allowed_tels:
+            interleaved_writer._writer.exclude(f'dl1/event/telescope/images/tel_{tel_id:03d}', 
+                                               'image')
 
     with HDF5TableWriter(
             filename=output_filename,
@@ -610,7 +616,7 @@ def r0_to_dl1(
             # Option to add nsb in waveforms
             if nsb_tuning:
                 # FIXME? assumes same correction ratio for all telescopes
-                for tel_id in config['source_config']['LSTEventSource']['allowed_tels']:
+                for tel_id in allowed_tels:
                     waveform = event.r1.tel[tel_id].waveform
                     selected_gains = event.r1.tel[tel_id].selected_gain_channel
                     mask_high = selected_gains == 0

--- a/lstchain/tools/lstchain_create_cat_B_calibration_file.py
+++ b/lstchain/tools/lstchain_create_cat_B_calibration_file.py
@@ -16,7 +16,6 @@ from lstchain.calib.camera.calibration_calculator import CalibrationCalculator
 from lstchain.io import add_config_metadata, add_global_metadata, global_metadata, write_metadata
 from ctapipe.containers import EventType
 from lstchain.io.calibration import read_calibration_file
-from ctapipe_io_lst.constants import PIXEL_INDEX, N_GAINS, N_PIXELS
 
 __all__ = [
     'CatBCalibrationHDF5Writer'

--- a/lstchain/tools/lstchain_create_cat_B_calibration_file.py
+++ b/lstchain/tools/lstchain_create_cat_B_calibration_file.py
@@ -196,17 +196,6 @@ class CatBCalibrationHDF5Writer(Tool):
                         add_config_metadata(calib_data, self.config)
                         add_global_metadata(calib_data, metadata)
         
-                    # Put the pixel time correction in event.calibration,
-                    # if available in event.r1:
-                    if event.calibration.tel[tel_id].dl1.time_shift is None:
-                        if event.r1.tel[tel_id].as_dict().get('pixel_time_shift') is not None:
-                            sg = event.r1.tel[tel_id].selected_gain_channel
-                            if sg is None:
-                                event.calibration.tel[tel_id].dl1.time_shift = event.r1.tel[tel_id].pixel_time_shift
-                            else:
-                                event.calibration.tel[tel_id].dl1.time_shift = np.zeros((N_GAINS, N_PIXELS))
-                                event.calibration.tel[tel_id].dl1.time_shift[sg, PIXEL_INDEX] = event.r1.tel[tel_id].pixel_time_shift[0, PIXEL_INDEX]
-
                     # if pedestal event
                     if self._is_pedestal(event, tel_id):
 
@@ -216,8 +205,12 @@ class CatBCalibrationHDF5Writer(Tool):
 
                     # if flat-field event
                     elif self._is_flatfield(event, tel_id):
-
-                        if self.processor.flatfield.calculate_relative_gain(event):
+                        # For the times we use the peak times calculated in 
+                        # the Cat-A DL1 file. The times computed from the
+                        # waveforms would require corrections that have already
+                        # been done in that stage:
+                        if self.processor.flatfield.calculate_relative_gain(event,
+                                                                            use_existing_dl1a_pix_times=True):
                             new_ff = True
                             count_ff = count+1
                         
@@ -258,33 +251,6 @@ class CatBCalibrationHDF5Writer(Tool):
                         self.processor.calculate_calibration_coefficients(event)
                         if self.processor.use_scaled_low_gain:
                             status_data.flatfield_failing_pixels[1, :] = False
-
-                        # For data which are *not* calibrated by the EvB:
-                        # The inter-pixel Cat-A time flat-fielding is *not* 
-                        # applied in the Cat-B calibration, hence the obtained
-                        # time_correction values must be modified so that 
-                        # they become corrections relative to the DL1a pixel
-                        # times, that were already flatfielded. Note that for 
-                        # such data the Fourier correction to account for 
-                        # DRS4 sampling inhomogeneitites is not applied at all
-                        # during this CatB calculations. Still, since the time 
-                        # (re-)calibration is based on averages over many 
-                        # events, covering the whole DRS4 buffer, it more or 
-                        # less works (the t-deviations due to the DRS4 average
-                        # out). 
-                        # 
-                        # In contrast, data fully calibrated by the EvB 
-                        # contain the Fourier corrections in the R1 data,
-                        # which are then copied to event.calibration, and 
-                        # hence used for correcting the pulse time 
-                        # calculations in this Cat-B processing. Therefore, 
-                        # in that case one should not remove the cat-A
-                        # calibration from the computed values.
-
-                        if event.r1.tel[tel_id].as_dict().get('pixel_time_shift') is None:
-                            # Set the time correction relative to the Cat-A calibration
-                            # so to avoid to decalibrate.
-                            calib_data.time_correction -= self.cat_A_monitoring_data.calibration.time_correction
 
                         # Now pedestals, check if they are gain-selected
                         num_events_seen = self.processor.pedestal.num_events_seen


### PR DESCRIPTION
Use DL1a pixel times from CatA DL1 file for the calculation of Cat-B time corrections