### PR TITLE
Fix statistic type for mean_coszd calculation

### DIFF
--- a/notebooks/data_quality.ipynb
+++ b/notebooks/data_quality.ipynb
@@ -725,7 +725,7 @@
     "std_dec, _, _ = binned_statistic(cis['runnumber'], cis['dec_tel'], statistic='std', bins=bin_edges)\n",
     "# We do not compute std_ra - it is not totally straightforward because of 0=360 deg...\n",
     "\n",
-    "mean_coszd, _, _ = binned_statistic(cis['runnumber'], cis['cos_zenith'], statistic=ra_mean, bins=bin_edges)\n",
+    "mean_coszd, _, _ = binned_statistic(cis['runnumber'], cis['cos_zenith'], statistic='mean', bins=bin_edges)\n",
     "\n",
     "# Picture threshold should be the same for all subruns in a run\n",
     "picture_threshold, _, _ = binned_statistic(cis['runnumber'], cis['picture_thresh'], \n",


### PR DESCRIPTION
Fixed cut&paste error which had no actual consequences (mean cos_zd was computed in an absurd way which however resulted in the correct result). Thanks @zhipzhang for reporting this!