### PR TITLE
Cat-B plotting bug

### DIFF
--- a/lstchain/scripts/lstchain_longterm_dl1_check.py
+++ b/lstchain/scripts/lstchain_longterm_dl1_check.py
@@ -887,7 +887,7 @@ def plot(filename='longterm_dl1_check.h5', batch=False, tel_id=1):
     min_average_ff_charge = ff_charge * (1 - ff_charge_tolerance)
     max_average_ff_rel_time_stdev = ff_max_rel_time_stdev
 
-    max_average_ff_time_stdev = 1.2
+    max_average_ff_time_stdev = 1.3
     min_average_ff_time = 12  # ns
     max_average_ff_time = 23  # ns
     max_average_ff_charge_stdev = 11  # pe

--- a/lstchain/visualization/plot_calib.py
+++ b/lstchain/visualization/plot_calib.py
@@ -52,7 +52,10 @@ def plot_calibration_results(ped_data, ff_data, calib_data, run=0, plot_file=Non
     camera = camera.transform_to(EngineeringCameraFrame())
 
     # Guess whether this calibration file comes from gain-selected ped events:
-    if np.all(np.isnan(ped_data.charge_mean[1])):
+    # Low-gain average values should be NaN for low gain pedestals, except for
+    # pixels which are disabled in the DAQ, in which case values are exactly 0 
+    if np.all(np.isnan(ped_data.charge_mean[1]) |
+              (ped_data.charge_mean[1]==0.0)):
         channels = [0]  # Just high gain
     else:
         channels = [0, 1] # Both gains

--- a/lstchain/visualization/plot_calib.py
+++ b/lstchain/visualization/plot_calib.py
@@ -52,8 +52,9 @@ def plot_calibration_results(ped_data, ff_data, calib_data, run=0, plot_file=Non
     camera = camera.transform_to(EngineeringCameraFrame())
 
     # Guess whether this calibration file comes from gain-selected ped events:
-    # Low-gain average values should be NaN for low gain pedestals, except for
-    # pixels which are disabled in the DAQ, in which case values are exactly 0 
+    # For gain-selected data, the low-gain average values should be NaN for 
+    # low gain pedestals, except for pixels which are disabled in the DAQ, in 
+    # which case the values are exactly 0:
     if np.all(np.isnan(ped_data.charge_mean[1]) |
               (ped_data.charge_mean[1]==0.0)):
         channels = [0]  # Just high gain


### PR DESCRIPTION
Revise condition to decide whether the calibration file was produced from gain-selected calibration events.
Previous one failed for data which had some missing pixel cluster.

Also updated max limit of the FF pixel time std dev (to match new definition of the times)