### PR TITLE
Improve the condition to identify Cat-B calibration files which were

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - astropy>=6.1,<8
   - pip
   - ctapipe >=0.25.0
-  - ctapipe_io_lst =0.29.0
+  - ctapipe_io_lst~=0.29.2
   - ctaplot~=0.6.4
   - gammapy=1.3
   - h5py

--- a/lstchain/visualization/plot_calib.py
+++ b/lstchain/visualization/plot_calib.py
@@ -52,11 +52,16 @@ def plot_calibration_results(ped_data, ff_data, calib_data, run=0, plot_file=Non
     camera = camera.transform_to(EngineeringCameraFrame())
 
     # Guess whether this calibration file comes from gain-selected ped events:
-    # For gain-selected data, the low-gain average values should be NaN for 
-    # low gain pedestals, except for pixels which are disabled in the DAQ, in 
-    # which case the values are exactly 0:
-    if np.all(np.isnan(ped_data.charge_mean[1]) |
-              (ped_data.charge_mean[1]==0.0)):
+    # For gain-selected data, the low-gain average & std values should be NaN 
+    # for low gain pedestals, except for pixels which are disabled in the DAQ,
+    # in which case the values are exactly 0. There can also be rare cases, 
+    # for gain-selected data, in which some pixel recorded the low gain in an 
+    # event tagged as pedestal (either due to wrong tagging, or to some light 
+    # accidentally coinciding with the recording of the event). So we now 
+    # require that  a *majority* of the pixels have valid low-gain charge 
+    # std values in order to proceed with the low-gain plotting:
+    if (np.isnan(ped_data.charge_std[1]) | 
+        (ped_data.charge_std[1] == 0.0)).sum() > ped_data.charge_std[1].size/2:
         channels = [0]  # Just high gain
     else:
         channels = [0, 1] # Both gains

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'astropy>=6.1,<8',
         'bokeh~=3.0',
         'ctapipe~=0.25.1',
-        'ctapipe_io_lst==0.29.0',
+        'ctapipe_io_lst~=0.29.2',
         'ctaplot~=0.6.4',
         'eventio>=1.9.1,<2.0.0a0',  # at least 1.1.1, but not 2
         'gammapy~=1.3.0',


### PR DESCRIPTION
Improve the condition to identify Cat-B calibration files which were produced from gain-selected interleaved events